### PR TITLE
Update Authoring_quick_start.md

### DIFF
--- a/doc/en/Authoring/Authoring_quick_start.md
+++ b/doc/en/Authoring/Authoring_quick_start.md
@@ -208,7 +208,7 @@ Modify the [question variables](KeyVals.md#Question_variables) from the previous
 Then change the [question text](CASText.md#question_text) to
 
 <textarea readonly="readonly" rows="3" cols="50">
-Differentiate @p@ with respect to \(x\).
+Differentiate @p@ with respect to \(x\) .
 [[input:ans1]]
 [[validation:ans1]]</textarea>
 

--- a/doc/en/Authoring/Authoring_quick_start.md
+++ b/doc/en/Authoring/Authoring_quick_start.md
@@ -208,7 +208,7 @@ Modify the [question variables](KeyVals.md#Question_variables) from the previous
 Then change the [question text](CASText.md#question_text) to
 
 <textarea readonly="readonly" rows="3" cols="50">
-Differentiate @p@ with respect to \(x\) .
+Differentiate @p@ with respect to \(x\).
 [[input:ans1]]
 [[validation:ans1]]</textarea>
 
@@ -268,7 +268,7 @@ This contains random numbers, and also examples of variables and expressions sel
 Then change the Question text to
 
 <textarea readonly="readonly" rows="3" cols="50">
-Differentiate @p@ with respect to @v@.
+Differentiate @p@ with respect to @v@ .
 [[input:ans1]]
 [[validation:ans1]]</textarea>
 


### PR DESCRIPTION
attempt to prevent `v@.` will get substituted with `mailto:v@.` in this github display.
done
minor, maybe useless change