### PR TITLE
Community

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,14 @@ The [current state of development](https://github.com/maths/moodle-qtype_stack/b
 
 The [documentation is here](https://github.com/maths/moodle-qtype_stack/blob/master/doc/en/index.md), including the [installation instructions](https://github.com/maths/moodle-qtype_stack/blob/master/doc/en/Installation/index.md).
 
+
+## Community
+### Exchange of questions
+There is a database of STACK-question at https://db.ak-mathe-digital.de/domain. Right now there are over 400 STACK-questions, in many different languages. A filter simplifies the search for specific questions. Questions can easily be exported as xml-files and as such can be used in moodle as well as in ILIAS. Everybody can contribute their own questions. 
+
+### Meetings
+The 1st international STACK Conference took place on the 15th and 16th of November 2018 in Fürth at the FAU. Further information and slides and at https://www.stack-konferenz.de/.
+
 ## License
 
 Stack is Licensed under the [GNU General Public, License Version 3](https://github.com/maths/moodle-qtype_stack/blob/master/COPYING.txt).

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ STACK was created by [Chris Sangwin](http://www.maths.ed.ac.uk/~csangwin/) of th
 
 STACK is based on continuing research and use at the University of Edinburgh, the Open University, Aalto, Loughborough University, the University of Birmingham and others.
 
+
 ## Current state of development
 
 STACK 4.2 contains some important new features, and a number of interface improvements and bug fixes.
@@ -23,11 +24,18 @@ The [documentation is here](https://github.com/maths/moodle-qtype_stack/blob/mas
 
 
 ## Community
+
 ### Exchange of questions
 There is a database of STACK-question at https://db.ak-mathe-digital.de/domain. Right now there are over 400 STACK-questions, in many different languages. A filter simplifies the search for specific questions. Questions can easily be exported as xml-files and as such can be used in moodle as well as in ILIAS. Everybody can contribute their own questions. 
 
 ### Meetings
-The 1st international STACK Conference took place on the 15th and 16th of November 2018 in Fürth at the FAU. Further information and slides and at https://www.stack-konferenz.de/.
+The 1st international STACK Conference took place on the 15th and 16th of November 2018 in Fürth at the Friedrich-Alexander-Universität Erlangen-Nürnberg. Further information and slides at https://www.stack-konferenz.de/.
+
+### Groups
+Groups of people who use STACK. You are welcome to join, ask questions and participate.
+* [SIG Mathe+ILIAS](https://docu.ilias.de/goto.php?target=grp_5183)
+* [Arbeitskreis Digitale Mathematik-Aufgaben in der Hochschullehre](http://www.ak-mathe-digital.de)
+
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -23,20 +23,6 @@ The [current state of development](https://github.com/maths/moodle-qtype_stack/b
 The [documentation is here](https://github.com/maths/moodle-qtype_stack/blob/master/doc/en/index.md), including the [installation instructions](https://github.com/maths/moodle-qtype_stack/blob/master/doc/en/Installation/index.md).
 
 
-## Community
-
-### Exchange of questions
-There is a database of STACK-question at https://db.ak-mathe-digital.de/domain. Right now there are over 400 STACK-questions, in many different languages. A filter simplifies the search for specific questions. Questions can easily be exported as xml-files and as such can be used in moodle as well as in ILIAS. Everybody can contribute their own questions. 
-
-### Meetings
-The 1st international STACK Conference took place on the 15th and 16th of November 2018 in Fürth at the Friedrich-Alexander-Universität Erlangen-Nürnberg. Further information and slides at https://www.stack-konferenz.de/.
-
-### Groups
-Groups of people who use STACK. You are welcome to join, ask questions and participate.
-* [SIG Mathe+ILIAS](https://docu.ilias.de/goto.php?target=grp_5183)
-* [Arbeitskreis Digitale Mathematik-Aufgaben in der Hochschullehre](http://www.ak-mathe-digital.de)
-
-
 ## License
 
 Stack is Licensed under the [GNU General Public, License Version 3](https://github.com/maths/moodle-qtype_stack/blob/master/COPYING.txt).

--- a/doc/en/About/Community.md
+++ b/doc/en/About/Community.md
@@ -23,15 +23,18 @@ Contributions to the code base are very welcome.  This is more difficult, but do
 
 ### How do I keep up to date with announcements about STACK?
 
-We will make announcements about progress and developments with STACK on the [Moodle maths tools](http://moodle.org/mod/forum/view.php?id=752) forum.
+We will make announcements about progress and developments with STACK on the [Moodle maths tools](http://moodle.org/mod/forum/view.php?id=752) forum. 
+For the STACK Question Plugin see https://docu.ilias.de/goto_docu_cat_4119.html.
 
 ### How do I report a bug?
 
 Bug reports are always very welcome.  Please try to make sure it is really not a bug with your question!  Where possible, please export a minimal question and a clear description of how to recreate the bug.  Issues such as this can be reported on [github](http://github.com/maths/moodle-qtype_stack/issues).
+For the STACK Question Plugin see https://docu.ilias.de/goto_docu_cat_4119.html.
 
 ### How do I request a new feature?
 
 Please look at the ideas we have for our [development track](../Developer/Development_track.md) and [future plans](../Developer/Future_plans.md).  If your request does not appear here, then please email the developers to discuss it.  Alternatively, you are very welcome to start a new issue on [github](http://github.com/maths/moodle-qtype_stack/issues) to discuss it.
+For the STACK Question Plugin see https://docu.ilias.de/goto_docu_cat_4119.html.
 
 ### How do I submit my code changes?
 
@@ -54,7 +57,7 @@ Groups of people who use STACK. You are welcome to join, ask questions and parti
 * [SIG Mathe+ILIAS](https://docu.ilias.de/goto.php?target=grp_5183)
 * [Arbeitskreis Digitale Mathematik-Aufgaben in der Hochschullehre](http://www.ak-mathe-digital.de)
 
-# STACK users
+### Institutions
 
 The following institutions made use of previous version of STACK.  If you are actively using STACK and would like to be listed below then please contact the developers.
 

--- a/doc/en/About/Community.md
+++ b/doc/en/About/Community.md
@@ -41,6 +41,19 @@ Submit a pull request [https://github.com/maths/moodle-qtype_stack](https://gith
 
 Please do research and publish your experiences of using STACK with students.  A list of [publications](Publications.md) is available.
 
+## User Community
+
+### Exchange of questions
+There is a database of STACK-question at https://db.ak-mathe-digital.de/domain. Right now there are over 400 STACK-questions, in many different languages. A filter simplifies the search for specific questions. Questions can easily be exported as xml-files and as such can be used in moodle as well as in ILIAS. Everybody can contribute their own questions. 
+
+### Meetings
+The 1st international STACK Conference took place on the 15th and 16th of November 2018 in Fürth at the Friedrich-Alexander-Universität Erlangen-Nürnberg. Further information and slides at https://www.stack-konferenz.de/.
+
+### Groups
+Groups of people who use STACK. You are welcome to join, ask questions and participate.
+* [SIG Mathe+ILIAS](https://docu.ilias.de/goto.php?target=grp_5183)
+* [Arbeitskreis Digitale Mathematik-Aufgaben in der Hochschullehre](http://www.ak-mathe-digital.de)
+
 # STACK users
 
 The following institutions made use of previous version of STACK.  If you are actively using STACK and would like to be listed below then please contact the developers.


### PR DESCRIPTION
Since @sangwinc suggested at the [STACK Conference 2018](https://www.stack-konferenz.de/) to use github also for community building, I looked for the info there on community. I couldn’t find the community.md right away, that’s why I started editing in the readme.md, but moved that to community.md later.

Do we want to keep the references to the STACK-Plugin for ILIAS in the FAQ? What do you think about further references between “STACK for moodle” and “STACK for ILIAS”? (@fneumann, @jcopado)

Could we make “Community” more prominent? As mentioned, it took me a while to find it. I would mention it somewhere in the readme.
