### PR TITLE
STACK: Inconsistent database defaults

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -807,6 +807,19 @@ function xmldb_qtype_stack_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2018120500, 'qtype', 'stack');
     }
 
+    $newversion = 2019061900;
+    if ($oldversion < $newversion) {
+        // Changing the default of field firstnodename on table qtype_stack_prts to drop it.
+        $table = new xmldb_table('qtype_stack_prts');
+        $field = new xmldb_field('firstnodename', XMLDB_TYPE_CHAR, '8', null, XMLDB_NOTNULL, null, '', 'feedbackvariables');
+
+        // Launch change of default for field firstnodename.
+        $dbman->change_field_default($table, $field);
+
+        // Stack savepoint reached.
+        upgrade_plugin_savepoint(true, $newversion, 'qtype', 'stack');
+    }
+
     // Add new upgrade blocks just above here.
 
     // Check the version of the Maxima library code that comes with this version

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019052700;
+$plugin->version   = 2019061900;
 $plugin->requires  = 2015111600;
 $plugin->cron      = 0;
 $plugin->component = 'qtype_stack';


### PR DESCRIPTION
Hi Chris,
This issue was highlighted during a db-server refresh, the XMLDB "Check defaults" tool was run via /admin/tool/xmldb/ and the following inconsistencies were found in qtype_stack:

Table: qtype_stack_prts. Field: firstnodename, Expected '' Actual -

I have updated the corresponding upgrade code.
BTW, in upgrade code this was done in 2013 (version 2013030802), however, I did the patch before seeing this. And the issue does not appear anymore. In other words, somehow the upgrade on 2013 (version=2013030802) did not apply on our server.

Mahmoud  