### PR TITLE
Always filter equation validation

### DIFF
--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -487,7 +487,7 @@ abstract class stack_input {
             return '';
         }
         $feedback  = '';
-        $feedback .= html_writer::tag('p', stack_string('studentValidation_yourLastAnswer', $state->contentsdisplayed));
+        $feedback .= html_writer::tag('p', format_text(stack_string('studentValidation_yourLastAnswer', $state->contentsdisplayed)));
 
         if ($this->requires_validation() && '' !== $state->contents) {
             $feedback .= html_writer::empty_tag('input', array('type' => 'hidden',
@@ -512,7 +512,7 @@ abstract class stack_input {
      * Used by the units input type.
      */
     protected function tag_listofvariables($vars) {
-        return html_writer::tag('p', stack_string('studentValidation_listofvariables', $vars));
+        return html_writer::tag('p', format_text(stack_string('studentValidation_listofvariables', $vars)));
     }
 
     /**


### PR DESCRIPTION
This item implements a fix that shows the validation of the equation correctly in realtime without the need for clicking the 'Check' button to do the validation.