### PR TITLE
Adding failable PHP 7.2, 7.3 and 7.4 unit test build targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
   postgresql: "9.6"
   apt:
     packages:
-      - oracle-java8-installer
-      - oracle-java8-set-default
+      - openjdk-8-jre-headless
+      - chromium-chromedriver
       - maxima
       - maxima-share
       - texinfo
@@ -29,6 +29,18 @@ matrix:
 
     - php: 7.0
       env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_32_STABLE   DB=pgsql
+    
+    - php: 7.1
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_32_STABLE   DB=pgsql
+
+    - php: 7.2
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_36_STABLE   DB=pgsql
+    
+    - php: 7.3
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_36_STABLE   DB=pgsql
+    
+    - php: 7.4
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_38_STABLE   DB=pgsql
 
     - php: 5.6
       env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_33_STABLE   DB=mysqli
@@ -66,7 +78,7 @@ matrix:
 
     # Master here will need to be changed to MOODLE_36_STABLE once Moodle 3.7 has been released.
     - php: 7.1
-      env: TASK=BEHAT          MOODLE_BRANCH=master             DB=pgsql
+      env: TASK=BEHAT          MOODLE_BRANCH=MOODLE_36_STABLE   DB=pgsql
 
 
     - php: 7.1
@@ -80,13 +92,24 @@ matrix:
     # We don't care if these checks fail, but we want to be able to see the results.
     - php: 7.1
       env: TASK=CODEKNOWNFAILS MOODLE_BRANCH=MOODLE_35_STABLE   DB=mysqli
+    # STACK doesn't yet support PHP >= 7.2 (see above).
+    # These are here to help identify unit tests.
+    - php: 7.2
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_36_STABLE   DB=pgsql
+    - php: 7.3
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_36_STABLE   DB=pgsql
+    # 3.8 is going to provide support for PHP 7.4. At this time support isn't quite there.
+    # Reference: https://tracker.moodle.org/browse/MDL-66260
+    # This should start to succeed as support comes for 7.4.
+    - php: 7.4
+      env: TASK=PHPUNIT        MOODLE_BRANCH=MOODLE_38_STABLE   DB=pgsql
 
 before_install:
   - phpenv config-rm xdebug.ini
   - nvm install 8.9
   - nvm use 8.9
   - cd ../..
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
+  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:


### PR DESCRIPTION
Hello,

A small one solving:

1. PHP 7.2, 7.3 and 7.4 build targets for unit test runs. All of them are allowed failures.
2. [moodlerooms/moodle-plugin-ci is now abandoned](https://packagist.org/packages/moodlerooms/moodle-plugin-ci). Replaced with [blackboard-open-source/moodle-plugin-ci](https://packagist.org/packages/blackboard-open-source/moodle-plugin-ci) as recommended.
3. apt-get dependencies that aren't available in travis. Dependency list now matches [stack/4.3a](https://github.com/maths/moodle-qtype_stack/blob/stack4.3A/.travis.yml#L13).
4. Running Behat tests with moodle 3.6 as 3.7 has been released.

Should MOODLE_BRANCH=master be "MOODLE_BRANCH=MOODLE_37_STABLE" now that moodle 3.8 is out?

Kind Regards,
Will