### PR TITLE
Create Graphics.md

### DIFF
--- a/doc/en/CAS/Graphics.md
+++ b/doc/en/CAS/Graphics.md
@@ -1,0 +1,13 @@
+# Graphics in STACK questions
+
+Graphics (which can be produced to be dependent on Question Variables) can be placed into any of the [CASText](./Authoring/CASText.md) fields.
+There are several different ways in which graphics can be generated. These include the following.
+
+* Including an image file, using the HTML `<img>` tag.
+* [Using the STACK `plot`command, which is a wrapper to the Maxima `plot2d` command.](CAS/Plots.md)
+* Using SVG commands.
+* Using jsXgraph commands. 
+
+Remember that when including a graphic in a question, to ensure the question is accessible to, for example, screen-reader users, authors should always include an appropriate figure description/alt-text.
+
+


### PR DESCRIPTION
A new "graphics" landing page.
Should this be in en/Authoring rather than en/CAS?  Plots.md is in en/CAS, but JSXGraph.md is in en/Authoring.