### PR TITLE
Fix 'Back' navigation url on bulk test results page

### DIFF
--- a/doc/en/Developer/Running_question_tests_other_site.md
+++ b/doc/en/Developer/Running_question_tests_other_site.md
@@ -97,7 +97,7 @@ diff --git a/bulktestindex.php b/bulktestindex.php
 index 3d5eafa..f84b4bd 100644
 --- a/bulktestindex.php
 +++ b/bulktestindex.php
-@@ -38,13 +38,20 @@ $PAGE->set_url('/question/type/stack/bulktestindex.php');
+@@ -38,13 +38,20 @@ $PAGE->set_url('/question/type/stack/adminui/bulktestindex.php');
  $PAGE->set_context($context);
  $PAGE->set_title(stack_string('bulktestindextitle'));
 

--- a/stack/bulktester.class.php
+++ b/stack/bulktester.class.php
@@ -515,7 +515,7 @@ class stack_bulk_tester {
             }
         }
 
-        echo html_writer::tag('p', html_writer::link(new moodle_url('/question/type/stack/bulktestindex.php'),
+        echo html_writer::tag('p', html_writer::link(new moodle_url('/question/type/stack/adminui/bulktestindex.php'),
                 get_string('back')));
     }
 }


### PR DESCRIPTION
Hi Chris, 

Here is a small change to fix the 'Back' navigation URL on bulk test results page. Could you please review?

One of the PHPUnit test is failing, which is the same as the one failing on https://github.com/maths/moodle-qtype_stack/actions/runs/3970684491/jobs/6806699507. (If I figure out the fix for that then will create a new pull request)

Thanks, 
Anupama.