### PR TITLE
Iss824

### DIFF
--- a/cli/ast_filter_tester.php
+++ b/cli/ast_filter_tester.php
@@ -173,8 +173,8 @@ if ($only === false) {
                                'letToken' => stack_string('equiv_LET')));
     }
 
-    $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('996_call_modification', '998_security'),
-            array('998_security' => array('security' => 's')), true);
+    $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('995_ev_modification', '996_call_modification', '998_security'),
+            array('998_security' => array('security' => 's'), '995_ev_modification' => ['flags' => false]), true);
     check_filter($freshast, $pipeline, new stack_cas_security(false), 'core + security(s)');
 
     cli_heading('= core + security(t) + strict =');
@@ -186,7 +186,7 @@ if ($only === false) {
                                'letToken' => stack_string('equiv_LET')));
     }
 
-    $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('996_call_modification', '998_security', '999_strict'),
-            array('998_security' => array('security' => 't')), true);
+    $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('995_ev_modification', '996_call_modification', '998_security', '999_strict'),
+            array('998_security' => array('security' => 't'), '995_ev_modification' => ['flags' => true]), true);
     check_filter($freshast, $pipeline, new stack_cas_security(false), 'core + security(t) + strict');
 }

--- a/cli/clearcascache.php
+++ b/cli/clearcascache.php
@@ -31,7 +31,7 @@ require_once($CFG->dirroot . '/question/type/stack/stack/cas/cassession2.class.p
 require_once($CFG->dirroot . '/question/type/stack/stack/cas/connector.dbcache.class.php');
 
 // Get cli options.
-list($options, $unrecognized) = cli_get_params(['help' => false], ['h' => 'help']);
+list($options, $unrecognized) = cli_get_params(['help' => false, 'ccc' => false], ['h' => 'help']);
 
 if ($unrecognized) {
     $unrecognized = implode("\n  ", $unrecognized);
@@ -41,13 +41,35 @@ if ($unrecognized) {
 if ($options['help']) {
     echo "This script clears the STACK CAS cache. This can safely be done at any time,
 but afterwards STACK questions will run a bit slower for a while.
+
+With the additional option --ccc one can also clear the compiled cache, which
+can also be done at any time but is not necessary unless one modifies STACK.
+Clearing the compiled cache during production use is not recommended as 
+regenerating it is much more expensive.
 ";
     exit(0);
 }
+
 
 echo "Clearing the CAS cache, which contains " .
         stack_cas_connection_db_cache::entries_count($DB) .
         " entries.\n";
 stack_cas_connection_db_cache::clear_cache($DB);
 echo "\nCache cleared successfully.\n\n";
+
+if (isset($options['ccc']) && $options['ccc']) {
+    echo "Clearing compiled cache.\n";
+    // First make absolutely certain that none of these are present in the
+    // question-cache.
+    $rs = $DB->get_records_sql('SELECT questionid FROM {qtype_stack_options} WHERE NOT compiledcache = ?;', ["{}"]);
+    $c = 0;
+    foreach ($rs as $item) {
+        cache::make('core', 'questiondata')->delete($item->questionid);
+        $c = $c + 1;
+    }
+    // Then clear the compiledcache.
+    $DB->execute('UPDATE {qtype_stack_options} SET compiledcache = ?', ['{}']);
+    echo "\nCompiled cache cleared, $c questions require recompilation and have beeen removed from Moodles caches.\n\n";
+}
+
 exit(0);

--- a/doc/en/Authoring/Future_proof.md
+++ b/doc/en/Authoring/Future_proof.md
@@ -33,7 +33,7 @@ To ensure consistent presentation you should avoid using inline CSS styles in yo
 
 If your CASText document contains scripts like JSXGraph content definitions you should ensure that if they require some external files to be evaluated you include those files with the question as links to external files will be broken at some point or the external files themselves change. In the case of JSXGraph use the `jsxgraph` CASText block which will handle the scripts at STACK level.
 
-__All external files/links are bad!__ If you have images or other documents related to the question they should be included in the question. Avoid embedded frames, applets and other interactive content. To test inclusion you should be able to export the question and import it to a freshly installed raw system on a computer not connected to the internet and those questions should work. *There is nothing wrong with internal files of any type, as long as they come with the question.*
+__All external files/links are bad!__ If you have images or other documents related to the question they should be included in the question. Avoid embedded frames, applets and other interactive content. To test inclusion you should be able to export the question and import it to a freshly installed raw system on a computer not connected to the internet and those questions should work. *There is nothing wrong with internal files of any type, as long as they come with the question.* Use of the [include](Inclusions.md) feature from 4.4 is also a bad thing, but you can make it less bad if the included file is present on a public server and if it is versioned so that one can link to a version that never changes.
 
 ## Writing CAS code
 

--- a/stack/cas/ast.container.silent.class.php
+++ b/stack/cas/ast.container.silent.class.php
@@ -200,11 +200,12 @@ class stack_ast_container_silent implements cas_evaluatable {
         }
 
         // As we take no filter options for teachers sourced stuff lets build them from scratch.
-        $filteroptions = array('998_security' => array('security' => 't'));
+        $filteroptions = array('998_security' => ['security' => 't'], '995_ev_modification' => ['flags' => true]);
 
         // Get the filter pipeline. Now we only want the core filtters and
         // append the strict syntax check to the end.
-        $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('996_call_modification', '998_security',
+        $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array(
+            '995_ev_modification', '996_call_modification', '998_security',
             '999_strict'), $filteroptions, true);
 
         if ($ast !== null) {
@@ -232,8 +233,10 @@ class stack_ast_container_silent implements cas_evaluatable {
 
         $errors = array();
         $answernotes = array();
-        $filteroptions = array('998_security' => array('security' => 't'));
-        $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('998_security', '999_strict'), $filteroptions, true);
+        $filteroptions = array('998_security' => ['security' => 't']);
+
+        $pipeline = stack_parsing_rule_factory::get_filter_pipeline(array('998_security',
+            '999_strict'), $filteroptions, true);
         $ast = $pipeline->filter($ast, $errors, $answernotes, $securitymodel);
 
         $astc = new static;

--- a/stack/cas/castext2/blocks/latex.block.php
+++ b/stack/cas/castext2/blocks/latex.block.php
@@ -32,10 +32,8 @@ class stack_cas_castext2_latex extends stack_cas_castext2_raw {
 
         // So we need to know if there is simplification in play
         // from the given expression.
-        // TODO: remove the extra ev-wrap if possible and do static type
-        // identification so that we can dorp that if.
-        $forcesimp = mb_strpos($ev, ',simp=true') !== false;
-        $disablesimp = mb_strpos($ev, ',simp=false') !== false;
+        $forcesimp = (mb_strpos($ev, ',simp=true') !== false) || (mb_strpos($ev, ',simp = true') !== false);
+        $disablesimp = (mb_strpos($ev, ',simp=false') !== false) || (mb_strpos($ev, ',simp = false') !== false);
 
         $mode = '""';
         if ($format === castext2_parser_utils::MDFORMAT) {

--- a/stack/cas/castext2/blocks/raw.block.php
+++ b/stack/cas/castext2/blocks/raw.block.php
@@ -40,10 +40,8 @@ class stack_cas_castext2_raw extends stack_cas_castext2_block {
 
         // So we need to know if there is simplification in play
         // from the given expression.
-        // TODO: remove the extra ev-wrap if possible and do static type
-        // identification so that we can drop that if.
-        $forcesimp = mb_strpos($ev, ',simp=true') !== false;
-        $disablesimp = mb_strpos($ev, ',simp=false') !== false;
+        $forcesimp = (mb_strpos($ev, ',simp=true') !== false) || (mb_strpos($ev, ',simp = true') !== false);
+        $disablesimp = (mb_strpos($ev, ',simp=false') !== false) || (mb_strpos($ev, ',simp = false') !== false);
 
         $r = 'string(' . $ev . ')';
         $epos = $options['context'] . '/' . $this->position['start'] . '-' . $this->position['end'];

--- a/stack/cas/keyval.class.php
+++ b/stack/cas/keyval.class.php
@@ -329,9 +329,11 @@ class stack_cas_keyval {
         $errors = [];
         $answernotes = [];
         $filteroptions = ['998_security' => ['security' => 't'],
-            '601_castext' => ['context' => $contextname, 'errclass' => $this->errclass]];
+            '601_castext' => ['context' => $contextname, 'errclass' => $this->errclass], 
+            '995_ev_modification' => ['flags' => true]];
         $pipeline = stack_parsing_rule_factory::get_filter_pipeline(['601_castext',
-            '602_castext_simplifier', '680_gcl_sconcat', '996_call_modification', '998_security', '999_strict'],
+            '602_castext_simplifier', '680_gcl_sconcat', '995_ev_modification',
+            '996_call_modification', '998_security', '999_strict'],
             $filteroptions, true);
         $tostringparams = ['nosemicolon' => true, 'pmchar' => 1];
         $securitymodel = $this->security;

--- a/stack/cas/parsingrules/995_ev_modification.filter.php
+++ b/stack/cas/parsingrules/995_ev_modification.filter.php
@@ -25,9 +25,6 @@ require_once(__DIR__ . '/996_call_modification.filter.php');
  */
 class stack_ast_filter_995_ev_modification implements stack_cas_astfilter_parametric {
 
-    // Unique counter for temp vars.
-    public static $TMPVARCOUNT = 1;
-
     // Whether to rewrite evaluation flags. Don't do for students.
     private $flags = false;
 
@@ -44,6 +41,8 @@ class stack_ast_filter_995_ev_modification implements stack_cas_astfilter_parame
                 if ($node->statement instanceof MP_Operation && $node->statement->op === ':') {
                     $fun->arguments[0] = $node->statement->rhs;
                     $node->statement->rhs = $fun;
+                } else {
+                    $node->statement = $fun;
                 }
                 foreach ($node->flags as $flag) {
                     $fun->arguments[] = new MP_Operation('=', $flag->name, $flag->value);
@@ -61,12 +60,12 @@ class stack_ast_filter_995_ev_modification implements stack_cas_astfilter_parame
                 }
                 if (count($tc['funs']) > 0) {
                     // Complex `ev`. As in iss824.
-                    $id = '%_ev_tmp_' . self::$TMPVARCOUNT;
-                    self::$TMPVARCOUNT = self::$TMPVARCOUNT + 1;
-                    $id2 = '%_ev_tmp_' . self::$TMPVARCOUNT;
-                    self::$TMPVARCOUNT = self::$TMPVARCOUNT + 1;
-                    $replacement = new MP_Group([new MP_Operation(':', new MP_Identifier($id2), new MP_Identifier('simp')), new MP_Operation(':', new MP_Identifier('simp'), new MP_Boolean(false)), new MP_Operation(':', new MP_Identifier($id), $payload), new MP_Operation(':', new MP_Identifier('simp'), new MP_Identifier($id2)), $node]);
-                    $node->arguments[0] = new MP_Identifier($id);
+                    $replacement = new MP_FunctionCall(new MP_Identifier('block'),
+                        [
+                            new MP_List([new MP_Identifier('%_sev_e')]),
+                            new MP_Operation(':', new MP_Identifier('%_sev_e'), $payload), 
+                            $node]);
+                    $node->replace($payload, new MP_Identifier('%_sev_e'));
                     $node->parentnode->replace($node, $replacement);
                     return false;
                 }

--- a/stack/cas/parsingrules/995_ev_modification.filter.php
+++ b/stack/cas/parsingrules/995_ev_modification.filter.php
@@ -35,6 +35,8 @@ class stack_ast_filter_995_ev_modification implements stack_cas_astfilter_parame
     public function filter(MP_Node $ast, array &$errors, array &$answernotes, stack_cas_security $identifierrules): MP_Node {
 
         $process = function($node) {
+            // If not student input, turn all evaluation flags to ev-calls.
+            // Do it now before other ev logic gets executed.
             if ($this->flags && $node instanceof MP_Statement && 
                 $node->flags !== null && count($node->flags) > 0) {
                 $fun = new MP_FunctionCall(new MP_Identifier('ev'), [$node->statement]);

--- a/stack/cas/parsingrules/995_ev_modification.filter.php
+++ b/stack/cas/parsingrules/995_ev_modification.filter.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Stack - https://stack.maths.ed.ac.uk
+//
+// Stack is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Stack is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Stack.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/filter.interface.php');
+require_once(__DIR__ . '/996_call_modification.filter.php');
+
+/**
+ * AST filter that rewrites calls to ev in such a way that they can deal
+ * with the security system. Also rewrites evaluation flags if they are 
+ * in play.
+ */
+class stack_ast_filter_995_ev_modification implements stack_cas_astfilter_parametric {
+
+    // Unique counter for temp vars.
+    public static $TMPVARCOUNT = 1;
+
+    // Whether to rewrite evaluation flags. Don't do for students.
+    private $flags = false;
+
+    public function set_filter_parameters(array $parameters) {
+        $this->flags = isset($parameters['flags']) ? $parameters['flags'] : false;
+    }
+
+    public function filter(MP_Node $ast, array &$errors, array &$answernotes, stack_cas_security $identifierrules): MP_Node {
+
+        $process = function($node) {
+            if ($this->flags && $node instanceof MP_Statement && 
+                $node->flags !== null && count($node->flags) > 0) {
+                $fun = new MP_FunctionCall(new MP_Identifier('ev'), [$node->statement]);
+                if ($node->statement instanceof MP_Operation && $node->statement->op === ':') {
+                    $fun->arguments[0] = $node->statement->rhs;
+                    $node->statement->rhs = $fun;
+                }
+                foreach ($node->flags as $flag) {
+                    $fun->arguments[] = new MP_Operation('=', $flag->name, $flag->value);
+                }
+                $node->flags = [];
+                return false;
+            }
+            if ($node instanceof MP_FunctionCall && $node->name instanceof MP_Atom &&
+                $node->name->value === 'ev') {
+                $payload = $node->arguments[0];
+                $tc = $payload->type_count();
+                // Do not touch these, indempotent behaviour required.
+                if (isset($tc['funs'][stack_ast_filter_996_call_modification::EXPCHECK])) {
+                    unset($tc['funs'][stack_ast_filter_996_call_modification::EXPCHECK]);
+                }
+                if (count($tc['funs']) > 0) {
+                    // Complex `ev`. As in iss824.
+                    $id = '%_ev_tmp_' . self::$TMPVARCOUNT;
+                    self::$TMPVARCOUNT = self::$TMPVARCOUNT + 1;
+                    $id2 = '%_ev_tmp_' . self::$TMPVARCOUNT;
+                    self::$TMPVARCOUNT = self::$TMPVARCOUNT + 1;
+                    $replacement = new MP_Group([new MP_Operation(':', new MP_Identifier($id2), new MP_Identifier('simp')), new MP_Operation(':', new MP_Identifier('simp'), new MP_Boolean(false)), new MP_Operation(':', new MP_Identifier($id), $payload), new MP_Operation(':', new MP_Identifier('simp'), new MP_Identifier($id2)), $node]);
+                    $node->arguments[0] = new MP_Identifier($id);
+                    $node->parentnode->replace($node, $replacement);
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        // @codingStandardsIgnoreStart
+        while (!$ast->callbackRecurse($process)) { }
+        // @codingStandardsIgnoreEnd
+
+        return $ast;
+    }
+}

--- a/stack/cas/parsingrules/parsingrule.factory.php
+++ b/stack/cas/parsingrules/parsingrule.factory.php
@@ -62,6 +62,7 @@ require_once(__DIR__ . '/802_singleton_units.filter.php');
 require_once(__DIR__ . '/910_inert_float_for_display.filter.php');
 require_once(__DIR__ . '/990_no_fixing_spaces.filter.php');
 require_once(__DIR__ . '/991_no_fixing_stars.filter.php');
+require_once(__DIR__ . '/995_ev_modification.filter.php');
 require_once(__DIR__ . '/996_call_modification.filter.php');
 require_once(__DIR__ . '/997_string_security.filter.php');
 require_once(__DIR__ . '/998_security.filter.php');
@@ -166,6 +167,8 @@ class stack_parsing_rule_factory {
                 return new stack_ast_filter_990_no_fixing_spaces();
             case '991_no_fixing_stars':
                 return new stack_ast_filter_991_no_fixing_stars();
+            case '995_ev_modification':
+                return new stack_ast_filter_995_ev_modification();
             case '996_call_modification':
                 return new stack_ast_filter_996_call_modification();
             case '997_string_security':
@@ -211,7 +214,7 @@ class stack_parsing_rule_factory {
                            '801_singleton_numeric', '802_singleton_units',
                            '910_inert_float_for_display',
                            '990_no_fixing_spaces', '991_no_fixing_stars',
-                           '996_call_modification',
+                           '995_ev_modification', '996_call_modification',
                            '997_string_security',
                            '998_security', '999_strict') as $name) {
                 self::$singletons[$name] = self::build_from_name($name);

--- a/stack/prt.class.php
+++ b/stack/prt.class.php
@@ -719,9 +719,15 @@ class stack_potentialresponse_tree_lite {
                     }
                 }
             }
-            $cs = stack_ast_container::make_from_teacher_source($ct->get_evaluationform(), $context . '/ft');
+            $cts = $ct->get_evaluationform();
+            // If it is a pure static string it is too simple for latter processing to detect static content. So we will add some wrapping to make it obvious.
+            if (mb_substr($cts, 0, 1) === '"') {
+                $cts = '["%root",' . $cts . ']';
+            }
+
+            $cs = stack_ast_container::make_from_teacher_source($cts, $context . '/ft');
             $usage = $cs->get_variable_usage($usage); // Update the references.
-            $body .= '_EC(errcatch(%PRT_FEEDBACK:castext_concat(%PRT_FEEDBACK,' . $ct->get_evaluationform() . ')),' .
+            $body .= '_EC(errcatch(%PRT_FEEDBACK:castext_concat(%PRT_FEEDBACK,' . $cts . ')),' .
                 stack_utils::php_string_to_maxima_string($context . '/ft') . ')';
         }
 
@@ -807,9 +813,16 @@ class stack_potentialresponse_tree_lite {
                     }
                 }
             }
-            $cs = stack_ast_container::make_from_teacher_source($ct->get_evaluationform(), $context . '/ff');
+
+            $cts = $ct->get_evaluationform();
+            // If it is a pure static string it is too simple for latter processing to detect static content. So we will add some wrapping to make it obvious.
+            if (mb_substr($cts, 0, 1) === '"') {
+                $cts = '["%root",' . $cts . ']';
+            }
+
+            $cs = stack_ast_container::make_from_teacher_source($cts, $context . '/ff');
             $usage = $cs->get_variable_usage($usage); // Update the references.
-            $body .= '_EC(errcatch(%PRT_FEEDBACK:castext_concat(%PRT_FEEDBACK,' . $ct->get_evaluationform() . ')),' .
+            $body .= '_EC(errcatch(%PRT_FEEDBACK:castext_concat(%PRT_FEEDBACK,' . $cts . ')),' .
                 stack_utils::php_string_to_maxima_string($context . '/ff') . ')';
         }
 

--- a/stack/prt.evaluatable.class.php
+++ b/stack/prt.evaluatable.class.php
@@ -186,7 +186,7 @@ class prt_evaluatable implements cas_raw_value_extractor {
                 // If it was flat.
                 $this->renderedfeedback  = stack_utils::maxima_string_to_php_string($this->feedback);
                 if ($this->statics !== null) {
-                    $this->evaluated = $this->statics->replace($this->evaluated);
+                    $this->renderedfeedback = $this->statics->replace($this->renderedfeedback);
                 }
             } else {
                 $value = castext2_parser_utils::unpack_maxima_strings($this->feedback);

--- a/tests/maxima_replication_test.php
+++ b/tests/maxima_replication_test.php
@@ -185,4 +185,16 @@ class maxima_replication_test extends qtype_stack_testcase {
         $this->check($code, $result);
     }
 
+    public function test_diff() {
+        $code = 'simp:false;';
+        $code .= 'a:x;';
+        $code .= 'b:x^2;';
+        $code .= 'RESULT:ev(diff(a-b,x),simp);';
+
+        $result = '1-2*x';
+
+        $this->check($code, $result);
+    }
+
+
 }

--- a/tests/maxima_replication_test.php
+++ b/tests/maxima_replication_test.php
@@ -1,0 +1,188 @@
+<?php
+// This file is part of Stack - http://stack.maths.ed.ac.uk/
+//
+// Stack is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Stack is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Stack.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_stack;
+
+use qtype_stack_testcase;
+use stack_ast_container;
+use stack_cas_keyval;
+use stack_cas_security;
+use stack_cas_session2;
+use castext2_evaluatable;
+use stack_secure_loader;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../locallib.php');
+require_once(__DIR__ . '/fixtures/test_base.php');
+require_once(__DIR__ . '/../stack/cas/cassession2.class.php');
+require_once(__DIR__ . '/../stack/cas/keyval.class.php');
+require_once(__DIR__ . '/../stack/cas/secure_loader.class.php');
+require_once(__DIR__ . '/../stack/cas/castext2/castext2_evaluatable.class.php');
+
+/**
+ * Tests confirming that what happens in raw maxima will also happen in STACK
+ * when STACK does its own security and other rewriting.
+ * 
+ * @group qtype_stack
+ * @covers \stack_cas_keyval
+ */
+class maxima_replication_test extends qtype_stack_testcase {
+
+    /**
+     * All tests in this set of tests share the form of having
+     * a section of code which will be taken as a keyval and which
+     * contains a variable named `RESULT` that will end up containing
+     * something that will be compared to the expected form. The result
+     * will be outputted as `string(RESULT)`. In this case, we do that
+     * outputting through a CASText-evaluatable.
+     */
+    public function check($code, $result) {
+        // Do a full compile of the keyval.
+        $keyval = new stack_cas_keyval($code, null, 123);
+        $keyval->get_valid();
+        $keyval = new stack_secure_loader($keyval->compile('test')['statement']);
+        $output = castext2_evaluatable::make_from_source('{#RESULT#}', 'test');
+        $output->get_valid();
+        $session = new stack_cas_session2([$keyval, $output], null, 123);
+
+        // Execute.
+        $session->instantiate();
+
+        $this->assertEquals($result, $output->get_rendered());
+    }
+
+    public function test_matrix_mult() {
+        $code = 'simp:true;';
+        $code .= 'a:matrix([1,2],[3,4]);';
+        $code .= 'RESULT:a.a;';
+
+        $result = 'matrix([7,10],[15,22])';
+
+        $this->check($code, $result);
+    }
+
+
+    public function test_ev_flag_1() {
+        $code = 'simp:true;';
+        $code .= 'a:1+t;';
+        $code .= 'RESULT:a,t=1;';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_flag_2() {
+        $code = 'simp:true;';
+        $code .= 'a:sqrt(t);';
+        $code .= 'RESULT:a,t=4;';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_flag_3() {
+        $code = 'simp:false;';
+        $code .= 'a:1+1;';
+        $code .= 'RESULT:a;';
+
+        $result = '1+1';
+
+        $this->check($code, $result);
+
+        $code = 'simp:false;';
+        $code .= 'a:1+1,simp;';
+        $code .= 'RESULT:a;';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_flag_4() {
+        $code = 'simp:true;';
+        $code .= 'foo(x):=0+sqrt(x);';
+        $code .= 'RESULT:foo(t),t=4;';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_1() {
+        $code = 'simp:true;';
+        $code .= 'a:1+t;';
+        $code .= 'RESULT:ev(a,t=1);';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_2() {
+        $code = 'simp:true;';
+        $code .= 'a:sqrt(t);';
+        $code .= 'RESULT:ev(a,t=4);';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_3() {
+        $code = 'simp:false;';
+        $code .= 'a:ev(1+1);';
+        $code .= 'RESULT:a;';
+
+        $result = '1+1';
+
+        $this->check($code, $result);
+
+        $code = 'simp:false;';
+        $code .= 'a:ev(1+1,simp);';
+        $code .= 'RESULT:a;';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_ev_4() {
+        $code = 'simp:true;';
+        $code .= 'foo(x):=0+sqrt(x);';
+        $code .= 'RESULT:ev(foo(t),t=4);';
+
+        $result = '2';
+
+        $this->check($code, $result);
+    }
+
+    public function test_iss824() {
+        $code = 'simp:true;';
+        $code .= 'a:2;';
+        $code .= 'u:matrix([t,-1,a*t]);';
+        $code .= 'v:matrix([-1,a+1,5]);';
+        $code .= 'myvar1:ev(t,solve(u.u=1,t));';
+        $code .= 'RESULT:ev(sqrt(u.v), t=myvar1);';
+
+        $result = 'sqrt(3)*%i';
+
+        $this->check($code, $result);
+    }
+
+}


### PR DESCRIPTION
Unable to come up with more fixes that would not have more significant side effects, so this is what we should have as it restores much of the expected behaviour of `ev`. The use of `ev(...,eval)` would restore the rest, but as that can only be applied when it is safe to apply, and it is practically impossible to find out when it is safe we cannot apply it automatically.