### PR TITLE
Refactor calls to ssubst

### DIFF
--- a/stack/maxima/stackstrings.mac
+++ b/stack/maxima/stackstrings.mac
@@ -197,22 +197,17 @@ stack_string_parse_number(somestring) := block([c, b, phase, neg,nege, tmp, i],
  return(c)
 )$
 
-
 /* Takes pretty much anything and turns it to a JSON string */
-stackjson_stringify(obj) := block([tmp,r,l],
+stackjson_stringify(obj) := block([tmp,r,l,f],
  r:und,
+ f(c) := if c = "\\" then "\\\\" else if c = "\"" then "\\\"" else if c = ascii(8) then "\\b" 
+    else if c = ascii(9) then "\\t" else if c = ascii(10) then "\\n" else if c = ascii(12) then "\\f" 
+    else if c = ascii(13) then "\\r" else c,
  if is(obj=und) then r:"null"
  else if is(obj=false) then r:"false"
  else if is(obj=true) then r:"true"
  else if stringp(obj) then (
-  tmp:ssubst("\\\\","\\",obj),
-  tmp:ssubst("\\\"","\"",tmp),
-  tmp:ssubst("\\b",ascii(8),tmp),
-  tmp:ssubst("\\t",ascii(9),tmp),
-  tmp:ssubst("\\n",ascii(10),tmp),
-  tmp:ssubst("\\f",ascii(12),tmp),
-  tmp:ssubst("\\r",ascii(13),tmp),
-  r:sconcat("\"",tmp,"\"")
+  r : sconcat("\"",simplode(map(f,charlist(obj))),"\"")
  ) else if is_stackmap(obj) then (
   l:[],
   for tmp in stackmap_keys(obj) do l:append(l,[sconcat(stackjson_stringify(tmp),":",stackjson_stringify(stackmap_get(obj,tmp)))]), 

--- a/stack/maxima/utils.mac
+++ b/stack/maxima/utils.mac
@@ -2,26 +2,19 @@
 
 /* Takes a Maxima string and converts everything that could cause trouble in a HTML/XML document to entities.
    Note that if the string already contains entities even them are converted and thus broken. */
-str_to_html(string_to_escape) := block([tmp],
-    tmp: ssubst("&amp;", "&", string_to_escape),
-    tmp: ssubst("&#39;", "'", tmp), /* &apos; is for XHTML, we need to still deal with HTML. */
-    tmp: ssubst("&quot;", "\"", tmp),
-    tmp: ssubst("&gt;", ">", tmp),
-    tmp: ssubst("&lt;", "<", tmp),
-    return(tmp)
+str_to_html(string_to_escape) := block([f,tmp],
+    f(c) := if c = "&" then "&amp;" else if c = "'" then "&#39;" else if c = "\"" then "&quot;" 
+       else if c = ">" then "&gt;" else if c = "<" then "&lt;" else c,
+    return(simplode(map(f,charlist(string_to_escape))))
 )$
 
 /* Same for generating ECMAScript strings. */
-str_to_js(string_to_escape) := block([tmp,lines],
-    tmp: ssubst("\\\\", "\\", string_to_escape),
-    tmp: ssubst("\\\"", "\"", tmp),
-    tmp: ssubst("\\'", "'", tmp),
-    tmp: ssubst("\\b", ascii(8), tmp),
-    tmp: ssubst("\\t", ascii(9), tmp),
-    tmp: ssubst("\\n", ascii(10), tmp),
-    tmp: ssubst("\\v", ascii(11), tmp),
-    tmp: ssubst("\\r", ascii(13), tmp), /* \b\t\v\r might as well set to "" but maybe someone uses them to do magic. */
-    return(tmp)
+str_to_js(string_to_escape) := block([f],
+    f(c) := if c = "\\" then "\\\\" else if c = "\"" then "\\\"" else if c = "'" then "\\'" 
+       else if c = ascii( 8) then "\\b" else if c = ascii( 9) then "\\t" 
+       else if c = ascii(10) then "\\n" else if c = ascii(12) then "\\f" 
+       else if c = ascii(13) then "\\r" else c,
+    return(simplode(map(f,charlist(string_to_escape))))
 )$
 
 /* Split a Maxima timestamp (seconds from Jan 1 1900) to numbers representing a date.


### PR DESCRIPTION
This fixes https://github.com/maths/moodle-qtype_stack/issues/674.  The function `ssubst(a,b,s)` generates an error if there are too many instances of `b` in `s`; this is a bug in Maxima (in some versions on some platforms, at least).  This comes into play if we have complex questions that generate generate LaTeX strings with many backslashes, for example.  So we change the functions `stackjson_stringify`, `str_to_html` and `str_to_js` to use `charlist` and `simplode` rather than `ssubst`.