### PR TITLE
More Swedish translation.

### DIFF
--- a/lang/sv/qtype_stack.php
+++ b/lang/sv/qtype_stack.php
@@ -121,3 +121,13 @@ $string['stackCas_spaces'] = 'Förbjudna mellanslag i uttrycket {$a->expr}.';
 $string['stackCas_unknownFunction'] = 'Obekant funktion: {$a->forbid}.';
 $string['stackDoc_404message'] = 'Filen hittades inte.';
 $string['true'] = 'Sant';
+$string['generalfeedback'] = 'Allmän feedback';
+$string['generalfeedbacktags'] = 'Allmän feedback får inte innehålla \'{$a}\'.';
+$string['healthcheck'] = 'STACK systemkontroll';
+$string['healthchecklatex'] = 'Kontrollera att LaTeX visas på rätt sätt';
+$string['healthcheck_desc'] = '<a href="{$a->link}">Systemkontrollskriptet</a> hjälper dig att kontrollera att alla apekter av STACK fungerar korrekt.';
+$string['prtcorrectfeedback'] = 'Standardfeedback för rätt svar';
+$string['specificfeedback'] = 'Specifik feedback';
+$string['specificfeedbacktags'] = 'Den specifika feedbacken får inte innehålla \'{$a}\'.';
+$string['testsuitecolexpectedscore'] = 'Förväntad poäng';
+


### PR DESCRIPTION
A few translation issues:
1. In the answer tests, sometimes several strings are printed after each other without white space in between. I assume this should be fixed in the STACK code, not the translation? [Screenshot](http://dl.dropbox.com/u/11924798/missing-space.png)
2. The string Division by zero in the input tests is untranslatable. [Screenshot](http://dl.dropbox.com/u/11924798/untranslatable.png)
3. One bracket is the wrong way in the input tests. The other seem ok to me. [Screenshot](http://dl.dropbox.com/u/11924798/wrong-bracket.png)
