### PR TITLE
Make unit tests compatible with PHPUnit 9.5 - not yet fully working

### DIFF
--- a/tests/cassession2_test.php
+++ b/tests/cassession2_test.php
@@ -853,7 +853,7 @@ class stack_cas_session2_test extends qtype_stack_testcase {
         $at1 = new stack_cas_session2($s1, null, 0);
         $at1->instantiate();
         $this->assertEquals('0', $s1[0]->get_value());
-        $this->assertRegExp('/Division by (zero|0)/', trim($s1[1]->get_errors()));
+        $this->assertMatchesRegularExpression('/Division by (zero|0)/', trim($s1[1]->get_errors()));
         $this->assertFalse(strpos($s1[1]->get_value(), 'STACK auto-generated plot of 0 with parameters'));
     }
 

--- a/tests/fixtures/ast_filter_test_base.php
+++ b/tests/fixtures/ast_filter_test_base.php
@@ -128,4 +128,140 @@ abstract class qtype_stack_ast_testcase extends basic_testcase {
 
         $this->assertFalse($hasinvalid);
     }
+
+    /**
+     * Asserts that an array has a specified subset.
+     *
+     * This assert used to be provided by PHPUnit but they removed it
+     * without replacement. Therefore, we have a copy of it here.
+     *
+     * @param array|ArrayAccess $subset
+     * @param array|ArrayAccess $array
+     *
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws Exception
+     */
+    public function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
+    {
+        if (!(is_array($subset) || $subset instanceof ArrayAccess)) {
+            throw \PHPUnit\Framework\InvalidArgumentException::create(
+                1,
+                'array or ArrayAccess'
+            );
+        }
+        if (!(is_array($array) || $array instanceof ArrayAccess)) {
+            throw \PHPUnit\Framework\InvalidArgumentException::create(
+                2,
+                'array or ArrayAccess'
+            );
+        }
+        $constraint = new ArraySubset($subset, $checkForObjectIdentity);
+        \PHPUnit\Framework\Assert::assertThat($array, $constraint, $message);
+    }
+}
+
+
+/**
+ * Constraint that asserts that the array it is evaluated for has a specified subset.
+ *
+ * Uses array_replace_recursive() to check if a key value subset is part of the
+ * subject array.
+ *
+ * PHPUnit removed this, but we need it, so adding it back here.
+ */
+final class ArraySubset extends PHPUnit\Framework\Constraint\Constraint {
+    /**
+     * @var iterable
+     */
+    private $subset;
+
+    /**
+     * @var bool
+     */
+    private $strict;
+
+    public function __construct(iterable $subset, bool $strict = false) {
+        $this->strict = $strict;
+        $this->subset = $subset;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool {
+        //type cast $other & $this->subset as an array to allow
+        //support in standard array functions.
+        $other = $this->toArray($other);
+        $this->subset = $this->toArray($this->subset);
+        $patched = array_replace_recursive($other, $this->subset);
+        if ($this->strict) {
+            $result = $other === $patched;
+        } else {
+            $result = $other == $patched;
+        }
+        if ($returnResult) {
+            return $result;
+        }
+        if (!$result) {
+            $f = new \SebastianBergmann\Comparator\ComparisonFailure(
+                    $patched,
+                    $other,
+                    var_export($patched, true),
+                    var_export($other, true)
+            );
+            $this->fail($other, $description, $f);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function toString(): string
+    {
+        return 'has the subset ' . $this->exporter()->export($this->subset);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+
+    private function toArray(iterable $other): array
+    {
+        if (is_array($other)) {
+            return $other;
+        }
+        if ($other instanceof ArrayObject) {
+            return $other->getArrayCopy();
+        }
+        if ($other instanceof Traversable) {
+            return iterator_to_array($other);
+        }
+        // Keep BC even if we know that array would not be the expected one
+        return (array) $other;
+    }
 }

--- a/tests/fixtures/test_base.php
+++ b/tests/fixtures/test_base.php
@@ -46,7 +46,7 @@ abstract class qtype_stack_testcase extends advanced_testcase {
      */
     protected $lisp = 'SBCL';
 
-    public function setUp() :void {
+    public function setUp(): void {
         parent::setUp();
 
         stack_utils::clear_config_cache();
@@ -219,7 +219,7 @@ abstract class qtype_stack_testcase extends advanced_testcase {
 abstract class qtype_stack_walkthrough_test_base extends qbehaviour_walkthrough_test_base {
     protected $currentoutput = null;
 
-    public function setUp() :void {
+    public function setUp(): void {
         parent::setUp();
         qtype_stack_testcase::setup_test_maxima_connection($this);
         $this->resetAfterTest();
@@ -318,7 +318,7 @@ abstract class qtype_stack_walkthrough_test_base extends qbehaviour_walkthrough_
                 $this->currentoutput);
 
         if ($content) {
-            $this->assertRegExp('/' . preg_quote(s($content), '/') . '/', $this->currentoutput);
+            $this->assertMatchesRegularExpression('/' . preg_quote(s($content), '/') . '/', $this->currentoutput);
         }
 
         if ($enabled) {
@@ -331,22 +331,22 @@ abstract class qtype_stack_walkthrough_test_base extends qbehaviour_walkthrough_
 
     protected function check_output_contains_input_validation($name) {
         $id = $this->quba->get_question_attempt($this->slot)->get_qt_field_name($name . '_val');
-        $this->assertRegExp('~<div (?=[^>]*\bclass="stackinputfeedback standard")(?=[^>]*\bid="' . $id . '")~',
+        $this->assertMatchesRegularExpression('~<div (?=[^>]*\bclass="stackinputfeedback standard")(?=[^>]*\bid="' . $id . '")~',
                 $this->currentoutput,
                 'Input validation for ' . $name . ' not found in ' . $this->currentoutput);
     }
 
     protected function check_output_contains_input_validation_compact($name) {
         $id = $this->quba->get_question_attempt($this->slot)->get_qt_field_name($name . '_val');
-        $this->assertRegExp('~<span (?=[^>]*\bclass="stackinputfeedback compact")(?=[^>]*\bid="' . $id . '")~',
+        $this->assertMatchesRegularExpression('~<span (?=[^>]*\bclass="stackinputfeedback compact")(?=[^>]*\bid="' . $id . '")~',
                 $this->currentoutput,
                 'Input validation for ' . $name . ' not found in ' . $this->currentoutput);
     }
 
     protected function check_output_does_not_contain_any_input_validation() {
-        $this->assertNotRegExp('~<div [^>]*\bclass="stackinputfeedback standard(?:(?! empty)[^"])*"~',
+        $this->assertDoesNotMatchRegularExpression('~<div [^>]*\bclass="stackinputfeedback standard(?:(?! empty)[^"])*"~',
                 $this->currentoutput, 'Input validation should not be present in ' . $this->currentoutput);
-        $this->assertNotRegExp('~<div [^>]*\bclass="stackinputfeedback compact(?:(?! empty)[^"])*"~',
+        $this->assertDoesNotMatchRegularExpression('~<div [^>]*\bclass="stackinputfeedback compact(?:(?! empty)[^"])*"~',
                 $this->currentoutput, 'Input validation should not be present in ' . $this->currentoutput);
     }
 
@@ -356,7 +356,7 @@ abstract class qtype_stack_walkthrough_test_base extends qbehaviour_walkthrough_
             return;
         }
         $id = $this->quba->get_question_attempt($this->slot)->get_qt_field_name($name . '_val');
-        $this->assertNotRegExp('~<div (?=[^>]*\bclass="stackinputfeedback standard")(?=[^>]*\bid="' . $id . '")~',
+        $this->assertDoesNotMatchRegularExpression('~<div (?=[^>]*\bclass="stackinputfeedback standard")(?=[^>]*\bid="' . $id . '")~',
                 $this->currentoutput,
                 'Input validation for ' . $name . ' should not be present in ' . $this->currentoutput);
     }
@@ -380,7 +380,7 @@ abstract class qtype_stack_walkthrough_test_base extends qbehaviour_walkthrough_
     }
 
     protected function check_output_does_not_contain_stray_placeholders() {
-        $this->assertNotRegExp('~\[\[|\]\]~', $this->currentoutput, 'Not all placehoders were replaced.');
+        $this->assertDoesNotMatchRegularExpression('~\[\[|\]\]~', $this->currentoutput, 'Not all placehoders were replaced.');
     }
 
     protected function check_output_contains_lang_string($identifier, $component = '', $a = null) {

--- a/tests/mathsoutputmaths_test.php
+++ b/tests/mathsoutputmaths_test.php
@@ -49,15 +49,15 @@ class stack_maths_maths_test extends advanced_testcase {
         filter_set_global_state('mathjaxloader', TEXTFILTER_DISABLED);
 
         // Test language string.
-        $this->assertRegExp('~^Your answer needs to be a single fraction of the form <a .*alt="a over b".*</a>\. $~',
+        $this->assertMatchesRegularExpression('~^Your answer needs to be a single fraction of the form <a .*alt="a over b".*</a>\. $~',
                 stack_string('ATSingleFrac_part'));
 
         // Test docs - make sure maths inside <code> is not rendered.
-        $this->assertRegExp('~^<p><code>\\\\\(x\^2\\\\\)</code> gives <a .*alt="x squared".*</a>\.</p>\n$~',
+        $this->assertMatchesRegularExpression('~^<p><code>\\\\\(x\^2\\\\\)</code> gives <a .*alt="x squared".*</a>\.</p>\n$~',
                 stack_docs_render_markdown('<code>\(x^2\)</code> gives \(x^2\).'));
 
         // Test docs - make sure maths inside <textarea> is not rendered.
-        $this->assertRegExp('~^<p><textarea readonly="readonly" rows="3" cols="50">\n' .
+        $this->assertMatchesRegularExpression('~^<p><textarea readonly="readonly" rows="3" cols="50">\n' .
                         'Differentiate \\\\\[x\^2 \+ y\^2\\\\\] with respect to \\\\\(x\\\\\).</textarea></p>\n$~',
                 stack_docs_render_markdown('<textarea readonly="readonly" rows="3" cols="50">' . "\n" .
                         'Differentiate \[x^2 + y^2\] with respect to \(x\).</textarea>'));

--- a/tests/mathsoutputtex_test.php
+++ b/tests/mathsoutputtex_test.php
@@ -38,12 +38,12 @@ class stack_maths_tex_test extends advanced_testcase {
         // Test language string.
         // The <span class="MathJax_Preview"> bit is something that got added in
         // Moodle 2.8, so match it optionally.
-        $this->assertRegExp('~^Your answer needs to be a single fraction of the form ' .
+        $this->assertMatchesRegularExpression('~^Your answer needs to be a single fraction of the form ' .
                 '(<span class="MathJax_Preview">)?<a .*alt=" \{a\}\\\\over\{b\} ".*</(a|script)> \. ~',
                 stack_string('ATSingleFrac_part'));
 
         // Test docs - make sure maths inside <code> is not rendered.
-        $this->assertRegExp('~^<p><code>\\\\\(x\^2\\\\\)</code> gives (<span class="MathJax_Preview">)?'
+        $this->assertMatchesRegularExpression('~^<p><code>\\\\\(x\^2\\\\\)</code> gives (<span class="MathJax_Preview">)?'
                 .'<a .*alt="x\^2".*</(a|script)> \.</p>\n$~',
                 stack_docs_render_markdown('<code>\(x^2\)</code> gives \(x^2\).'));
 

--- a/tests/potentialresponsenode_test.php
+++ b/tests/potentialresponsenode_test.php
@@ -101,7 +101,7 @@ class stack_potentialresponse_node_test extends qtype_stack_testcase {
         $this->assertEquals(false, $result->valid);
         $this->assertNotEquals('', $result->errors);
         $this->assertEquals(2, count($result->feedback));
-        $this->assertRegExp('~The answer test failed to execute correctly: ' .
+        $this->assertMatchesRegularExpression('~The answer test failed to execute correctly: ' .
                 'please alert your teacher. Division by (zero\.|0)~',
                 $result->feedback[0]->feedback);
         $this->assertEquals('Boo!', $result->feedback[1]->feedback);

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -36,12 +36,12 @@ class qtype_stack_test extends qtype_stack_walkthrough_test_base {
     /** @var qtype_stack */
     private $qtype;
 
-    public function setUp() :void {
+    public function setUp(): void {
         parent::setUp();
         $this->qtype = new qtype_stack();
     }
 
-    public function tearDown() :void {
+    public function tearDown(): void {
         $this->qtype = null;
         parent::tearDown();
     }

--- a/tests/stack_options_test.php
+++ b/tests/stack_options_test.php
@@ -48,12 +48,14 @@ class stack_options_set_exception_test extends basic_testcase {
     }
 
     public function test_set_exception_4() {
+        $this->expectException('stack_exception');
         $opts = new stack_options();
         $this->expectException(stack_exception::class);
         $opts->set_option('display', false);
     }
 
     public function test_set_exception_5() {
+        $this->expectException('stack_exception');
         $opts = new stack_options();
         $this->expectException(stack_exception::class);
         $opts->set_option('display', 'latex');

--- a/tests/walkthrough_adaptive_test.php
+++ b/tests/walkthrough_adaptive_test.php
@@ -2235,7 +2235,7 @@ class qtype_stack_walkthrough_adaptive_test extends qtype_stack_walkthrough_test
         $this->check_output_contains_prt_feedback('prt1');
         $this->check_output_contains_prt_feedback('prt2');
         $this->check_output_does_not_contain_stray_placeholders();
-        $this->assertRegExp('~' . preg_quote($q->prtcorrect, '~') . '~', $this->currentoutput);
+        $this->assertMatchesRegularExpression('~' . preg_quote($q->prtcorrect, '~') . '~', $this->currentoutput);
         $this->check_current_output(
                 $this->get_does_not_contain_num_parts_correct(),
                 $this->get_no_hint_visible_expectation()

--- a/tests/walkthrough_deferred_feedback_test.php
+++ b/tests/walkthrough_deferred_feedback_test.php
@@ -549,7 +549,7 @@ class qtype_stack_walkthrough_deferred_feedback_test extends qtype_stack_walkthr
         $this->check_output_contains_input_validation('ans1');
         $this->check_output_contains_prt_feedback(); // Since there is no feedback for right.
         $this->check_output_does_not_contain_stray_placeholders();
-        $this->assertRegExp('~' . preg_quote($q->prtcorrect, '~') . '~', $this->currentoutput);
+        $this->assertMatchesRegularExpression('~' . preg_quote($q->prtcorrect, '~') . '~', $this->currentoutput);
         $this->check_current_output(
                 $this->get_does_not_contain_num_parts_correct(),
                 $this->get_no_hint_visible_expectation()
@@ -574,9 +574,9 @@ class qtype_stack_walkthrough_deferred_feedback_test extends qtype_stack_walkthr
 
         // Check how the image is rendered.
         $this->render();
-        $this->assertNotRegExp('~PLUGINFILE~', $this->currentoutput,
+        $this->assertDoesNotMatchRegularExpression('~PLUGINFILE~', $this->currentoutput,
                 'Embedded image not displayed correctly in ' . $this->currentoutput);
-        $this->assertRegExp('~' . preg_quote($CFG->wwwroot) . '/pluginfile.php/~', $this->currentoutput,
+        $this->assertMatchesRegularExpression('~' . preg_quote($CFG->wwwroot) . '/pluginfile.php/~', $this->currentoutput,
                 'Embedded image not displayed correctly in ' . $this->currentoutput);
     }
 }


### PR DESCRIPTION
We are now using Moodle 3.11, so we need these changes. Hopefully they also work with older Moodle.