### PR TITLE
Accessible: Add answer label for input

### DIFF
--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -47,6 +47,7 @@ $string['stackversionmulerror'] = 'This question has an input which uses the "mu
 // Strings used on the editing form.
 $string['addanothernode'] = 'Add another node';
 $string['allnodefeedbackmustusethesameformat'] = 'All the feedback for all the nodes in a PRT must use the same text format.';
+$string['answer'] = 'Answer: {$a}';
 $string['answernote'] = 'Answer note';
 $string['answernote_err'] = 'Answer notes may not contain the character |.  This character is inserted by STACK and is later used to split answer notes automatically.';
 $string['answernote_help'] = 'This is a tag which is key for reporting purposes.  It is designed to record the unique path through the tree, and the outcome of each answer test.  This is automatically generated, but can be changed to something meaningful.';

--- a/stack/input/algebraic/algebraic.class.php
+++ b/stack/input/algebraic/algebraic.class.php
@@ -59,7 +59,12 @@ class stack_algebraic_input extends stack_input {
             $attributes['readonly'] = 'readonly';
         }
 
-        return html_writer::empty_tag('input', $attributes);
+        $input = html_writer::empty_tag('input', $attributes);
+        $result = html_writer::tag('label', get_string('answer', 'qtype_stack',
+                html_writer::tag('span', $input, ['class' => 'answer'])),
+                ['for' => $attributes['id']]);
+
+        return $result;
     }
 
     public function add_to_moodleform_testinput(MoodleQuickForm $mform) {

--- a/stack/input/numerical/numerical.class.php
+++ b/stack/input/numerical/numerical.class.php
@@ -76,7 +76,12 @@ class stack_numerical_input extends stack_input {
             $attributes['readonly'] = 'readonly';
         }
 
-        return html_writer::empty_tag('input', $attributes);
+        $input = html_writer::empty_tag('input', $attributes);
+        $result = html_writer::tag('label', get_string('answer', 'qtype_stack',
+                html_writer::tag('span', $input, ['class' => 'answer'])),
+                ['for' => $attributes['id']]);
+
+        return $result;
     }
 
     public function add_to_moodleform_testinput(MoodleQuickForm $mform) {

--- a/stack/input/singlechar/singlechar.class.php
+++ b/stack/input/singlechar/singlechar.class.php
@@ -45,7 +45,12 @@ class stack_singlechar_input extends stack_input {
             $attributes['readonly'] = 'readonly';
         }
 
-        return html_writer::empty_tag('input', $attributes);
+        $input = html_writer::empty_tag('input', $attributes);
+        $result = html_writer::tag('label', get_string('answer', 'qtype_stack',
+                html_writer::tag('span', $input, ['class' => 'answer'])),
+                ['for' => $attributes['id']]);
+
+        return $result;
     }
 
     protected function extra_validation($contents) {

--- a/stack/input/string/string.class.php
+++ b/stack/input/string/string.class.php
@@ -59,7 +59,12 @@ class stack_string_input extends stack_algebraic_input {
             $attributes['readonly'] = 'readonly';
         }
 
-        return html_writer::empty_tag('input', $attributes);
+        $input = html_writer::empty_tag('input', $attributes);
+        $result = html_writer::tag('label', get_string('answer', 'qtype_stack',
+                html_writer::tag('span', $input, ['class' => 'answer'])),
+                ['for' => $attributes['id']]);
+
+        return $result;
     }
 
     /**

--- a/stack/input/units/units.class.php
+++ b/stack/input/units/units.class.php
@@ -72,7 +72,12 @@ class stack_units_input extends stack_input {
             $attributes['readonly'] = 'readonly';
         }
 
-        return html_writer::empty_tag('input', $attributes);
+        $input = html_writer::empty_tag('input', $attributes);
+        $result = html_writer::tag('label', get_string('answer', 'qtype_stack',
+                html_writer::tag('span', $input, ['class' => 'answer'])),
+                ['for' => $attributes['id']]);
+
+        return $result;
     }
 
     public function add_to_moodleform_testinput(MoodleQuickForm $mform) {

--- a/tests/input_algebraic_test.php
+++ b/tests/input_algebraic_test.php
@@ -45,49 +45,55 @@ class stack_algebra_input_test extends qtype_stack_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('algebraic', 'ans1', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
 
     public function test_render_zero() {
         $el = stack_input_factory::make('algebraic', 'ans1', '0');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
 
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" />',
+        $this->assertEquals('<label for="stack1__test">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__test" id="stack1__test" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
 
     public function test_render_pre_filled_nasty_input() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x&lt;y" />',
+        $this->assertEquals('<label for="stack1__test">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__test" id="stack1__test" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x&lt;y" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('x<y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
 
     public function test_render_max_length() {
         $el = stack_input_factory::make('algebraic', 'test', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" />',
+        $this->assertEquals('<label for="stack1__test">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__test" id="stack1__test" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+y" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+y'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
 
     public function test_render_disabled() {
         $el = stack_input_factory::make('algebraic', 'input', 'x^2');
-        $this->assertEquals(
-                '<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+1" readonly="readonly" />',
+        $this->assertEquals('<label for="stack1__input">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__input" id="stack1__input" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="x+1" readonly="readonly" />'
+                .'</span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+1'), '', '', '', '', ''),
                         'stack1__input', true, null));
     }
@@ -95,8 +101,9 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_different_size() {
         $el = stack_input_factory::make('algebraic', 'input', 'x^2');
         $el->set_parameter('boxWidth', 30);
-        $this->assertEquals('<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="x+1" />',
+        $this->assertEquals('<label for="stack1__input">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__input" id="stack1__input" '
+                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="x+1" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('x+1'), '', '', '', '', ''),
                         'stack1__input', false, null));
     }
@@ -104,8 +111,9 @@ class stack_algebra_input_test extends qtype_stack_testcase {
     public function test_render_syntaxhint() {
         $el = stack_input_factory::make('algebraic', 'sans1', '[a, b, c]');
         $el->set_parameter('syntaxHint', '[?, ?, ?]');
-        $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="[?, ?, ?]" />',
+        $this->assertEquals('<label for="stack1__sans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__sans1" id="stack1__sans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="[?, ?, ?]" /></span></label>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }
@@ -114,8 +122,9 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('algebraic', 'sans1', '[a, b, c]');
         $el->set_parameter('syntaxHint', 'Remove me');
         $el->set_parameter('syntaxAttribute', 1);
-        $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" placeholder="Remove me" />',
+        $this->assertEquals('<label for="stack1__sans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__sans1" id="stack1__sans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" placeholder="Remove me" /></span></label>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }
@@ -126,8 +135,8 @@ class stack_algebra_input_test extends qtype_stack_testcase {
         $state = $el->validate_student_response(array('sans1' => 'x^2'), $options, 'x^2/(1+x^2)', null);
         $this->assertEquals(stack_input::VALID, $state->status);
         $this->assertEquals('A correct answer is <span class="filter_mathjaxloader_equation">'
-          . '<span class="nolink">\( \frac{x^2}{1+x^2} \)</span></span>, which can be typed in as follows: '
-          . '<code>x^2/(1+x^2)</code>', $el->get_teacher_answer_display('x^2/(1+x^2)', '\frac{x^2}{1+x^2}'));
+                . '<span class="nolink">\( \frac{x^2}{1+x^2} \)</span></span>, which can be typed in as follows: '
+                . '<code>x^2/(1+x^2)</code>', $el->get_teacher_answer_display('x^2/(1+x^2)', '\frac{x^2}{1+x^2}'));
     }
 
     public function test_validate_student_response_2() {

--- a/tests/input_numerical_test.php
+++ b/tests/input_numerical_test.php
@@ -33,16 +33,18 @@ class stack_numerical_input_test extends qtype_stack_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('numerical', 'ans1', '2');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
 
     public function test_render_zero() {
         $el = stack_input_factory::make('numerical', 'ans1', '0');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -469,8 +471,9 @@ class stack_numerical_input_test extends qtype_stack_testcase {
     public function test_render_syntaxhint() {
         $el = stack_input_factory::make('numerical', 'sans1', '[a, b, c]');
         $el->set_parameter('syntaxHint', '?/?');
-        $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?/?" />',
+        $this->assertEquals('<label for="stack1__sans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__sans1" id="stack1__sans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?/?" /></span></label>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }

--- a/tests/input_singlechar_test.php
+++ b/tests/input_singlechar_test.php
@@ -30,24 +30,27 @@ class stack_singlechar_input_test extends basic_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('singleChar', 'ans1', null);
-        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" ' .
-                'value="" autocapitalize="none" spellcheck="false" />',
+        $this->assertEquals('<label for="question__ans1">Answer: <span class="answer">' .
+                '<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" ' .
+                'value="" autocapitalize="none" spellcheck="false" /></span></label>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', '', ''),
                         'question__ans1', false, null));
     }
 
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('singleChar', 'test', null);
-        $this->assertEquals('<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" ' .
-                'value="Y" autocapitalize="none" spellcheck="false" />',
+        $this->assertEquals('<label for="question__ans1">Answer: <span class="answer">' .
+                '<input type="text" name="question__ans1" id="question__ans1" size="1" maxlength="1" ' .
+                'value="Y" autocapitalize="none" spellcheck="false" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('Y'), '', '', '', '', ''),
                         'question__ans1', false, null));
     }
 
     public function test_render_disabled() {
         $el = stack_input_factory::make('singleChar', 'input', null);
-        $expected = '<input type="text" name="question__stack1" id="question__stack1" size="1" maxlength="1" ' .
-            'value="a" autocapitalize="none" spellcheck="false" readonly="readonly" />';
+        $expected = '<label for="question__stack1">Answer: <span class="answer">' .
+                '<input type="text" name="question__stack1" id="question__stack1" size="1" maxlength="1" ' .
+                'value="a" autocapitalize="none" spellcheck="false" readonly="readonly" /></span></label>';
         $this->assertEquals($expected,
                 $el->render(new stack_input_state(stack_input::VALID, array('a'), '', '', '', '', ''),
                         'question__stack1', true, null));

--- a/tests/input_string_test.php
+++ b/tests/input_string_test.php
@@ -34,16 +34,18 @@ class stack_string_input_test extends qtype_stack_testcase {
 
     public function test_render_blank() {
         $el = stack_input_factory::make('string', 'ans1', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
 
     public function test_render_hello_world() {
         $el = stack_input_factory::make('string', 'ans1', '"Hello world"');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }

--- a/tests/input_units_test.php
+++ b/tests/input_units_test.php
@@ -32,8 +32,9 @@ require_once(__DIR__ . '/../stack/input/factory.class.php');
 class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_blank() {
         $el = stack_input_factory::make('units', 'ans1', 'x^2');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array(), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
@@ -41,26 +42,28 @@ class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_zero() {
         // We must have some units for this input type.
         $el = stack_input_factory::make('units', 'ans1', '0');
-        $this->assertEquals('<input type="text" name="stack1__ans1" id="stack1__ans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" />',
+        $this->assertEquals('<label for="stack1__ans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__ans1" id="stack1__ans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="0" /></span></label>',
                 $el->render(new stack_input_state(stack_input::INVALID, array('0'), '', '', '', '', ''),
                         'stack1__ans1', false, null));
     }
 
     public function test_render_pre_filled() {
         $el = stack_input_factory::make('units', 'test', 'm/s');
-        $this->assertEquals('<input type="text" name="stack1__test" id="stack1__test" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="m/s" />',
+        $this->assertEquals('<label for="stack1__test">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__test" id="stack1__test" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="m/s" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('m/s'), '', '', '', '', ''),
                         'stack1__test', false, null));
     }
 
     public function test_render_basic() {
         $el = stack_input_factory::make('units', 'input', '9.81*m/s^2');
-        $this->assertEquals(
-                '<input type="text" name="stack1__input" id="stack1__input" '
+        $this->assertEquals('<label for="stack1__input">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__input" id="stack1__input" '
                 .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="9.81*m/s^2" '
-                .'readonly="readonly" />',
+                .'readonly="readonly" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('9.81*m/s^2'), '', '', '', '', ''),
                         'stack1__input', true, null));
     }
@@ -68,8 +71,9 @@ class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_different_size() {
         $el = stack_input_factory::make('units', 'input', '-9.81*m/s^2');
         $el->set_parameter('boxWidth', 30);
-        $this->assertEquals('<input type="text" name="stack1__input" id="stack1__input" '
-                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="-9.81*m/s^2" />',
+        $this->assertEquals('<label for="stack1__input">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__input" id="stack1__input" '
+                .'size="33" style="width: 27.1em" autocapitalize="none" spellcheck="false" value="-9.81*m/s^2" /></span></label>',
                 $el->render(new stack_input_state(stack_input::VALID, array('-9.81*m/s^2'), '', '', '', '', ''),
                         'stack1__input', false, null));
     }
@@ -77,8 +81,9 @@ class stack_units_input_test extends qtype_stack_testcase {
     public function test_render_syntaxhint() {
         $el = stack_input_factory::make('units', 'sans1', '9.81*m/s^2');
         $el->set_parameter('syntaxHint', '?*m/s^2');
-        $this->assertEquals('<input type="text" name="stack1__sans1" id="stack1__sans1" '
-                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?*m/s^2" />',
+        $this->assertEquals('<label for="stack1__sans1">Answer: <span class="answer">'
+                .'<input type="text" name="stack1__sans1" id="stack1__sans1" '
+                .'size="16.5" style="width: 13.6em" autocapitalize="none" spellcheck="false" value="?*m/s^2" /></span></label>',
                 $el->render(new stack_input_state(stack_input::BLANK, array(), '', '', '', '', ''),
                         'stack1__sans1', false, null));
     }


### PR DESCRIPTION
This is an accessibility bug. 
As all input of the other question has a <label> tag, so this should be added following the pattern used by other Moodle question types.