### PR TITLE
Fix saving the deployed variants and question tests when a question is duplicated #880

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -35,6 +35,9 @@ jobs:
             moodle-branch: 'master'
             database: 'pgsql'
           - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
+          - php: '7.3'
             moodle-branch: 'MOODLE_311_STABLE'
             database: 'pgsql'
           - php: '7.3'
@@ -148,7 +151,6 @@ jobs:
         run: moodle-plugin-ci phpunit
 
       - name: Behat features
-        continue-on-error: true # Currently fails. We really ought to get this passing.
         if: ${{ always() }}
         run: moodle-plugin-ci behat --profile chrome
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -73,28 +73,16 @@ class qtype_stack extends question_type {
 
         $fromform->penalty = stack_utils::fix_approximate_thirds($fromform->penalty);
 
-        // This odd looking guard clause exists because moodle core test case generator
-        // functions return a question without an id.
-        $oldid = 0;
-        if (property_exists($question, 'id')) {
-            $oldid = $question->id;
+        // If this questions is being derived from another one (either duplicate in any
+        // Moodle version, or editing making a new version in Moodle 4.0+) then we need
+        // to get the deployed variants and question tests, so they can be copied too.
+        // The property used seems to be the reliable way to get the old question id.
+        if (isset($question->options->questionid) && $question->options->questionid) {
+            $fromform->deployedseeds = $this->get_question_deployed_seeds($question->options->questionid);
+            $fromform->testcases = $this->load_question_tests($question->options->questionid);
         }
 
         $new = parent::save_question($question, $fromform);
-        // Earlier than Moodle 4.0.
-        if (stack_determine_moodle_version() < 400) {
-            return $new;
-        }
-        $newid = $new->id;
-
-        // Copy over test cases.
-        $testcases = $this->load_question_tests($oldid);
-        $this->save_question_tests($newid, $testcases);
-
-        // Copy over deployed seeds.
-        foreach ($this->get_question_deployed_seeds($oldid) as $seed) {
-            $this->deploy_variant($newid, $seed);
-        }
 
         return $new;
     }
@@ -139,7 +127,6 @@ class qtype_stack extends question_type {
         if (!$options) {
             $options = new stdClass();
             $options->questionid = $fromform->id;
-            $options->stackversion = '';
             $options->questionvariables = '';
             $options->questionnote = '';
             $options->specificfeedback = '';
@@ -357,20 +344,6 @@ class qtype_stack extends question_type {
 
         $this->save_hints($fromform);
 
-        // This is a bit of a hack. If doing 'Duplicate' in the question bank
-        // then when saving the editing form, then detect that here, and try to
-        // copy the deployed variants from the original question.
-        if (!isset($fromform->deployedseeds) && !empty($fromform->makecopy)) {
-            $oldquestionid = optional_param('id', 0, PARAM_INT);
-            if ($oldquestionid) {
-                $fromform->deployedseeds = $DB->get_fieldset_sql('
-                        SELECT seed
-                          FROM {qtype_stack_deployed_seeds}
-                         WHERE questionid = ?
-                      ORDER BY id', [$oldquestionid]);;
-            }
-        }
-
         if (isset($fromform->deployedseeds)) {
             $DB->delete_records('qtype_stack_deployed_seeds', array('questionid' => $fromform->id));
             foreach ($fromform->deployedseeds as $deployedseed) {
@@ -378,16 +351,6 @@ class qtype_stack extends question_type {
                 $record->questionid = $fromform->id;
                 $record->seed = $deployedseed;
                 $DB->insert_record('qtype_stack_deployed_seeds', $record, false);
-            }
-        }
-
-        // This is a bit of a hack. If doing 'Duplicate' in the question bank
-        // then when saving the editing form, then detect that here, and try to
-        // copy the question tests from the original question.
-        if (!isset($fromform->testcases) && !empty($fromform->makecopy)) {
-            $oldquestionid = optional_param('id', 0, PARAM_INT);
-            if ($oldquestionid) {
-                $fromform->testcases = $this->load_question_tests($oldquestionid);
             }
         }
 

--- a/tests/behat/create_preview_edit.feature
+++ b/tests/behat/create_preview_edit.feature
@@ -15,13 +15,10 @@ Feature: Create, preview, test, tidy and edit STACK questions
     And the following "course enrolments" exist:
       | user    | course | role           |
       | teacher | C1     | editingteacher |
-    And I log in as "teacher"
-    And I am on "Course 1" course homepage
-    And I navigate to "Question bank" in current page administration
 
   @javascript
   Scenario: Create, preview, test, tidy and edit STACK questions
-    And I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
+    When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
     # Create a new question.
     And I add a "STACK" question filling the form with:
       | Question name      | Test STACK question                                                           |
@@ -103,7 +100,10 @@ Feature: Create, preview, test, tidy and edit STACK questions
 
   @javascript
   Scenario: Test duplicating a STACK question keeps the deployed variants and question tests
-    Given the following "questions" exist:
+    Given the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Default for C1 |
+    And the following "questions" exist:
       | questioncategory | qtype | name             | template |
       | Default for C1   | stack | Question to copy | test1    |
     And the following "qtype_stack > Deployed variants" exist:
@@ -112,10 +112,34 @@ Feature: Create, preview, test, tidy and edit STACK questions
     And the following "qtype_stack > Question tests" exist:
       | question         | ans1 | PotResTree_1 score | PotResTree_1 penalty | PotResTree_1 note |
       | Question to copy | ta+C | 1                  | 0                    | PotResTree_1-1-T  |
-    And I reload the page
-    When I choose "Duplicate" action for "Question to copy" in the question bank
+    When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
+    And I choose "Duplicate" action for "Question to copy" in the question bank
     And I press "id_submitbutton"
     And I choose "Question tests & deployed variants" action for "Question to copy (copy)" in the question bank
     Then I should see "Deployed variants (1)"
     And I should see "42"
-    And I should see "Test case 1 Pass"
+    And I should see "Test case 1"
+    And I should see "All tests passed!"
+
+  @javascript
+  Scenario: Editing a STACK question (to make a new version) keeps the deployed variants and question tests
+    Given the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Default for C1 |
+    And the following "questions" exist:
+      | questioncategory | qtype | name             | template |
+      | Default for C1   | stack | Question to edit | test1    |
+    And the following "qtype_stack > Deployed variants" exist:
+      | question         | seed |
+      | Question to edit | 42   |
+    And the following "qtype_stack > Question tests" exist:
+      | question         | ans1 | PotResTree_1 score | PotResTree_1 penalty | PotResTree_1 note |
+      | Question to edit | ta+C | 1                  | 0                    | PotResTree_1-1-T  |
+    When I am on the "Question to edit" "core_question > edit" page logged in as "teacher"
+    And I set the field "Question name" to "Edited question"
+    And I press "id_submitbutton"
+    And I choose "Question tests & deployed variants" action for "Edited question" in the question bank
+    Then I should see "Deployed variants (1)"
+    And I should see "42"
+    And I should see "Test case 1"
+    And I should see "All tests passed!"

--- a/tests/behat/restore_demo.feature
+++ b/tests/behat/restore_demo.feature
@@ -1,21 +1,23 @@
 @qtype @qtype_stack
-Feature: Test restoring the STACK demo course
+Feature: Test restoring a backup including STACK questions
   In order to reuse all the existing shared STACK questions
   As an admin
   I need to restore the STACK demo course.
 
   Background:
-    Given I log in as "admin"
+    Given the following "courses" exist:
+      | fullname            | shortname |
+      | Demonstrating STACK | STACK     |
+    And I log in as "admin"
     And I navigate to "Courses > Restore course" in site administration
     And I click on "Manage backup files" "button" in the "//h2[contains(., 'User private backup area')]/following-sibling::div[1]" "xpath_element"
-    And I upload "question/type/stack/samplequestions/STACK-demo.mbz" file to "Files" filemanager
+    And I upload "question/type/stack/samplequestions/STACK-syntax-quiz.mbz" file to "Files" filemanager
     And I press "Save changes"
 
   @javascript @_file_upload
   Scenario: Restore the STACK demo course.
-    When I restore "STACK-demo.mbz" backup into a new course using this options:
-    And I am on "Demonstrating STACK (v4.3.9)" course homepage
-    Then I should see "Demonstration quiz"
-    And I am on the "Demonstrating STACK (v4.3.9)" "core_question > course question bank" page
-    And I set the field "Select a category" to "Example_questions"
-    And I should see "Cart speed analysis"
+    When I restore "STACK-syntax-quiz" backup into "Demonstrating STACK" course using this options:
+    And I am on "Demonstrating STACK" course homepage
+    Then I should see "Stack Syntax Quiz"
+    And I am on the "Stack Syntax Quiz" "mod_quiz > edit" page
+    And I should see "Syntax-21-Numbers-Greek"


### PR DESCRIPTION
Also, this gets all the Behat tests passing, and puts them back into the CI build properly. The other one with issues was the one that tested restore.