### PR TITLE
Fix logic error in if-elif-else-blocks else branch.

### DIFF
--- a/stack/cas/castext/castext.peg.inc
+++ b/stack/cas/castext/castext.peg.inc
@@ -540,6 +540,9 @@ class stack_cas_castext_parsetreenode {
                         $i->firstchild = $i->nextsibling;
                         $i->firstchild->previoussibling = null;
                         $i->nextsibling = $iter->nextsibling;
+                        if ($iter->nextsibling !== null) {
+                            $iter->nextsibling->previoussibling = $i;
+                        }
                         $i->previoussibling = $iter;
                         $iter->nextsibling = $i;
                         $iter = $i;
@@ -561,6 +564,9 @@ class stack_cas_castext_parsetreenode {
                         $i->firstchild = $i->nextsibling;
                         $i->firstchild->previoussibling = null;
                         $i->nextsibling = $iter->nextsibling;
+                        if ($iter->nextsibling !== null) {
+                            $iter->nextsibling->previoussibling = $i;
+                        }
                         $i->previoussibling = $iter;
                         $iter->nextsibling = $i;
                         $iter = $i;
@@ -605,7 +611,11 @@ class stack_cas_castext_parsetreenode {
                         if ($cc == 0) {
                             $newdef->params[$key] = $n->get_parameter('test', 'false');
                         } else if ($n->get_parameter('test', 'false') == 'else') {
-                            $newdef->params[$key] = 'not (' . $reconds[$cc - 1]->get_parameter('test', 'false') . ')';
+                            $keys = array();
+                            foreach (array_slice($reconds, 0, -1) as $b) {
+                                $keys[] = $b->get_parameter('test', 'false');
+                            }
+                            $newdef->params[$key] = 'not (' . implode(' or ', $keys). ')';
                         } else {
                             $newdef->params[$key] = 'not (' . $reconds[$cc - 1]->get_parameter('test', 'false') . ') and (' .
                                     $n->get_parameter('test', 'false') . ')';

--- a/stack/cas/castext/castextparser.class.php
+++ b/stack/cas/castext/castextparser.class.php
@@ -1414,6 +1414,9 @@ class stack_cas_castext_parsetreenode {
                         $i->firstchild = $i->nextsibling;
                         $i->firstchild->previoussibling = null;
                         $i->nextsibling = $iter->nextsibling;
+                        if ($iter->nextsibling !== null) {
+                            $iter->nextsibling->previoussibling = $i;
+                        }
                         $i->previoussibling = $iter;
                         $iter->nextsibling = $i;
                         $iter = $i;
@@ -1435,6 +1438,9 @@ class stack_cas_castext_parsetreenode {
                         $i->firstchild = $i->nextsibling;
                         $i->firstchild->previoussibling = null;
                         $i->nextsibling = $iter->nextsibling;
+                        if ($iter->nextsibling !== null) {
+                            $iter->nextsibling->previoussibling = $i;
+                        }
                         $i->previoussibling = $iter;
                         $iter->nextsibling = $i;
                         $iter = $i;
@@ -1479,7 +1485,11 @@ class stack_cas_castext_parsetreenode {
                         if ($cc == 0) {
                             $newdef->params[$key] = $n->get_parameter('test', 'false');
                         } else if ($n->get_parameter('test', 'false') == 'else') {
-                            $newdef->params[$key] = 'not (' . $reconds[$cc - 1]->get_parameter('test', 'false') . ')';
+                            $keys = array();
+                            foreach (array_slice($reconds, 0, -1) as $b) {
+                                $keys[] = $b->get_parameter('test', 'false');
+                            }
+                            $newdef->params[$key] = 'not (' . implode(' or ', $keys). ')';
                         } else {
                             $newdef->params[$key] = 'not (' . $reconds[$cc - 1]->get_parameter('test', 'false') . ') and (' .
                                     $n->get_parameter('test', 'false') . ')';

--- a/tests/castext_test.php
+++ b/tests/castext_test.php
@@ -79,6 +79,10 @@ class stack_cas_text_test extends qtype_stack_testcase {
 
     public function test_if_block() {
         $a1 = array('a:true', 'b:is(1>2)', 'c:false');
+        // From iss309.
+        $c = '[[ if test="false" ]]Alpha[[ elif test="true"]]Beta[[ elif test="false"]]Gamma'
+                . '[[ else ]]Delta[[/ if]]';
+
 
         $cases = array(
                 array('[[ if test="a" ]]ok1[[/ if ]]', $a1, true, "ok1"),
@@ -90,6 +94,8 @@ class stack_cas_text_test extends qtype_stack_testcase {
                 array('[[ if test="a" ]][[ if test="b" ]]ok7[[/ if ]][[/ if ]]', $a1, true, ""),
                 array('[[ if test="a" ]][[ if test="b" ]]ok8[[else]]OK8[[/ if ]][[/ if ]]', $a1, true, "OK8"),
                 array('[[if test="is(5>3)"]]OK9[[/if]]', $a1, true, "OK9"),
+                array($c . ' ' . $c, $a1, true, "Beta Beta"),
+                array($c . $c, $a1, true, "BetaBeta"),
         );
 
         foreach ($cases as $case) {

--- a/tests/parser_test.php
+++ b/tests/parser_test.php
@@ -349,7 +349,7 @@ class stack_cas_castext_parser_test extends qtype_stack_testcase {
                 $parsed['to_string']);
         // String check against node->to_string. The conversion to the tree-form shoudl have rewriten the elses as new ifs.
         // Should generate about this: '[[ define stackparsecond18="a" stackparsecond19="not (stackparsecond18) and (b)"
-        // stackparsecond20="not (stackparsecond19)" /]][[ if test="stackparsecond18" ]]1[[/ if ]][[ if test="stackparsecond19"
+        // stackparsecond20="not (stackparsecond18 or stackparsecond19)" /]][[ if test="stackparsecond18" ]]1[[/ if ]][[ if test="stackparsecond19"
         // ]]2[[/ if ]][[ if test="stackparsecond20" ]][[ define stackparsecond21="c" stackparsecond22="not (stackparsecond21)"
         // /]][[ if test="stackparsecond21" ]]3[[/ if ]][[ if test="stackparsecond22" ]]4[[/ if ]][[/ if ]]'
         // Problem is that the numbers in those stackparsecond?? Variables can change depending on excecution order.
@@ -358,26 +358,26 @@ class stack_cas_castext_parser_test extends qtype_stack_testcase {
         $matches = array();
         preg_match_all('/stackparsecond([0-9]*)/' , $parsed['tree_form']->to_string() , $matches);
         $this->assertEquals($matches[1][0], $matches[1][2]); // The first cond needs to appear here.
-        $this->assertEquals($matches[1][0], $matches[1][5]);
+        $this->assertEquals($matches[1][0], $matches[1][4]);
         $this->assertEquals($matches[1][0] + 1, $matches[1][1]); // The second needs to be stored to the next and so on.
-        $this->assertEquals($matches[1][1], $matches[1][4]);
-        $this->assertEquals($matches[1][1], $matches[1][6]);
+        $this->assertEquals($matches[1][1], $matches[1][5]);
+        $this->assertEquals($matches[1][1], $matches[1][7]);
         $this->assertEquals($matches[1][1] + 1, $matches[1][3]);
-        $this->assertEquals($matches[1][3], $matches[1][7]);
-        $this->assertEquals($matches[1][8], $matches[1][10]);
-        $this->assertEquals($matches[1][8], $matches[1][11]);
-        $this->assertEquals($matches[1][8] + 1, $matches[1][9]);
+        $this->assertEquals($matches[1][3], $matches[1][8]);
+        $this->assertEquals($matches[1][9], $matches[1][11]);
         $this->assertEquals($matches[1][9], $matches[1][12]);
+        $this->assertEquals($matches[1][9] + 1, $matches[1][10]);
+        $this->assertEquals($matches[1][10], $matches[1][13]);
 
         // Test the same equalitys with the full text.
         $testpattern = '[[ define stackparsecond' . $matches[1][0] . '="a" stackparsecond' . $matches[1][1]
                     . '="not (stackparsecond' . $matches[1][0] . ') and (b)" stackparsecond' . $matches[1][3]
-                    . '="not (stackparsecond' . $matches[1][1] . ')" /]][[ if test="stackparsecond' . $matches[1][0]
+                    . '="not (stackparsecond' . $matches[1][0] . ' or stackparsecond' . $matches[1][1] . ')" /]][[ if test="stackparsecond' . $matches[1][0]
                     . '" ]]1[[/ if ]][[ if test="stackparsecond' . $matches[1][1]
                     . '" ]]2[[/ if ]][[ if test="stackparsecond' . $matches[1][3]
-                    . '" ]][[ define stackparsecond' . $matches[1][8] . '="c" stackparsecond' . $matches[1][9]
-                    . '="not (stackparsecond' . $matches[1][8] . ')" /]][[ if test="stackparsecond' . $matches[1][8]
-                    . '" ]]3[[/ if ]][[ if test="stackparsecond' . $matches[1][9] . '" ]]4[[/ if ]][[/ if ]]';
+                    . '" ]][[ define stackparsecond' . $matches[1][9] . '="c" stackparsecond' . $matches[1][10]
+                    . '="not (stackparsecond' . $matches[1][9] . ')" /]][[ if test="stackparsecond' . $matches[1][9]
+                    . '" ]]3[[/ if ]][[ if test="stackparsecond' . $matches[1][10] . '" ]]4[[/ if ]][[/ if ]]';
         $this->assertEquals($testpattern, $parsed['tree_form']->to_string());
     }
 


### PR DESCRIPTION
Inconvenient logic failure present in a case that was not tested. Also fixes an error not yet reported relating to DOM-tree corruption when handling if-elif-else constructs that were directly next to each other.

#309 