### PR TITLE
Improve input usability on iPads, etc.

### DIFF
--- a/stack/input/algebraic/algebraic.class.php
+++ b/stack/input/algebraic/algebraic.class.php
@@ -40,7 +40,9 @@ class stack_algebraic_input extends stack_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em'
+            'style' => 'width: '.$size.'em',
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/equiv/equiv.class.php
+++ b/stack/input/equiv/equiv.class.php
@@ -128,6 +128,8 @@ class stack_equiv_input extends stack_input {
             'id'   => $fieldname,
             'rows' => max(3, count($rows) + 1),
             'cols' => min($boxwidth, 50),
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($readonly) {

--- a/stack/input/matrix/matrix.class.php
+++ b/stack/input/matrix/matrix.class.php
@@ -211,11 +211,6 @@ class stack_matrix_input extends stack_input {
             return $this->render_error($this->errors);
         }
 
-        $attributes = array(
-            'type' => 'text',
-            'name' => $fieldname,
-        );
-
         $tc = $state->contents;
         $blank = $this->is_blank_response($state->contents);
         if ($blank) {
@@ -226,10 +221,9 @@ class stack_matrix_input extends stack_input {
             }
         }
 
+        $attr = ' autocapitalize="none" spellcheck="false"';
         if ($readonly) {
-            $readonlyattr = ' readonly="readonly"';
-        } else {
-            $readonlyattr = '';
+            $attr .= ' readonly="readonly"';
         }
 
         // Build the html table to contain these values.
@@ -252,7 +246,7 @@ class stack_matrix_input extends stack_input {
                 }
                 $name = $fieldname.'_sub_'.$i.'_'.$j;
                 $xhtml .= '<td><input type="text" name="'.$name.'" value="'.$val.'" size="'.
-                        $this->parameters['boxWidth'].'"'.$readonlyattr.'></td>';
+                        $this->parameters['boxWidth'].'"'.$attr.'></td>';
             }
 
             if ($i == 0) {

--- a/stack/input/numerical/numerical.class.php
+++ b/stack/input/numerical/numerical.class.php
@@ -57,7 +57,9 @@ class stack_numerical_input extends stack_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em'
+            'style' => 'width: '.$size.'em',
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/singlechar/singlechar.class.php
+++ b/stack/input/singlechar/singlechar.class.php
@@ -37,6 +37,8 @@ class stack_singlechar_input extends stack_input {
             'size'      => 1,
             'maxlength' => 1,
             'value'     => $this->contents_to_maxima($state->contents),
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($readonly) {

--- a/stack/input/string/string.class.php
+++ b/stack/input/string/string.class.php
@@ -39,7 +39,9 @@ class stack_string_input extends stack_algebraic_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em'
+            'style' => 'width: '.$size.'em',
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/textarea/textarea.class.php
+++ b/stack/input/textarea/textarea.class.php
@@ -39,6 +39,8 @@ class stack_textarea_input extends stack_input {
         $attributes = array(
             'name' => $fieldname,
             'id'   => $fieldname,
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/units/units.class.php
+++ b/stack/input/units/units.class.php
@@ -57,7 +57,9 @@ class stack_units_input extends stack_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em'
+            'style' => 'width: '.$size.'em',
+            'autocapitalize' => 'none',
+            'spellcheck'     => 'false',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/tests/input_algebraic_test.php
+++ b/tests/input_algebraic_test.php
@@ -46,7 +46,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_blank() {
         $el = stack_input_factory::make('algebraic', 'ans1', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -54,7 +54,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_zero() {
         $el = stack_input_factory::make('algebraic', 'ans1', '0');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="0" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -62,7 +62,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" value="x+y" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
@@ -70,7 +70,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_pre_filled_nasty_input() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" value="x&lt;y" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x&lt;y" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('x<y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
@@ -78,7 +78,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_max_length() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" value="x+y" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
@@ -87,7 +87,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('algebraic', 'input', 'x^2');
         $this->assertEquals(
                 '<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="16.5" style="width: 13.6em" value="x+1" readonly="readonly" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+1" readonly="readonly" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+1'), '', '', '', '', ''),
                         'stack1__input', true, null));
     }
@@ -96,7 +96,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('algebraic', 'input', 'x^2');
         $el->set_parameter('boxWidth', 30);
         $this->assertEquals('<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="33" style="width: 27.1em" value="x+1" />',
+                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="x+1" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+1'), '', '', '', '', ''),
                         'stack1__input', false, null));
     }
@@ -105,7 +105,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('algebraic', 'sans1', '[a, b, c]');
         $el->set_parameter('syntaxHint', '[?, ?, ?]');
         $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" value="[?, ?, ?]" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="[?, ?, ?]" />',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }
@@ -115,7 +115,7 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'Remove me');
         $el->set_parameter('syntaxAttribute', 1);
         $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" placeholder="Remove me" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" placeholder="Remove me" />',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }

--- a/tests/input_equiv_test.php
+++ b/tests/input_equiv_test.php
@@ -47,7 +47,7 @@ class stack_equiv_input_test extends qtype_stack_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('equiv', 'ans1', '[]');
-        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25"></textarea></td>' .
+        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25" autocapitalize="none" spellcheck="false"></textarea></td>' .
                 '<td><div class="stackinputfeedback" id="stack1__ans1_val">' .
                 '<input type="hidden" name="stack1__ans1_val" value="[]" /></div></td></tr></table>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
@@ -57,7 +57,7 @@ class stack_equiv_input_test extends qtype_stack_testcase {
     public function test_render_firstline() {
         $el = stack_input_factory::make('equiv', 'ans1', '[]');
         $el->set_parameter('syntaxHint', 'firstline');
-        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25">' .
+        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25" autocapitalize="none" spellcheck="false">' .
                 'x^2=4</textarea></td><td><div class="stackinputfeedback" id="stack1__ans1_val">' .
                 '<input type="hidden" name="stack1__ans1_val" value="[]" /></div></td></tr></table>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
@@ -68,7 +68,7 @@ class stack_equiv_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('equiv', 'ans1', '[]');
         // Note the syntax hint must be a list.
         $el->set_parameter('syntaxHint', '[x^2=3]');
-        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25">x^2=3' .
+        $this->assertEquals('<table><tr><td><textarea name="stack1__ans1" id="stack1__ans1" rows="3" cols="25" autocapitalize="none" spellcheck="false">x^2=3' .
                 '</textarea></td><td><div class="stackinputfeedback" id="stack1__ans1_val">' .
                 '<input type="hidden" name="stack1__ans1_val" value="[]" /></div></td></tr></table>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),

--- a/tests/input_matrix_test.php
+++ b/tests/input_matrix_test.php
@@ -35,14 +35,14 @@ class stack_matrix_input_test extends qtype_stack_testcase {
         $this->assertEquals('<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" border="0" cellpadding="1" cellspacing="0">' .
                 '<tbody><tr><td style="border-width: 2px 0px 0px 2px; padding-top: 0.5em">&nbsp;</td>' .
-                '<td><input type="text" name="ans1_sub_0_0" value="" size="5"></td>' .
-                '<td><input type="text" name="ans1_sub_0_1" value="" size="5"></td>' .
-                '<td><input type="text" name="ans1_sub_0_2" value="" size="5"></td>' .
+                '<td><input type="text" name="ans1_sub_0_0" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_0_1" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_0_2" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
                 '<td style="border-width: 2px 2px 0px 0px; padding-top: 0.5em">&nbsp;</td></tr>' .
                 '<tr><td style="border-width: 0px 0px 2px 2px;">&nbsp;</td>' .
-                '<td><input type="text" name="ans1_sub_1_0" value="" size="5"></td>' .
-                '<td><input type="text" name="ans1_sub_1_1" value="" size="5"></td>' .
-                '<td><input type="text" name="ans1_sub_1_2" value="" size="5"></td>' .
+                '<td><input type="text" name="ans1_sub_1_0" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_1_1" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_1_2" value="" size="5" autocapitalize="none" spellcheck="false"></td>' .
                 '<td style="border-width: 0px 2px 2px 0px; padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'ans1', false, null));
@@ -66,12 +66,15 @@ class stack_matrix_input_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $el->adapt_to_model_answer('matrix([1,0],[0,1])');
         $this->assertEquals('<table class="matrixtable" id="ans1_container" style="display:inline; vertical-align: middle;" '.
-              'border="0" cellpadding="1" cellspacing="0"><tbody><tr><td style="border-width: 2px 0px 0px 2px; padding-top: '.
-              '0.5em">&nbsp;</td><td><input type="text" name="ans1_sub_0_0" value="a" size="5"></td><td><input type="text" '.
-              'name="ans1_sub_0_1" value="b" size="5"></td><td style="border-width: 2px 2px 0px 0px; padding-top: 0.5em">'.
-              '&nbsp;</td></tr><tr><td style="border-width: 0px 0px 2px 2px;">&nbsp;</td><td><input type="text" '.
-              'name="ans1_sub_1_0" value="?" size="5"></td><td><input type="text" name="ans1_sub_1_1" value="d" size="5"></td>'.
-              '<td style="border-width: 0px 2px 2px 0px; padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>',
+                'border="0" cellpadding="1" cellspacing="0">' .
+                '<tbody><tr><td style="border-width: 2px 0px 0px 2px; padding-top: 0.5em">&nbsp;</td>' .
+                '<td><input type="text" name="ans1_sub_0_0" value="a" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_0_1" value="b" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td style="border-width: 2px 2px 0px 0px; padding-top: 0.5em">&nbsp;</td></tr>' .
+                '<tr><td style="border-width: 0px 0px 2px 2px;">&nbsp;</td>' .
+                '<td><input type="text" name="ans1_sub_1_0" value="?" size="5" autocapitalize="none" spellcheck="false"></td>' .
+                '<td><input type="text" name="ans1_sub_1_1" value="d" size="5" autocapitalize="none" spellcheck="false"></td>'.
+                '<td style="border-width: 0px 2px 2px 0px; padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'ans1', false, null));
     }

--- a/tests/input_numerical_test.php
+++ b/tests/input_numerical_test.php
@@ -34,7 +34,7 @@ class stack_numerical_input_test extends qtype_stack_testcase {
     public function test_render_blank() {
         $el = stack_input_factory::make('numerical', 'ans1', '2');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -42,7 +42,7 @@ class stack_numerical_input_test extends qtype_stack_testcase {
     public function test_render_zero() {
         $el = stack_input_factory::make('numerical', 'ans1', '0');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="0" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -470,7 +470,7 @@ class stack_numerical_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('numerical', 'sans1', '[a, b, c]');
         $el->set_parameter('syntaxHint', '?/?');
         $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" value="?/?" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?/?" />',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }

--- a/tests/input_singlechar_test.php
+++ b/tests/input_singlechar_test.php
@@ -30,14 +30,14 @@ class stack_singlechar_input_test extends basic_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('singleChar', 'ans1', null);
-        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" value="" />',
+        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" value="" autocapitalize="none" spellcheck="false" />',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', '', ''),
                         'question__ans1', false, null));
     }
 
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('singleChar', 'test', null);
-        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" value="Y" />',
+        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" value="Y" autocapitalize="none" spellcheck="false" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('Y'), '', '', '', '', ''),
                         'question__ans1', false, null));
     }
@@ -45,7 +45,7 @@ class stack_singlechar_input_test extends basic_testcase {
     public function test_render_disabled() {
         $el = stack_input_factory::make('singleChar', 'input', null);
         $expected = '<input type="text" name="question__stack1" id="question__stack1" size="1" maxlength="1" ' .
-            'value="a" readonly="readonly" />';
+            'value="a" autocapitalize="none" spellcheck="false" readonly="readonly" />';
         $this->assertEquals($expected,
                 $el->render(new stack_input_state(stack_input::VALID, array('a'), '', '', '', '', ''),
                         'question__stack1', true, null));

--- a/tests/input_string_test.php
+++ b/tests/input_string_test.php
@@ -35,7 +35,7 @@ class stack_string_input_test extends qtype_stack_testcase {
     public function test_render_blank() {
         $el = stack_input_factory::make('string', 'ans1', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -43,7 +43,7 @@ class stack_string_input_test extends qtype_stack_testcase {
     public function test_render_hello_world() {
         $el = stack_input_factory::make('string', 'ans1', '"Hello world"');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="0" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }

--- a/tests/input_textarea_test.php
+++ b/tests/input_textarea_test.php
@@ -36,14 +36,14 @@ class stack_textarea_input_test extends qtype_stack_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('textArea', 'ans1', null);
-        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" rows="5" cols="20"></textarea>',
+        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" autocapitalize="none" spellcheck="false" rows="5" cols="20"></textarea>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'st_ans1', false, null));
     }
 
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('textArea', 'test', null);
-        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" rows="5" cols="20">' .
+        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" autocapitalize="none" spellcheck="false" rows="5" cols="20">' .
                 "1\n1/sum([1,3])\nmatrix([1],[2])</textarea>",
                 $el->render(new stack_input_state(
                         stack_input::VALID, array("1", "1/sum([1,3])", "matrix([1],[2])"), '', '', '', '', ''),
@@ -52,7 +52,7 @@ class stack_textarea_input_test extends qtype_stack_testcase {
 
     public function test_render_pre_syntaxhint() {
         $el = stack_input_factory::make('textArea', 'test', null, null, array('syntaxHint' => '[y=?, z=?]'));
-        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" rows="5" cols="20">' .
+        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" autocapitalize="none" spellcheck="false" rows="5" cols="20">' .
                     "y=?\n z=?</textarea>",
         $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                             'st_ans1', false, null));
@@ -60,7 +60,7 @@ class stack_textarea_input_test extends qtype_stack_testcase {
 
     public function test_render_disabled() {
         $el = stack_input_factory::make('textArea', 'input', null);
-        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" rows="5" cols="20" readonly="readonly"></textarea>',
+        $this->assertEquals('<textarea name="st_ans1" id="st_ans1" autocapitalize="none" spellcheck="false" rows="5" cols="20" readonly="readonly"></textarea>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'st_ans1', true, null));
     }

--- a/tests/input_units_test.php
+++ b/tests/input_units_test.php
@@ -34,7 +34,7 @@ class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_blank() {
         $el = stack_input_factory::make('units', 'ans1', 'x^2');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -43,7 +43,7 @@ class stack_units_input_test extends qtype_stack_testcase {
         // We must have some units for this input type.
         $el = stack_input_factory::make('units', 'ans1', '0');
         $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" value="0" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
                 $el->render(new stack_input_state(stack_input::INVALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -51,7 +51,7 @@ class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('units', 'test', 'm/s');
         $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" value="m/s" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="m/s" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('m/s'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
@@ -60,7 +60,7 @@ class stack_units_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('units', 'input', '9.81*m/s^2');
         $this->assertEquals(
                 '<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="16.5" style="width: 13.6em" value="9.81*m/s^2" readonly="readonly" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="9.81*m/s^2" readonly="readonly" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('9.81*m/s^2'), '', '', '', '', ''),
                         'stack1__input', true, null));
     }
@@ -69,7 +69,7 @@ class stack_units_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('units', 'input', '-9.81*m/s^2');
         $el->set_parameter('boxWidth', 30);
         $this->assertEquals('<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="33" style="width: 27.1em" value="-9.81*m/s^2" />',
+                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="-9.81*m/s^2" />',
                 $el->render(new stack_input_state(stack_input::VALID, array('-9.81*m/s^2'), '', '', '', '', ''),
                         'stack1__input', false, null));
     }
@@ -78,7 +78,7 @@ class stack_units_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('units', 'sans1', '9.81*m/s^2');
         $el->set_parameter('syntaxHint', '?*m/s^2');
         $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" value="?*m/s^2" />',
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?*m/s^2" />',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }


### PR DESCRIPTION
I was demoing STACK on an iPad yesterday, and it was a real pain because if you tried to type x + 1, it automatically changed it to X + 1. (It upper-cases the first character of input by default.)

Fortunately, HTML5 provides a way to tame this behaviour, which is what I implement here. See https://caniuse.com/#search=spellcheck and https://github.com/Fyrd/caniuse/issues/1729.

However, I have not yet tested this on an iPad to verify that it acutally has the desired effect, and it is too late this evening. I just wanted to get the code written. I have run the unit tests, and they pass.