### PR TITLE
Updates custom overrides of mkdocs-material files

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -13,6 +13,6 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: pip install https://github.com/mitya57/python-markdown-math/archive/master.zip
-      - run: pip install pip install mkdocs-exclude
+      - run: pip install mkdocs-exclude
       - run: pip install mkdocs-redirects
       - run: mkdocs gh-deploy --force

--- a/doc/en/Developer/Website.md
+++ b/doc/en/Developer/Website.md
@@ -53,7 +53,7 @@ You can also edit the theme directly. Any file in the `site_overrides` folder wi
 Before adding major style changes to the online docs, you are encouraged to test your changes locally. For this, you will need to install MkDocs and all the required extensions.
 
 1. [Install MkDocs](https://www.mkdocs.org/), including its requirements.
-2. Install Bootstrap with `pip install mkdocs-bootstrap`
+2. Install Material with `pip install mkdocs-material`
 3. Install the markdown extension with `pip install https://github.com/mitya57/python-markdown-math/archive/master.zip`
 4. Install the exclude plugin with `pip install mkdocs-exclude`
 5. Install the redirect plugin with `pip install mkdocs-redirects`

--- a/site_overrides/main.html
+++ b/site_overrides/main.html
@@ -15,35 +15,28 @@
 <!--Override basic header-->
 {% block header %}
 <header class="md-header" data-md-component="header">
-  <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
-    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }}"
-    class="md-header-nav__button md-logo" style="width:1.7rem;" aria-label="{{ config.site_name }}">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header.title') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" 
+	class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
     </a>
-    <label class="md-header-nav__button md-icon" for="__drawer">
+    <label class="md-header__button md-icon" for="__drawer">
       {% include ".icons/material/menu" ~ ".svg" %}
     </label>
     <!--Make site title permament-->
-    <div class="md-header-nav__title" data-md-component="header-title">
-      <div class="md-header-nav__ellipsis md-ellipsis">
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis md-header__topic md-ellipsis">
         {{ config.site_name }}
       </div>
     </div>
-    {% if "search" in config["plugins"] %}
-      <label class="md-header-nav__button md-icon" for="__search">
+     {% if "search" in config["plugins"] %}
+      <label class="md-header__button md-icon" for="__search">
         {% include ".icons/material/magnify.svg" %}
       </label>
       {% include "partials/search.html" %}
     {% endif %}
-    {% if config.repo_url %}
-      <div class="md-header-nav__source">
-        {% include "partials/source.html" %}
-      </div>
-    {% endif %}
   </nav>
-  
 </header>
-
 {% endblock %}
 
 <!--Override basic footer-->

