### PR TITLE
Add special character rendering as escapes to help with problems like #321.

### DIFF
--- a/stack/cas/casstring.class.php
+++ b/stack/cas/casstring.class.php
@@ -776,7 +776,28 @@ class stack_cas_casstring {
             foreach ($matches as $match) {
                 $badchar = $match[0];
                 if (!array_key_exists($badchar, $invalidchars)) {
-                    $invalidchars[$badchar] = $badchar;
+                    switch ($badchar) {
+                        case "\n":
+                            $invalidchars[$badchar] = "\\n";
+                            break;
+                        case "\r":
+                            $invalidchars[$badchar] = "\\r";
+                            break;
+                        case "\t":
+                            $invalidchars[$badchar] = "\\t";
+                            break;
+                        case "\v":
+                            $invalidchars[$badchar] = "\\v";
+                            break;
+                        case "\e":
+                            $invalidchars[$badchar] = "\\e";
+                            break;
+                        case "\f":
+                            $invalidchars[$badchar] = "\\f";
+                            break;
+                        default:
+                            $invalidchars[$badchar] = $badchar;
+                    }
                 }
             }
             $this->add_error(stack_string('stackCas_forbiddenChar', array( 'char' => implode(", ", array_unique($invalidchars)))));


### PR DESCRIPTION
Breaks no tests and is trivial enough.