### PR TITLE
Quote HTML entities in alt attribute.

### DIFF
--- a/stack/maxima/stackmaxima.mac
+++ b/stack/maxima/stackmaxima.mac
@@ -929,7 +929,7 @@ plot(ex, [ra]) :=  /*stack_web_plot*/
     afn: concat("'", IMAGE_DIR, filename, ".", PLOT_TERMINAL, "'"),
     if PLOT_TERMINAL="svg" then
         afn: concat(IMAGE_DIR, filename, ".", PLOT_TERMINAL),
-    ufn: concat("<img src='", URL_BASE, filename, ".", PLOT_TERMINAL, "' alt='", alttext, "' width='", string(plot_size[1]), "' />"),
+    ufn: concat("<img src='", URL_BASE, filename, ".", PLOT_TERMINAL, "' alt='", str_to_html(alttext), "' width='", string(plot_size[1]), "' />"),
     if plot_tags then
         ufn: concat("<div class='stack_plot'>", ufn, "</div>"),
     ufn: concat(" <html>", ufn, "</html> "),


### PR DESCRIPTION
When plotting an expression containing greater than and less than symbols, the generated HTML output is malformed, and part of the alt text of the img tag is displayed below the plot in the browser.