### PR TITLE
Fix table in Potential_response_trees.md

### DIFF
--- a/doc/en/Authoring/Potential_response_trees.md
+++ b/doc/en/Authoring/Potential_response_trees.md
@@ -100,7 +100,7 @@ The `[Generic feedback]` is a question level option, e.g. "Standard feedback for
 How PRT feedback is displayed is controlled by the PRT option `feedbackstyle` as follows.  Note the Generic feedback might include the symbol, if you retain the default.
 
 Value | Options      | Symbol | Generic feedback | Errors | PRT feedback | Score ? 
----------------------|--------|------------------|--------|--------------|------------------------------------------
+------|--------------|--------|------------------|--------|--------------|------------------------------------------
   0   | Formative    |  No    |  No              |  Yes   |  Yes         | No (PRT does not contribute to score)
   1   | Standard     |  No    |  Yes             |  Yes   |  Yes         | Respects quiz setting
   2   | Compact      |  Yes   |  No              |  Yes   |  Yes         | No


### PR DESCRIPTION
There was a missing `|` in table, making the rendering of table fail.