### PR TITLE
Fix questiontestreport DB query to fetch all attempts of all versions

### DIFF
--- a/questiontestreport.php
+++ b/questiontestreport.php
@@ -125,52 +125,37 @@ flush();
 // Later we only display inputs relevant to a particular PTR, so we sort out prt input requirements here.
 $inputsbyprt = $question->get_cached('required');
 
+$params = [$questionid];
+$query = "SELECT qa.*, qas_last.*
+              FROM {question_attempts} qa
+              LEFT JOIN {question_attempt_steps} qas_last ON qas_last.questionattemptid = qa.id
+              /* attach another copy of qas to those rows with the most recent timecreated,
+              using method from https://stackoverflow.com/a/28090544 */
+              LEFT JOIN {question_attempt_steps} qas_prev
+                            ON qas_last.questionattemptid = qas_prev.questionattemptid
+                                AND (qas_last.sequencenumber < qas_prev.sequencenumber
+                                    OR (qas_last.sequencenumber = qas_prev.sequencenumber
+                                        AND qas_last.id < qas_prev.id))
+              LEFT JOIN {user} u ON qas_last.userid = u.id
+          WHERE qas_prev.timecreated IS NULL";
+
 if (stack_determine_moodle_version() < 400) {
-
-    $query = 'SELECT qa.*, qas_last.*
-        FROM {question_attempts} qa
-        LEFT JOIN {question_attempt_steps} qas_last ON qas_last.questionattemptid = qa.id
-        /* attach another copy of qas to those rows with the most recent timecreated,
-        using method from https://stackoverflow.com/a/28090544 */
-        LEFT JOIN {question_attempt_steps} qas_prev
-        ON qas_last.questionattemptid = qas_prev.questionattemptid
-        AND (qas_last.sequencenumber < qas_prev.sequencenumber
-        OR (qas_last.sequencenumber = qas_prev.sequencenumber
-        AND qas_last.id < qas_prev.id))
-        LEFT JOIN {user} u ON qas_last.userid = u.id
-        WHERE
-        qas_prev.timecreated IS NULL
-        AND qa.questionid = ' . $questionid . '
-        ORDER BY u.username, qas_last.timecreated';
-
+    $query .= " AND qa.questionid = ?";
 } else {
-    // In moodle 4 we look at all attemps at all versions.
+    // In moodle 4 we look at all attempts at all versions.
     // Otherwise an edit, regrade and re-analysis becomes impossible.
-    $query = 'SELECT qa.*, qas_last.*
-    FROM {question_attempts} qa
-    LEFT JOIN {question_attempt_steps} qas_last ON qas_last.questionattemptid = qa.id
-    /* attach another copy of qas to those rows with the most recent timecreated,
-    using method from https://stackoverflow.com/a/28090544 */
-    LEFT JOIN {question_attempt_steps} qas_prev
-    ON qas_last.questionattemptid = qas_prev.questionattemptid
-    AND (qas_last.sequencenumber < qas_prev.sequencenumber
-    OR (qas_last.sequencenumber = qas_prev.sequencenumber
-    AND qas_last.id < qas_prev.id))
-    LEFT JOIN {user} u ON qas_last.userid = u.id
-    LEFT JOIN {question} q ON q.id = (SELECT qv.questionid FROM {question_versions} qv
-                                  JOIN {question_bank_entries} qbe ON qbe.id = qv.questionbankentryid
-                                  WHERE qbe.id = (SELECT be.id FROM {question_bank_entries} be
-                                                  JOIN {question_versions} v ON v.questionbankentryid = be.id
-                                                  WHERE v.questionid = ' . $questionid . ')
-                                 )
-    WHERE
-    qas_prev.timecreated IS NULL
-    ORDER BY u.username, qas_last.timecreated';
+    $query .= " AND qa.questionid IN (
+                    SELECT qv.questionid
+                      FROM {question_versions} qv_original
+                      JOIN {question_versions} qv ON
+                                qv.questionbankentryid = qv_original.questionbankentryid
+                    WHERE qv_original.questionid = ?)";
 }
+$query .= " ORDER BY u.username, qas_last.timecreated";
 
 global $DB;
 
-$result = $DB->get_records_sql($query);
+$result = $DB->get_records_sql($query, $params);
 $summary = array();
 foreach ($result as $qattempt) {
     if (!array_key_exists($qattempt->variant, $summary)) {


### PR DESCRIPTION
Hi Chris,

The DB query in questiontestreport for Moodle 4.0 was fetching all the question attempts irrespective of the question id. Because of which, we were getting the below warning messages in the 'Basic question use report'. Have made the changes to fetch the question attempts considering all the question versions.

Could you please review the same?

Basic question use report:

Warning: Undefined array key 11 in <path>\question\type\stack\question.php on line 312
Warning: Undefined array key 10 in ...\question\type\stack\question.php on line 312

Thanks,
Anupama