### PR TITLE
Fix display CAS text clean-up #340

### DIFF
--- a/stack/cas/cassession.class.php
+++ b/stack/cas/cassession.class.php
@@ -470,8 +470,8 @@ class stack_cas_session {
             $dummy = '{@'.$key.'@}';
 
             // When we have only a single string in the output remove the maths environment.
-            if ($errors == '' and substr(trim($value), 0, 1) == '"' and !(strpos($strin, '\({@'.$key.'@}\)') === false)) {
-                $disp = substr(trim($disp), 6, strlen($disp) - 7);
+            if ($errors == '' and substr(trim($value), 0, 1) == '"' and strpos($strin, '\(@'.$key.'@\)') !== false) {
+                $disp = preg_replace('|^\\\\mbox\{(.*)\}$|', '$1', trim($disp));
                 if ($value == '""') {
                     $disp = '';
                 }

--- a/stack/cas/castext.class.php
+++ b/stack/cas/castext.class.php
@@ -399,9 +399,9 @@ class stack_cas_text {
         $this->castext = $this->trimmedcastext;
 
         // Another modification. Stops <html> tags from being given $ tags.
-        $this->castext = str_replace('\(<html>', '', $this->castext);
+        $this->castext = str_replace('<html>', '', $this->castext);
         // Bug occurs when maxima returns <html>tags in output, eg plots or div by 0 errors.
-        $this->castext = str_replace('</html>\)', '', $this->castext);
+        $this->castext = str_replace('</html>', '', $this->castext);
         $this->latex_tidy();
 
         $this->instantiated = true;


### PR DESCRIPTION
I think this is the required fix:

* We should use preg_replace to strip the \mbox{ ... } so that it does not mangle strings that don't match teh expected pattern.
* We should always string <html> ... </html> wrappers. I cannot imagine any case when we would want them in the output.