### PR TITLE
Option to skip trying to build maxima-optimised when installing for test

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -77,7 +77,7 @@ function xmldb_qtype_stack_install() {
         set_config('casdebugging', 1, 'qtype_stack');
         set_config('mathsdisplay', 'mathjax', 'qtype_stack');
 
-        if (!defined('QTYPE_STACK_TEST_CONFIG_PLATFORM') || QTYPE_STACK_TEST_CONFIG_PLATFORM !== 'server') {
+        if (!defined('QTYPE_STACK_TEST_CONFIG_PLATFORM') || !in_array(QTYPE_STACK_TEST_CONFIG_PLATFORM, ['server', 'none'])) {
             list($ok, $message) = stack_cas_configuration::create_auto_maxima_image();
             if (!$ok) {
                 throw new coding_exception('maxima_opt_auto creation failed.', $message);

--- a/doc/en/Developer/Unit_tests.md
+++ b/doc/en/Developer/Unit_tests.md
@@ -65,6 +65,16 @@ Commands are
 
 (where folder-name is the folder that you want to contains the report)
 
+If, for some reason, you have the STACK code in your codebase, and you want to run other
+unit tests on a server without Maxima installed, then you will get an error when you
+try to install the PHPunit site. You can avoid that by putting
+
+    define('QTYPE_STACK_TEST_CONFIG_PLATFORM',        'none');
+
+in your config.php file. This will prevent the install from trying to create maxima-optimised.
+It will also cause most of the STACK unit tests to be skipped.
+
+
 ## Stop resetting the dataroot directory.
 
 

--- a/tests/fixtures/test_maxima_configuration.php
+++ b/tests/fixtures/test_maxima_configuration.php
@@ -38,7 +38,7 @@ abstract class qtype_stack_test_config {
         // because auto-optimse worked during install, or
         // settings given in config.php.
         return get_config('qtype_stack', 'platform') !== 'linux' ||
-                defined('QTYPE_STACK_TEST_CONFIG_PLATFORM');
+                (defined('QTYPE_STACK_TEST_CONFIG_PLATFORM') && QTYPE_STACK_TEST_CONFIG_PLATFORM !== 'none');
     }
 
     /**


### PR DESCRIPTION
We were getting a problem with fatal errors on our CI server when trying to install Moodle including the STACK code on a system without Maxima.

This provides a way for people to avoid those fatal errors. It would help us if you are prepared to merge this. Thanks.