### PR TITLE
Force math formulas input directionality to LTR, also in RTL mode.

### DIFF
--- a/stack/input/algebraic/algebraic.class.php
+++ b/stack/input/algebraic/algebraic.class.php
@@ -42,7 +42,7 @@ class stack_algebraic_input extends stack_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em',
+            'style' => 'width: '.$size.'em'.'; direction: ltr;',
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
         );

--- a/stack/input/algebraic/algebraic.class.php
+++ b/stack/input/algebraic/algebraic.class.php
@@ -42,9 +42,10 @@ class stack_algebraic_input extends stack_input {
             'name'  => $fieldname,
             'id'    => $fieldname,
             'size'  => $this->parameters['boxWidth'] * 1.1,
-            'style' => 'width: '.$size.'em'.'; direction: ltr;',
+            'style' => 'width: '.$size.'em',
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class' => 'algebraic',
         );
 
         $value = $this->contents_to_maxima($state->contents);

--- a/stack/input/equiv/equiv.class.php
+++ b/stack/input/equiv/equiv.class.php
@@ -88,6 +88,7 @@ class stack_equiv_input extends stack_input {
             'cols' => min($boxwidth, 50),
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class'     => 'equiv',
         );
 
         if ($readonly) {

--- a/stack/input/numerical/numerical.class.php
+++ b/stack/input/numerical/numerical.class.php
@@ -62,6 +62,7 @@ class stack_numerical_input extends stack_input {
             'style' => 'width: '.$size.'em',
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class'     => 'numerical',
         );
 
         $value = $this->contents_to_maxima($state->contents);

--- a/stack/input/string/string.class.php
+++ b/stack/input/string/string.class.php
@@ -46,6 +46,7 @@ class stack_string_input extends stack_algebraic_input {
             'style' => 'width: '.$size.'em',
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class'     => 'maxima-string',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/textarea/textarea.class.php
+++ b/stack/input/textarea/textarea.class.php
@@ -45,6 +45,7 @@ class stack_textarea_input extends stack_input {
             'id'   => $fieldname,
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class'     => 'maxima-list',
         );
 
         if ($this->is_blank_response($state->contents)) {

--- a/stack/input/units/units.class.php
+++ b/stack/input/units/units.class.php
@@ -62,6 +62,7 @@ class stack_units_input extends stack_input {
             'style' => 'width: '.$size.'em',
             'autocapitalize' => 'none',
             'spellcheck'     => 'false',
+            'class'     => 'algebraic-units',
         );
 
         if ($state->contents == 'EMPTYANSWER') {

--- a/styles.css
+++ b/styles.css
@@ -301,3 +301,29 @@ body.ie:not(.ie11) .stack_abstract_graph {
     right: -16px;
     cursor: pointer;
 }
+
+/* RTL support */
+
+/* Student answer form fields */
+.que.stack .algebraic,
+.que.stack .algebraic-units,
+.que.stack .numerical,
+.que.stack .maxima-string,
+.que.stack .maxima-list,
+.que.stack .equiv,
+/* Question authoring form */
+#page-question-type-stack textarea#id_questionvariables,
+#page-question-type-stack input#id_variantsselectionseed,
+#page-question-type-stack #id_questionnote,
+#page-question-type-stack #id_prt1feedbackvariables,
+#page-question-type-stack input#id_ans1modelans,
+#page-question-type-stack input#id_ans1allowwords,
+#page-question-type-stack input#id_ans1options {
+    display: inline-block;
+    /*rtl:ignore*/
+    direction: ltr;
+}
+/* Properly display inversetrig values, in RTL mode */
+#page-question-type-stack #id_inversetrig option {
+    unicode-bidi: plaintext;
+}


### PR DESCRIPTION
Suggested fix for RTL mode, in which all math formulas need to be input in LTR mode (text directionality)