### PR TITLE
change param-order and return type

### DIFF
--- a/stack/cas/castext2/block.interface.php
+++ b/stack/cas/castext2/block.interface.php
@@ -96,7 +96,7 @@ abstract class stack_cas_castext2_block {
      * list of PRTs. What it contains in use case specific. One can typically assume
      * that it contaisn the same values as the simillar aray for `compile`.
      */
-    public function validate(&$errors = [], array $options): bool {
+    public function validate(array $options, &$errors = []): bool {
         return true;
     }
 

--- a/stack/cas/castext2/blocks/castext.block.php
+++ b/stack/cas/castext2/blocks/castext.block.php
@@ -37,7 +37,7 @@ class stack_cas_castext2_castext extends stack_cas_castext2_block {
         return $r;
     }
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('evaluated', $this->params)) {
             $errors[] = new $options['errclass']('The castext block must be empty and needs to have the "evaluated" ' .
                 'attribute providing the castext-fragment.', $options['context'] . '/' . $this->position['start'] .

--- a/stack/cas/castext2/blocks/commonstring.block.php
+++ b/stack/cas/castext2/blocks/commonstring.block.php
@@ -118,7 +118,7 @@ class stack_cas_castext2_commonstring extends stack_cas_castext2_block {
     }
 
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('key', $this->params)) {
             $errors[] = new $options['errclass']('The commonstring block must always have a key for the string template.',
                 $options['context'] . '/' . $this->position['start'] . '-' . $this->position['end']);

--- a/stack/cas/castext2/blocks/escape.block.php
+++ b/stack/cas/castext2/blocks/escape.block.php
@@ -51,7 +51,7 @@ class stack_cas_castext2_escape extends stack_cas_castext2_block {
         return array();
     }
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         // Due to escape block needing some backwards compatibility we still need to support
         // the old way of defining the value as an parameter but not both ways at the same time.
 

--- a/stack/cas/castext2/blocks/if.block.php
+++ b/stack/cas/castext2/blocks/if.block.php
@@ -174,7 +174,7 @@ class stack_cas_castext2_if extends stack_cas_castext2_block {
         return $r;
     }
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('test', $this->params)) {
             $errors[] = new $options['errclass']('If block requires a test parameter.', $options['context'] . '/' .
                 $this->position['start'] . '-' . $this->position['end']);

--- a/stack/cas/castext2/blocks/include.block.php
+++ b/stack/cas/castext2/blocks/include.block.php
@@ -87,7 +87,7 @@ class stack_cas_castext2_include extends stack_cas_castext2_block {
         return castext2_parser_utils::get_casstrings($src);
     }
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('src', $this->params)) {
             $errors[] = new $options['errclass']('Include block requires a src parameter.', $options['context'] . '/' .
                 $this->position['start'] . '-' . $this->position['end']);

--- a/stack/cas/castext2/blocks/jsxgraph.block.php
+++ b/stack/cas/castext2/blocks/jsxgraph.block.php
@@ -152,8 +152,8 @@ class stack_cas_castext2_jsxgraph extends stack_cas_castext2_block {
     }
 
     public function validate(
-        &$errors = [],
-        array $options
+        array $options,
+        &$errors = []
     ): bool {
         // Basically, check that the dimensions have units we know.
         // Also that the references make sense.

--- a/stack/cas/castext2/blocks/lang.block.php
+++ b/stack/cas/castext2/blocks/lang.block.php
@@ -62,7 +62,7 @@ class stack_cas_castext2_lang extends stack_cas_castext2_block {
         return [];
     }
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('code', $this->params)) {
             $errors[] = new $options['errclass']('The "lang"-block needs a code atribute with a singular code or a comma ' .
                 'separated list of alternatives.', $options['context'] . '/' . $this->position['start'] . '-' .

--- a/stack/cas/castext2/blocks/textdownload.block.php
+++ b/stack/cas/castext2/blocks/textdownload.block.php
@@ -79,7 +79,7 @@ class stack_cas_castext2_textdownload extends stack_cas_castext2_block {
     }
 
 
-    public function validate(&$errors=array(), array $options): bool {
+    public function validate(array $options, &$errors=array()): bool {
         if (!array_key_exists('name', $this->params)) {
             $errors[] = new $options['errclass']('The textdownload-block requires one to declare a name for the file.',
                 $options['context'] . '/' . $this->position['start'] . '-' . $this->position['end']);

--- a/stack/utils.class.php
+++ b/stack/utils.class.php
@@ -774,7 +774,7 @@ class stack_utils {
      * Converts a PHP string object to a PHP string object containing the Maxima code that would generate a similar
      * string in Maxima.
      * @param a string
-     * @return a string that contains ""-quotes around the content.
+     * @return null|string string that contains ""-quotes around the content.
      */
     public static function php_string_to_maxima_string($string) {
         $converted = str_replace("\\", "\\\\", $string);
@@ -784,7 +784,7 @@ class stack_utils {
     /**
      * Converts a PHP string object containing a Maxima string as presented by the grind command to a PHP string object.
      * @param a string that contains ""-quotes around the content.
-     * @return a string without those quotes.
+     * @return null|string string without those quotes.
      */
     public static function maxima_string_to_php_string($string) {
         $converted = str_replace("\\\\", "\\", $string);


### PR DESCRIPTION
Hello,
As of PHP 8.0, a deprecation log item is thrown when a required parameter follows an optional parameter.
By changing the parameter order, that can fix this problem.
Besides, the return type of php_string_to_maxima_string and maxima_string_to_php_string have a problem: "Expected type null|string. Found a"
So, I have also changed its return type into null|string.
Please have a look of these suggested solutions, or feel free if you any better ideas to fix the problems.

Thx and cheers,
Nisa