### PR TITLE
Fix Behat fails caused by the MDL-66821 edit menu changes

### DIFF
--- a/tests/behat/create_preview_edit.feature
+++ b/tests/behat/create_preview_edit.feature
@@ -32,7 +32,7 @@ Feature: Create, preview, test, tidy and edit STACK questions
     Then I should see "Test STACK question"
 
     # Preview it.
-    When I click on "Preview" "link" in the "Test STACK question" "table_row"
+    When I choose "Preview" action for "Test STACK question" in the question bank
     And I switch to "questionpreview" window
     And I set the following fields to these values:
       | How questions behave | Adaptive          |
@@ -87,7 +87,7 @@ Feature: Create, preview, test, tidy and edit STACK questions
     And I switch to the main window
 
     # Edit the question, verify the form field contents, then change some.
-    When I click on "Edit" "link" in the "Test STACK question" "table_row"
+    When I choose "Edit question" action for "Test STACK question" in the question bank
     Then the following fields match these values:
       | Question name      | Test STACK question                                                         |
       | Question variables | p : (x-1)^3;                                                                |

--- a/tests/behat/restore_demo.feature
+++ b/tests/behat/restore_demo.feature
@@ -14,8 +14,8 @@ Feature: Test restoring the STACK demo course
   @javascript
   Scenario: Restore the STACK demo course.
     When I restore "STACK-demo.mbz" backup into a new course using this options:
-    And I am on "Demonstrating STACK" course homepage
-    Then I should see "Demonstration Quiz"
+    And I am on "Demonstrating STACK (v4.3)" course homepage
+    Then I should see "Demonstration quiz"
     And I navigate to "Question bank" in current page administration
     And I set the field "Select a category" to "Example_questions"
     And I should see "Cart speed analysis"

--- a/tests/behat/validation_no_maths_in_question.feature
+++ b/tests/behat/validation_no_maths_in_question.feature
@@ -31,7 +31,7 @@ Feature: STACK input vaidation works even if there is no maths in the question
     Then I should see "Test STACK question"
 
     # Preview it.
-    When I click on "Preview" "link" in the "Test STACK question" "table_row"
+    When I choose "Preview" action for "Test STACK question" in the question bank
     And I switch to "questionpreview" window
     And I set the following fields to these values:
       | How questions behave | Adaptive          |


### PR DESCRIPTION
Chris,

At the point where you start using Moodle 3.8, you will need these changes, or all the Behat tests will start to fail.

And, as soon as you are using 3.7.3 or 3.6.7 for development it will be safe to incorporate these changes, becuase the new steps were put into all Moodle branches with appropirate implementations.

The explantion is here: https://github.com/moodle/moodle/blob/e04a73ccc06e18d8d3b3661f8f9bc16911747830/question/type/upgrade.txt#L5. I am afraid it is all my fault, but a necessary evil.