### PR TITLE
Hide the 'Question tests' link in iframes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,10 @@
     font-size: 0.7em;
     margin: -1.3em -3em;
 }
+body.pagelayout-embedded .que.stack .formulation .questiontestslink {
+    display: none;
+}
+
 .que.stack .formulation .answer .option {
     margin: 0.7em;
 }


### PR DESCRIPTION
Whe a STACK question is in an iframe, which might happen if you are
using https://moodle.org/plugins/filter_embedquestion, then it is a reall bad user-experience if you
can navigate to the 'Question tests & deployed versions' page.
Therefore, we hide the link in that case.

For embedded questions, authors will have to access the question tests
via the question bank.

(We just did a similar change in our 'Pattern-match' question type, and I thought I should submit the same change to STACK.)