--- a/site_overrides/partials/nav-item.html
+++ b/site_overrides/partials/nav-item.html
@@ -1,76 +1,74 @@
-{#-
-  This file was automatically generated - do not edit
--#}
-{% set class = "md-nav__item" %}
-{% if nav_item.active %}
-  {% set class = "md-nav__item md-nav__item--active" %}
-{% endif %}
+{% macro render(nav_item, path, level) %}
+  {% set class = "md-nav__item" %}
+  {% if nav_item.active %}
+    {% set class = class ~ " md-nav__item--active" %}
+  {% endif %}
 
 <!--Skip first level in the navigation bar, i.e. the "En" level-->
-{%if nav_item.title == "En"%}
-        {% set base = path %}
-        {% for nav_item in nav_item.children %}
-          {% set path = base + "-" + loop.index | string %}
-          {% set level = level + 1 %}
-          {% include "partials/nav-item.html"  %}
-        {% endfor %}
+  {%if nav_item.title == "En"%}
+    {% set base = path %}
+    {% for nav_item in nav_item.children %}
+      {% set path = base + "-" + loop.index | string %}
+      {% set level = level + 1 %}
+      {% include "partials/nav-item.html"  %}
+    {% endfor %}
 <!--Keep the rest the same-->
-{% elif nav_item.children %}
-  <li class="{{ class }} md-nav__item--nested">
-    {% if nav_item.active %}
-      <input class="md-nav__toggle md-toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}" checked>
-    {% else %}
-      <input class="md-nav__toggle md-toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}">
+  {% elif nav_item.children %}
+    {% if "navigation.sections" in features and level == 1 + (
+      "navigation.tabs" in features
+    ) %}
+      {% set class = class ~ " md-nav__item--section" %}
     {% endif %}
-    <label class="md-nav__link" for="{{ path }}">
-      {{ nav_item.title }}
-      <span class="md-nav__icon md-icon">
-        {% include ".icons/material/chevron-right.svg" %}
-      </span>
-    </label>
-    <nav class="md-nav" aria-label="{{ nav_item.title }}" data-md-level="{{ level }}">
-      <label class="md-nav__title" for="{{ path }}">
-        <span class="md-nav__icon md-icon">
-          {% include ".icons/material/arrow-left.svg" %}
-        </span>
+    <li class="{{ class }} md-nav__item--nested">
+      {% set checked = "checked" if nav_item.active %}
+      {% if "navigation.expand" in features and not checked %}
+        <input class="md-nav__toggle md-toggle" data-md-toggle="{{ path }}" data-md-state="indeterminate" type="checkbox" id="{{ path }}" checked>
+      {% else %}
+        <input class="md-nav__toggle md-toggle" data-md-toggle="{{ path }}" type="checkbox" id="{{ path }}" {{ checked }}>
+      {% endif %}
+      <label class="md-nav__link" for="{{ path }}">
         {{ nav_item.title }}
+        <span class="md-nav__icon md-icon"></span>
       </label>
-      <ul class="md-nav__list" data-md-scrollfix>
-        {% set base = path %}
-        {% for nav_item in nav_item.children %}
-          {% set path = base + "-" + loop.index | string %}
-          {% set level = level + 1 %}
-          {% include "partials/nav-item.html"  %}
-        {% endfor %}
-      </ul>
-    </nav>
-  </li>
-{% elif nav_item == page %}
-  <li class="{{ class }}">
-    {% set toc = page.toc %}
-    <input class="md-nav__toggle md-toggle" data-md-toggle="toc" type="checkbox" id="__toc">
-    {% if toc | first is defined and "\x3ch1 id=" in page.content %}
-      {% set toc = (toc | first).children %}
-    {% endif %}
-    {% if toc | first is defined %}
-      <label class="md-nav__link md-nav__link--active" for="__toc">
+      <nav class="md-nav" aria-label="{{ nav_item.title }}" data-md-level="{{ level }}">
+        <label class="md-nav__title" for="{{ path }}">
+          <span class="md-nav__icon md-icon"></span>
+          {{ nav_item.title }}
+        </label>
+        <ul class="md-nav__list" data-md-scrollfix>
+          {% for nav_item in nav_item.children %}
+            {{ render(nav_item, path ~ "_" ~ loop.index, level + 1) }}
+          {% endfor %}
+        </ul>
+      </nav>
+    </li>
+  {% elif nav_item == page %}
+    <li class="{{ class }}">
+      {% set toc = page.toc %}
+      <input class="md-nav__toggle md-toggle" data-md-toggle="toc" type="checkbox" id="__toc">
+      {% set first = toc | first %}
+      {% if first and first.level == 1 %}
+        {% set toc = first.children %}
+      {% endif %}
+      {% if toc %}
+        <label class="md-nav__link md-nav__link--active" for="__toc">
+          {{ nav_item.title }}
+          <span class="md-nav__icon md-icon"></span>
+        </label>
+      {% endif %}
+      <a href="{{ nav_item.url | url }}" class="md-nav__link md-nav__link--active">
         {{ nav_item.title }}
-        <span class="md-nav__icon md-icon">
-          {% include ".icons/material/table-of-contents.svg" %}
-        </span>
-      </label>
-    {% endif %}
-    <a href="{{ nav_item.url | url }}" title="{{ nav_item.title | striptags }}" class="md-nav__link md-nav__link--active">
-      {{ nav_item.title }}
-    </a>
-    {% if toc | first is defined %}
-      {% include "partials/toc.html" %}
-    {% endif %}
-  </li>
-{% else %}
-  <li class="{{ class }}">
-    <a href="{{ nav_item.url | url }}" title="{{ nav_item.title | striptags }}" class="md-nav__link">
-      {{ nav_item.title }}
-    </a>
-  </li>
-{% endif %}
+      </a>
+      {% if toc %}
+        {% include "partials/toc.html" %}
+      {% endif %}
+    </li>
+  {% else %}
+    <li class="{{ class }}">
+      <a href="{{ nav_item.url | url }}" class="md-nav__link">
+        {{ nav_item.title }}
+      </a>
+    </li>
+  {% endif %}
+{% endmacro %}
+{{ render(nav_item, path, level) }}


### PR DESCRIPTION
This fixes the style issue with the online docs identified by @shinuito in maths/moodle-qtype_stack#713. One of the updates to mkdocs-material had, among other things, changed the names of some of its css styles. Because our implementation includes custom overrides of some of the material files, the website would not work until we referred to the new style names locally.