### PR TITLE
Set a time limit on CAS connections when using MaximaPool

### DIFF
--- a/adminui/answertests.php
+++ b/adminui/answertests.php
@@ -25,6 +25,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+define('NO_OUTPUT_BUFFERING', true);
+
 require_once(__DIR__.'/../../../../config.php');
 require_once($CFG->dirroot .'/course/lib.php');
 require_once($CFG->libdir . '/questionlib.php');

--- a/adminui/studentinputs.php
+++ b/adminui/studentinputs.php
@@ -21,6 +21,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+define('NO_OUTPUT_BUFFERING', true);
+
 require_once(__DIR__.'/../../../../config.php');
 require_once($CFG->dirroot .'/course/lib.php');
 require_once($CFG->libdir . '/questionlib.php');


### PR DESCRIPTION
I just noticed from our monitoring, than when the MaximaPool server cannot be reached, it just sits there for a long time, much longer than the CAS timeout set in the Admin settings. So, adding this timeout probably helps things work more smoothly when MaximaPool is not working smoothly.