### PR TITLE
Iss317 - base N support (finally!)

### DIFF
--- a/doc/en/CAS/Numbers.md
+++ b/doc/en/CAS/Numbers.md
@@ -128,14 +128,14 @@ The following commands which are relevant to manipulation of numbers are defined
 
 The following commands generate displayed forms of numbers.  These will not be manipulated further automatically, so you will need to use these at the last moment, e.g. only when generating the teacher's answer etc.
 
-| Command                         | Description
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| `dispdp(x,n)`                   | Truncate \(x\) to \(n\) decimal places and display with trailing digits.  Note, this always prints as a float (or integer), and not in scientific notation.
-| `dispsf(x,n)`                   | Truncate \(x\) to \(n\) significant figures and display with trailing digits.  Note, this always prints as a float, and not in scientific notation.
-| `scientific_notation(x,n)`      | Write \(x\) in the form \(m10^e\).   Only works reliably with `simp:false` (e.g. try 9000).  The optional second argument applies `displaysci(m,n)` to the mantissa to control the display of trailing zeros.
-| `displaydp(x,n)`                | An intert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits.  This function does no rounding.
-| `displaysci(x,n,expo)`          | An intert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits, in scientific notation.  E.g. \(x\times 10^{expo}\).
-| `basen(x,n[,mode[,mindigits]])` | An inert internal function to record that \(x\) should be displayed and input in a base\(n\) integer format with at least mindigits digits.
+| Command                                         | Description
+| ------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| `dispdp(x,n)`                                   | Truncate \(x\) to \(n\) decimal places and display with trailing digits.  Note, this always prints as a float (or integer), and not in scientific notation.
+| `dispsf(x,n)`                                   | Truncate \(x\) to \(n\) significant figures and display with trailing digits.  Note, this always prints as a float, and not in scientific notation.
+| `scientific_notation(x,n)`                      | Write \(x\) in the form \(m10^e\).   Only works reliably with `simp:false` (e.g. try 9000).  The optional second argument applies `displaysci(m,n)` to the mantissa to control the display of trailing zeros.
+| `displaydp(x,n)`                                | An intert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits.  This function does no rounding.
+| `displaysci(x,n,expo)`                          | An intert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits, in scientific notation.  E.g. \(x\times 10^{expo}\).
+| `basen(x,n[,mode[,inpdigits[,mindispdigits]]])` | An inert internal function to record that \(x\) should be displayed with at least mindispdigits and input  with exactly inpdigits digits in a base\(n\) integer format.
 
 
 | Function                  | Predicate

