### PR TITLE
Remove libs from SBCL instructions

### DIFF
--- a/doc/en/CAS/Optimising_Maxima.md
+++ b/doc/en/CAS/Optimising_Maxima.md
@@ -95,10 +95,6 @@ use the following to generate a stand alone executable:
 * In Maxima, type the commands:
 ~~~~
     load("maximalocal.mac");
-    load("<path>/stackmaxima.mac");
-    load(stats);
-    load(distrib);
-    load(descriptive);
     :lisp (sb-ext:save-lisp-and-die "maxima-optimised" :toplevel #'run :executable t)
 ~~~~
 


### PR DESCRIPTION
These changes have been tested in CENTOS 6/7 and seem to resolve the stack page exception problem that appeared.