### PR TITLE
take continued fraction approximation of the score at the end of a PRT

### DIFF
--- a/stack/potentialresponsetree.class.php
+++ b/stack/potentialresponsetree.class.php
@@ -210,13 +210,16 @@ class stack_potentialresponse_tree {
         // Restrict score to be between 0 and 1.
         $results->_score = min(max($results->_score, 0), 1);
 
+        // Take a continued fraction approximation of the score, within 5 decimal places of the original
+        // This will round numbers like 0.999999 to exactly 1, 0.33333 to 1/3, etc.
+        $results->_score = stack_utils::fix_to_continued_fraction($results->score,5);
+
         // From a strictly logical point of view the 'score' and the 'penalty' are independent.
         // Hence, this clause belongs in the question behaviour.
         // From a practical point of view, it is confusing/off-putting when testing to see "score=1, penalty=0.1".
         // Why does this correct attempt attract a penalty?  So, this is a unilateral decision:
         // If the score is 1 there is never a penalty.
-        if ($results->_score > 0.999999) {
-            $results->_score = 1;
+        if ($results->_score == 1) {
             $results->_penalty = 0;
         }
 


### PR DESCRIPTION
Inspired by my comment in maths/moodle-qtype_stack#183, this adds functions `stack_utils::rational_approximation` and `stack_utils::fix_to_continued_fraction`.
Instead of just rounding scores >= 0.9999999 up to 1, this finds a rational approximation to the score which agrees to 5 d.p. (need to decide the best number of d.p.)
This rounds numbers which are close to 1 up to 1, but also rounds e.g. 0.33333 to 1/3 (or as close as you can get to 1/3 in a float)

This needs unit tests, but I don't know how to write those.

It might make sense to replace `stack_utils::fix_approximate_thirds` with `fix_to_continued_fraction` - as far as I can see, that's only used on penalties at the moment.