--- a/stack/basenoptions.class.php
+++ b/stack/basenoptions.class.php
@@ -124,7 +124,7 @@ class stack_basen_options {
     }
 
     private static function digit_range_pattern($radix, $underscoresallowed) {
-        $r = $radix - 1;
+        $r = abs($radix) - 1;
         if ($radix <= 10) {
             $pattern = "0-$r";
         } else if ($radix == 11) {
@@ -144,7 +144,7 @@ class stack_basen_options {
 
     private static function number_pattern($mode, $radix) {
         if ($mode == self::BASENMODE_C) {
-            if ($radix == 2) {
+            if (abs($radix) == 2) {
                 $pattern = "0[bB]" . self::digit_pattern($radix, true) . "+";
             } else if ($radix == 8) {
                 $pattern = "0" . self::digit_pattern($radix, true) . "+";
@@ -154,7 +154,7 @@ class stack_basen_options {
                 $pattern = "0[xX]" . self::digit_pattern($radix, true) . "+";
             }
         } else if ($mode == self::BASENMODE_BASIC) {
-            if ($radix == 2) {
+            if (abs($radix) == 2) {
                 $pattern = "&[bB]" . self::digit_pattern($radix, true) . "+";
             } else if ($radix == 8) {
                 $pattern = "&[oO]" . self::digit_pattern($radix, true) . "+";
@@ -164,7 +164,7 @@ class stack_basen_options {
                 $pattern = "&[xX]" . self::digit_pattern($radix, true) . "+";
             }
         } else if ($mode == self::BASENMODE_SUFFIX) {
-            $pattern = self::digit_pattern($radix, false) . "+" . "_$radix";
+            $pattern = self::digit_pattern($radix, false) . "+" . "_abs($radix)";
         }
         return $pattern;
     }

--- a/stack/basenoptions.class.php
+++ b/stack/basenoptions.class.php
@@ -21,7 +21,7 @@ defined('MOODLE_INTERNAL') || die();
  *
  * @property-read int $radix the number base 2 = binary etc.
  * @property-read int $mode one of the mode constants controlling the format of base-N literals.
- * @property-read int $mindigits the minimum number of digits used to display the base n number - padded with zeroes.
+ * @property-read int $inpdigits the minimum number of digits used to display the base n number - padded with zeroes.
  * @copyright 2017 The Open University
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @author Stephen Parry <stephen@edumake.org>
@@ -86,7 +86,8 @@ class stack_basen_options {
     }
 
     private $radix = 0;
-    private $mindigits = 0;
+    private $inpdigits = 0;
+    private $mindispdigits = 0;
     private $mode = 0;
 
     /**
@@ -94,12 +95,15 @@ class stack_basen_options {
      *
      * @param int $radix the number base 2 = binary etc.
      * @param int $mode one of the mode constants controlling the format of base-N literals.
-     * @param int $mindigits the minimum number of digits used to display the base n number
-     *      - padded with zeroes.
+     * @param int $inpdigits the exact number of digits the student must enter. zero => any.
+     *     -1 => use the minimum.
+     * @param int $mindispdigits the minimum number of digits used to display the base n
+     *     number, padded with zeroes. -1 => use inpdigits.
      */
-    public function __construct($radix = 0, $mode = 1, $mindigits = 0) {
+    public function __construct($radix = 0, $mode = 1, $inpdigits = 0, $mindispdigits = -1) {
         $this->radix = $radix;
-        $this->mindigits = $mindigits;
+        $this->inpdigits = $inpdigits;
+        $this->mindispdigits = $mindispdigits;
         $this->mode = self::basen_mode_to_num($mode);
     }
 
@@ -107,8 +111,12 @@ class stack_basen_options {
         return $this->radix;
     }
 
-    public function get_mindigits() {
-        return $this->mindigits;
+    public function get_inpdigits() {
+        return $this->inpdigits;
+    }
+
+    public function get_mindispdigits() {
+        return $this->mindispdigits;
     }
 
     public function get_mode() {
@@ -239,8 +247,9 @@ class stack_basen_options {
      * @returns string  the string with literals wrapped in function calls.
      */
     public function upgrade_escapes($string) {
-        $tail = "," . $this->get_radix() . "," . $this->get_mode() . "," . $this->get_mindigits() . ")";
-        return str_replace("![!", "basen(frombasen(", str_replace("!]!", "$tail$tail", $string));
+        $tail = "," . $this->get_radix() . "," . $this->get_mode() . "," . $this->get_inpdigits() . ")," . 
+                $this->get_radix() . "," . $this->get_mode() . "," . $this->get_inpdigits() . "," . $this->get_mindispdigits() . ")";
+        return str_replace("![!", "basen(frombasen(", str_replace("!]!", "$tail", $string));
     }
 
     /**

--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -365,12 +365,18 @@ abstract class stack_input {
                 $mode = trim($params[2], "\'\"");
             } else {
                 $mode = 1;
-            } if (count($params) > 3 && is_numeric($params[3])) {
-                $mindigits = (int)$params[3];
-            } else {
-                $mindigits = 0;
             }
-            return new stack_basen_options($radix, $mode, $mindigits);
+            if (count($params) > 3 && is_numeric($params[3])) {
+                $inpdigits = (int)$params[3];
+            } else {
+                $inpdigits = 0;
+            }
+            if (count($params) > 4 && is_numeric($params[4])) {
+                $mindispdigits = (int)$params[4];
+            } else {
+                $mindispdigits = -1;
+            }
+            return new stack_basen_options($radix, $mode, $inpdigits, $mindispdigits);
         } else {
             return null;
         }

--- a/stack/maxima/basen.lisp
+++ b/stack/maxima/basen.lisp
@@ -263,12 +263,17 @@
   (tobasen n base mode mindigits))
 
 ;; This function has grind (and hence "string") output the number in the following base.
-;; basen(number, base, mode, mindigits).
+;; basen(number, base, mode, inpdigits, mindigits).
 (defprop $basenvalue msz-basenvalue grind)
 (defun msz-basenvalue (x l r)
   (msz (mapcar #'(lambda (l) (char (string l) 0)) 
 	       (let* (
-		      (value (second x)) (base (third x)) (mode (fourth x)) (mindigits (fifth x)) (m (first (lookup-basen-mode mode))))
+		      (value (second x))
+              (base (if (null (third x)) 0 (third x)))
+              (mode (if (null (fourth x)) 1 (fourth x)))
+              (inpdigits (if (null (fifth x)) 0 (fifth x)))
+              (mindigits (if (or (null (sixth x)) (< (sixth x) 0) ) inpdigits (sixth x)) )
+              (m (first (lookup-basen-mode mode))))
 		 (makestring (tobasen value base mode mindigits) )  ) ) l r))
 
 ;; This function calculates the two's complement of a number, with mindigits or more bits.

--- a/stack/maxima/basen.lisp
+++ b/stack/maxima/basen.lisp
@@ -17,46 +17,46 @@
 (in-package :maxima)
 
 (defun split-number-string(s base m)
-    (if (or (eql m #\S) (eql m #\_))
+  (if (or (eql m #\S) (eql m #\_))
       (let* (
-          (sp (position #\_ s :from-end t))
-          (suff (if sp (subseq s (+ sp 1)) "" ))
-          (b2 (if (and (<= 1 (length suff) 2) (digit-char-p (elt suff 0)) (or (= 1 (length suff)) (digit-char-p (elt suff 1))) ) (parse-integer suff) -1))
-          (body (cond (sp (subseq s 0 sp)) (t s))))
-            
+             (sp (position #\_ s :from-end t))
+             (suff (if sp (subseq s (+ sp 1)) "" ))
+             (b2 (if (and (<= 1 (length suff) 2) (digit-char-p (elt suff 0)) (or (= 1 (length suff)) (digit-char-p (elt suff 1))) ) (parse-integer suff) -1))
+             (body (cond (sp (subseq s 0 sp)) (t s))))
+	
         (if (and (eql m #\_) ( > b2 10)) (if (eql (char s 0) #\0) (list "0" (subseq body 1) suff b2) (list "" body suff -2)) (list "" body suff b2)) )
 
-        (let* (
-            (prefs
-              (cond
-                ((eql m #\M)
-                  (if (> base 10)
-                    (list (cons "0" base) (cons "" -2))
-                    (list (cons "" base))))
-                ((eql m #\C) '(("0b". 2) ("0x" . 16) ("0" . 8) ("" . 10)))
-                ((eql m #\B) '(("&b". 2) ("&o" . 8) ("&h" . 16) ("" . 10)))
-                (t (list (cons ""  base)))))
-            (prefp (assoc s prefs :test (lambda(s1 s2) (and ( >= (length s1) (length s2) ) (string-equal (subseq s1 0 (length s2)) s2)) )))
-            (pref (car prefp))
-            (b2 (cdr prefp))
-            (body (subseq s (length pref))))
-          (list pref body "" b2))))
+    (let* (
+           (prefs
+            (cond
+             ((eql m #\M)
+              (if (> base 10)
+                  (list (cons "0" base) (cons "" -2))
+                (list (cons "" base))))
+             ((eql m #\C) '(("0b". 2) ("0x" . 16) ("0" . 8) ("" . 10)))
+             ((eql m #\B) '(("&b". 2) ("&o" . 8) ("&h" . 16) ("" . 10)))
+             (t (list (cons ""  base)))))
+           (prefp (assoc s prefs :test (lambda(s1 s2) (and ( >= (length s1) (length s2) ) (string-equal (subseq s1 0 (length s2)) s2)) )))
+           (pref (car prefp))
+           (b2 (cdr prefp))
+           (body (subseq s (length pref))))
+      (list pref body "" b2))))
 
 (defconstant basen-mode-list (list
-        '("D" . 0) (cons '"D<" (+ 128 0)) 
-        '("M" . 1) (cons '"M<" (+ 128 1)) 
-        '("G" . 2) (cons '"G<" (+ 128 2)) 
-        '("B" . 3) (cons '"B*" (+ 128 3)) '("C" . 4) (cons '"C*" (+ 64 4))
-        '("_" . 5) '("S" . 6) (cons '"_*" ( + 64 5)) (cons '"S*" (+ 64 6))))
+			      '("D" . 0) (cons '"D<" (+ 128 0)) 
+			      '("M" . 1) (cons '"M<" (+ 128 1)) 
+			      '("G" . 2) (cons '"G<" (+ 128 2)) 
+			      '("B" . 3) (cons '"B*" (+ 128 3)) '("C" . 4) (cons '"C*" (+ 64 4))
+			      '("_" . 5) '("S" . 6) (cons '"_*" ( + 64 5)) (cons '"S*" (+ 64 6))))
 
 (defun lookup-basen-mode(mode)
   (let* (
-      (mode-entry (cond 
-        ((not mode) (assoc '"M" basen-mode-list :test #'string-equal))
-        ((integerp mode) (rassoc mode basen-mode-list :test #'eql))
-        ((or (charp mode) (stringp mode)) (assoc mode basen-mode-list :test #'string-equal))
-        (t nil)))
-      (mn (cdr mode-entry)))
+	 (mode-entry (cond 
+		      ((not mode) (assoc '"M" basen-mode-list :test #'string-equal))
+		      ((integerp mode) (rassoc mode basen-mode-list :test #'eql))
+		      ((or (charp mode) (stringp mode)) (assoc mode basen-mode-list :test #'string-equal))
+		      (t nil)))
+	 (mn (cdr mode-entry)))
     (and mode-entry (list (elt (car mode-entry) 0) (cond ((> mn 128) (- mn 128)) ((> mn 64) (- mn 64)) (t mn)) (> mn 64) (> mn 128)))))
 
 (defun summarize-basen-mode-list()
@@ -70,16 +70,16 @@
 
 (defun validate-basen-params (func base mode mindigits)
   (let ((mode-entry (lookup-basen-mode mode)))
-    (if (and (integerp base) (or ( <= 2 base 36 ) (and mode-entry (third mode-entry) (= base 0))))
-      (if mode-entry
-        (if (or (not (or (eql (first mode-entry) #\B) (eql (first mode-entry) #\C) )) (third mode-entry) (= base 2) (= base 8) (= base 10) (= base 16) )
-          (if (or (not (eql (first mode-entry) #\D)) (<= base 10))
-            (if (and (integerp mindigits) ( >= mindigits 0 ))
-              mode-entry
-              (merror "~M: minimum number of digits ~M should be an integer 0 or greater." func mindigits) )
-            (merror "~M: base must be 10 or less for default mode." func ) )
-          (merror "~M: base must be 2, 8, 10 or 16 for mode ~M." func mode ) )
-        (merror "~M: ~M is not valid; must be one of ~M." func mode (summarize-basen-mode-list) ) )
+    (if (and (integerp base) (or ( <= 2 base 36 ) ( = -2 base ) (and mode-entry (third mode-entry) (= base 0))))
+	(if mode-entry
+            (if (or (not (or (eql (first mode-entry) #\B) (eql (first mode-entry) #\C) )) (third mode-entry) (= base 2) (= base 8) (= base 10) (= base 16) )
+		(if (or (not (eql (first mode-entry) #\D)) (<= base 10))
+		    (if (and (integerp mindigits) ( >= mindigits 0 ))
+			mode-entry
+		      (merror "~M: minimum number of digits ~M should be an integer 0 or greater." func mindigits) )
+		  (merror "~M: base must be 10 or less for default mode." func ) )
+              (merror "~M: base must be 2, 8, 10 or 16 for mode ~M." func mode ) )
+          (merror "~M: ~M is not valid; must be one of ~M." func mode (summarize-basen-mode-list) ) )
       (merror "~M: base of ~M is not an integer between 2 and 36." func base) ) ) )
 
 
@@ -116,78 +116,96 @@
 
 (defun $frombasen (s base &optional (mode "M") (mindigits 0))
   (if (stringp s)
-    (if (> (length (string-trim '(#\Space #\Tab #\Newline) s)) 0)
-      (let ((mode-entry (validate-basen-params "frombasen" base mode mindigits)))
-        (destructuring-bind (ml mn choice leftj) mode-entry
-          (declare (ignore mn))
-            (destructuring-bind (pref body suff b2) (split-number-string s base ml)
-  
-              (declare (ignore pref))
-  
-              (if (> b2 -2) 
-                (if (or choice (eql b2 base))
-                  (if (and (integerp b2) (<= 2 b2 36) )
-                    (if (or (> (length (string-trim '(#\Space #\Tab #\Newline) body)) 0) (and (eq ml #\M) (> base 10)) )
-                          
-                      (let* (
-                          (body-padded (cond-left-pad body mindigits leftj))
-                          (n 
-                              (catch 'macsyma-quit 
-                                (parse-basen-string (if (and (integerp b2) (> b2 10)) (concatenate 'string "0" body-padded) body-padded) b2)) ))
-                        (declare (special $report_synerr_info))
-                        (if (integerp n)
-                          (if (or (eq mindigits 0) (eq mindigits (length body)) (and leftj (>= mindigits (length body))) )
-                            n
-                            (merror "~M: ~M contains wrong number of digits for ~M digit base ~M integer." "frombasen" s mindigits (cond ((> base 0) base) (t b2))) )
+      (if (> (length (string-trim '(#\Space #\Tab #\Newline) s)) 0)
+	  (let 
+              ((mode-entry (validate-basen-params "frombasen" base mode mindigits))
+               (absbase (abs base)))
+            (destructuring-bind (ml mn choice leftj) mode-entry
+				(declare (ignore mn))
+				(destructuring-bind (pref body suff b2) (split-number-string s absbase ml)
+						    
+						    (declare (ignore pref))
+						    
+						    (if (> b2 -2) 
+							(if (or choice (eql b2 absbase))
+							    (if (and (integerp b2) (<= 2 b2 36) )
+								(if (or (> (length (string-trim '(#\Space #\Tab #\Newline) body)) 0) (and (eq ml #\M) (> absbase 10)) )
+								    
+								    (let* (
+									   (body-padded (cond-left-pad body mindigits leftj))
+									   (n 
+									    (catch 'macsyma-quit 
+									      (parse-basen-string (if (and (integerp b2) (> b2 10)) (concatenate 'string "0" body-padded) body-padded) (if (= base -2) -2 b2))) ))
+								      (declare (special $report_synerr_info))
+								      (if (integerp n)
+									  (if (or (eq mindigits 0) (eq mindigits (length body)) (and leftj (>= mindigits (length body))) )
+									      n
+									    (merror "~M: ~M contains wrong number of digits for ~M digit base ~M integer." "frombasen" s mindigits (cond ((> base 0) base) (t b2))) )
 
-                          (merror "~M: ~M is not a valid base ~M integer." "frombasen" s b2) ))
-                                
-                      (merror "~M: Empty value." "frombasen") )
-  
-                    (merror "~M: base \"~M\" should be an integer between 2 and 36." "frombasen" suff) )
-  
-                  (merror "~M: ~M is incorrect format for base ~M integer." "frombasen" s (if (> base 0) base b2) ) )
-                          
-                (merror "~M: Prefix 0 missing from ~M." "frombasen" s) ) ) ) )
-               
-      (merror "~M: Empty string." "frombasen" ) )
+									(merror "~M: ~M is not a valid base ~M integer." "frombasen" s b2) ))
+								  
+								  (merror "~M: Empty value." "frombasen") )
+							      
+							      (merror "~M: base \"~M\" should be an integer between 2 and 36." "frombasen" suff) )
+							  
+							  (merror "~M: ~M is incorrect format for base ~M integer." "frombasen" s (if (> base 0) base b2) ) )
+						      
+						      (merror "~M: Prefix 0 missing from ~M." "frombasen" s) ) ) ) )
+	
+	(merror "~M: Empty string." "frombasen" ) )
 
     (merror "~M: ~M is not a string." "frombasen" s) ) ) 
 
 (defun cond-left-pad (s mindigits leftj)
   (if (and leftj (< (length s) mindigits))
-    (concatenate 'string s (make-string (- mindigits (length s)) :initial-element #\0))
+      (concatenate 'string s (make-string (- mindigits (length s)) :initial-element #\0))
     s ) )
 
 ;; 
-;; (PARSE-STRING S)  --  parse the string as a Maxima expression.
+;; (PARSE-BASEN-STRING S BASE)  --  parse the string as a Maxima expression in base N.
 ;; Do not evaluate the parsed expression.
 
 (defun parse-basen-string (s base)
   (declare (special *mread-prompt*))
-  (let (
-      ( *read-base* base )
-      ( fstr (
-        make-array '(0) :element-type 'base-char :fill-pointer 0 :adjustable t)))
-  (with-output-to-string (*standard-output* fstr)
-    (with-input-from-string
-        (ss (ens-term s))
-        (third (let ((*mread-prompt*)) (mread ss)))))))
+  (let*
+      ((absbase (abs base))
+       s1
+       adj
+       ( *read-base* absbase )
+       ( fstr (
+               make-array '(0) :element-type 'base-char :fill-pointer 0 :adjustable t)))
+    (cond ((and (= base -2) (and (> (length s) 0) (not (eq (elt s 0) #\0))))
+	   (setq s1 (subseq s 1)) (setq adj (- (expt 2 (- (length s) 1)))))
+	  (t (setq s1 s) (setq adj 0)))
+    (+ (with-output-to-string (*standard-output* fstr)
+			      (with-input-from-string
+			       (ss (ens-term s1))
+			       (third (let ((*mread-prompt*)) (mread ss))))) adj )))
 
 ;; (ENS-TERM S)  -- if the string S does not contain dollar sign `$' or semicolon `;'
 ;; then append a dollar sign to the end of S.
 
 (defun ens-term (s)
   (cond
-    ((or (search "$" s :test #'char-equal) (search ";" s :test #'char-equal))
-     s)
-    (t
-      (concatenate 'string s "$"))))
+   ((or (search "$" s :test #'char-equal) (search ";" s :test #'char-equal))
+    s)
+   (t
+    (concatenate 'string s "$"))))
+
+(defun min-twos-comp-digits(n)
+  (+ (ceiling (log (if (< n 0) (- n) (+ n 1)) 2)) 1 ) )
+
+(defun twos-comp-of(n m)
+  (if (< n 0) (+ n (expt 2 m)) n ) )
 
 ;; This function is designed for converting from a number to a base n representation string.
 ;; tobasen(n, base, mode, mindigits) converts n from an integer to a base n format string
 ;; n        is the integer number to convert.
-;; base     is the radix of the number; must be 2 <= base <= 36.
+;; base     is the radix of the number; must be 2 <= base <= 36 or -2
+;;          -2 indicates that the number should be treated as two's complement;
+;;          any negative number n is first converted to 2^m + n - where m is either
+;;          mindigits or the minimum required to represent the number (eg, for
+;;          -128..127 this is 8 digits), whichever is greater.
 ;; mindigitsis the minimum number of figures outputted.
 ;; mode     is a string controlling the format:                                                 
 ;;    D    STACK compatible format; base must be < 11.
@@ -214,30 +232,32 @@
 
 (defun tobasen(n base &optional (mode "M") (mindigits 0))
   (if (integerp n)
-    (let ((mode-entry (validate-basen-params "tobasen" base mode mindigits)))
-      (destructuring-bind (ml mn choice leftj) mode-entry
-        (declare (ignore mn))
-          (format nil
-            (concatenate
-              'string 
-              (cond 
-                ((or (and (char-equal ml #\C) (/= base 10)) (and (or (char-equal ml #\_) (char-equal ml #\M)) (> base 10))) "0")
-                ((and (char-equal ml #\B) (/= base 10)) "&")
-                (t ""))
-              (cond 
-                ((char-equal ml #\C)
-                    (cond ((= base 2) "b") ((= base 8) "") ((= base 10) "") ((= base 16) "x") (t "?")))
-                ((char-equal ml #\B)
-                    (cond ((= base 2) "B") ((= base 8) "o") ((= base 10) "") ((= base 16) "H") (t "?")))
-                (t ""))
-              "~" (format nil "~d" base) "," (format nil "~d" mindigits) ",'0R" 
-              (cond 
-                ((or (char-equal ml #\_) (char-equal ml #\S))
-                  (format nil "_~d" base))
-                (t "")))
-            n) ) )
+      (let
+          ((mode-entry (validate-basen-params "tobasen" base mode mindigits)) (absbase (abs base))
+           (md (if (= base -2) (max (min-twos-comp-digits n) mindigits) mindigits ) ) )
+	(destructuring-bind (ml mn choice leftj) mode-entry
+			    (declare (ignore mn))
+			    (format nil
+				    (concatenate
+				     'string 
+				     (cond 
+				      ((or (and (char-equal ml #\C) (/= absbase 10)) (and (or (char-equal ml #\_) (char-equal ml #\M)) (> absbase 10))) "0")
+				      ((and (char-equal ml #\B) (/= absbase 10)) "&")
+				      (t ""))
+				     (cond 
+				      ((char-equal ml #\C)
+				       (cond ((= absbase 2) "b") ((= absbase 8) "") ((= absbase 10) "") ((= absbase 16) "x") (t "?")))
+				      ((char-equal ml #\B)
+				       (cond ((= absbase 2) "B") ((= absbase 8) "o") ((= absbase 10) "") ((= absbase 16) "H") (t "?")))
+				      (t ""))
+				     "~" (format nil "~d" absbase) "," (format nil "~d" md) ",'0R" 
+				     (cond 
+				      ((or (char-equal ml #\_) (char-equal ml #\S))
+				       (format nil "_~d" absbase))
+				      (t "")))
+				    (if (or (>= n 0) (/= base -2)) n (+ n (expt 2 md)) ) ) ) ) 
     (merror "~M: ~M is not an integer." "tobasen" n ) ) )
-      
+
 (defun $tobasen(n base &optional (mode "M") (mindigits 0))
   (tobasen n base mode mindigits))
 
@@ -246,6 +266,16 @@
 (defprop $basenvalue msz-basenvalue grind)
 (defun msz-basenvalue (x l r)
   (msz (mapcar #'(lambda (l) (char (string l) 0)) 
-    (let* (
-        (value (second x)) (base (third x)) (mode (fourth x)) (mindigits (fifth x)) (m (first (lookup-basen-mode mode))))
-    (makestring (tobasen value base mode mindigits) )  ) ) l r))
+	       (let* (
+		      (value (second x)) (base (third x)) (mode (fourth x)) (mindigits (fifth x)) (m (first (lookup-basen-mode mode))))
+		 (makestring (tobasen value base mode mindigits) )  ) ) l r))
+
+;; This function calculates the two's complement of a number, with mindigits or more bits.
+
+(defun $twoscompof(n &optional (mindigits (min-twos-comp-digits n)))
+  (twos-comp-of n mindigits))
+
+;; This function calculates the minimum number of digits required to represent a number 
+;; in two's complement representation.
+(defun $mintwoscompdigits(n) (min-twos-comp-digits n))
+

--- a/stack/maxima/basenfuncs.mac
+++ b/stack/maxima/basenfuncs.mac
@@ -26,9 +26,9 @@
 /****************************************************************/
 
 /* This function is designed for displaying base n numbers.                                 */
-/* basen(n, base, mode, mindigits) is an inert function. The tex function converts this to  */
-/* display. The input routines also use its presence in a model answer to decide what base  */
-/* and format the student answer must be in.                                                */
+/* basen(n, base, mode, inpdigits, mindispdigits) is an inert function. The tex function    */
+/*  converts this to display. The input routines also use its presence in a model answer to */
+/* decide what base and format the student answer must be in.                               */
 /* n is the number to be displayed                                                          */
 /* base is the radix (base) of the number for both display and, if in the model answer      */
 /*   field, the input of the student answer.                                                */
@@ -45,32 +45,39 @@
 /*   S  Suffix syntax; number should appear as a subscripted suffix, typed using an _ char. */
 /*   S* Suffix syntax; radix at students' discretion.                                       */
 /*                                                                                          */
-/* mindigits is the minimum number of figures to display and the exact number of places the */
-/*   student is required to enter. 0 or empty here indicates use the minimum.               */
+/* inpdigits is the exact number of places the student is required to enter. 0 or empty     */
+/* here indicates they may enter any number, -1 indicates enter the exact minimum.          */
+/*                                                                                          */
+/* mindispdigits is the minimum number of figures to display, empty or -1 here indicates    */
+/* use the same as inpdigits.                                                               */
 /*                                                                                          */
 /* Note, basen does not actually change the number, it is only for display. Internally the  */
 /* number is still held in the same format.                                                 */
 /* To print out *values* in a given base use this function.                                 */
 
-basentex(ex) := block([a, ss, n, base, mode, ml, mp, mindigits],
+basentex(ex) := block([a, ss, n, base, mode, ml, mp, digitstemp, inpdigits, mindispdigits],
   a: args(ex),
-  n : a[1], base: a[2], mode: if length(a) > 2 then a[3] else 1, mindigits: if length(a) > 3 then a[4] else 0,
-  ev(?tobasen(n, base, mode, mindigits),simp));
+  n : a[1], base: a[2], mode: if length(a) > 2 then a[3] else 1,
+  inpdigits: if length(a) > 3 then a[4] else 0,
+  digitstemp: if length(a) > 4 then a[5] else -1,
+  mindispdigits: if digitstemp > -1 then digitstemp else inpdigits,
+  ev(?tobasen(n, base, mode, mindispdigits),simp));
 
 texput(basen,basentex);
 
-make_basenvalue(ex):= block([n, base, mode, mindigits],
+make_basenvalue(ex):= block([n, base, mode, inpdigits, mindispdigits, temp],
     if atom(ex) then return(ex),
     if taylorp(ex) or functionp(ex) or freeof(basen, ex) then return(ex),
     if arrayp(ex) then return(arraymake(op(ex), maplist(make_basenvalue, args(ex)))),
     if not(is(safe_op(ex)="basen")) then return(apply(op(ex), maplist(make_basenvalue, args(ex)))),
-    if not(length(args(ex)) >= 2 and length(args(ex)) <= 4) then error("basen must have between 2 and 4 arguments"),
+    if not(length(args(ex)) >= 2 and length(args(ex)) <= 5) then error("basen must have between 2 and 5 arguments"),
     n:ev(first(args(ex)), simp),
     base:ev(second(args(ex)), simp),
     mode:ev(if length(args(ex)) >= 3 then third(args(ex)) else "M", simp),
-    mindigits:if length(args(ex)) >= 4 then ev(fourth(args(ex)), simp) else 0,
-    if not(integerp(n) and integerp(base) and integerp(mindigits) and not emptyp(lookup_basen_mode(mode))) then return(ex),
-    return(apply(basenvalue, [ n, base, mode, mindigits]))
+    inpdigits:if length(args(ex)) >= 4 then ev(fourth(args(ex)), simp) else 0,
+    mindispdigits: if length(args(ex)) >= 5 then ev(fifth(args(ex)), simp) else -1,
+    if not(integerp(n) and integerp(base) and integerp(inpdigits) and integerp(mindispdigits) and not emptyp(lookup_basen_mode(mode))) then return(ex),
+    return(apply(basenvalue, [ n, base, mode, inpdigits, mindispdigits]))
 );
 
 remove_basen(ex):= block(


### PR DESCRIPTION
OK, this is not the finished article, but I have been using it for a while now and it serves a purpose; here are the areas requiring further development, along with more testing:

1. The 'interpreted as' output in answer validation is pretty counter-intuitive, as it shows the function call wrapper (frombasen) used to process the students' answer.
2. Matrix handling; I have not fully tested whether the base N functions can be used in a matrix context and whether there is a way of making matrices more null friendly. This is important to me because it would allow the student enter working more easily and me to actually mark it.
3. Library functions; in presenting effective questions and answers I use a lorry load of helper definitions that do things like converting to from floating point binary format, producing levelled random questions (e.g. based on bit count) as so on. Currently I am just pasting them in the question box inline, but many could be put together as another library.