### PR TITLE
Answer_tests.md (SRegExp): testing for equality

### DIFF
--- a/doc/en/Authoring/Answer_tests.md
+++ b/doc/en/Authoring/Answer_tests.md
@@ -163,6 +163,7 @@ These answer tests are used with [equivalence reasoning](../CAS/Equivalence_reas
 
 This test uses Maxima's `regex_match` function.
 
+* It yields true if the pattern is matched anywhere within the student answer and false otherwise. Testing for full equality of the answer string can be achieved via regex anchoring by use of `^` or `$`.
 * Both arguments to the test must be Maxima strings.  If you have a general expression, turn it into a string in the feedback variables with Maxima's `string` function.
 * The first argument should be the string, and the second argument should be the pattern to match.
 * Don't forget to escape within the pattern strings as needed. Note that there is a function `string_to_regex()` that will handle escaping of characters that would otherwise have meaning in the pattern. Also remember that you need to escape the backslashes like normal in Maxima-strings.


### PR DESCRIPTION
Add note about using anchors in regular expressions in order to test against full equality as opposed to (sub-)pattern matching.