### PR TITLE
Fix cartesian_product not working with maxima >=5.43

### DIFF
--- a/stack/maxima/rtest_assessment_simpboth.mac
+++ b/stack/maxima/rtest_assessment_simpboth.mac
@@ -373,3 +373,5 @@ factorlist(-x^2-5*x+6);
 factorlist(x^3-1); 
 [x-1,x^2+x+1]$ 
 
+cartesian_product({1, 2}, {3, 4});
+{[1, 3], [1, 4], [2, 3], [2, 4]}$

--- a/stack/maxima/stack_logic.lisp
+++ b/stack/maxima/stack_logic.lisp
@@ -82,12 +82,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun cartesian-product (l1 l2)
-  (if l1
-    (append
-      (mapcar #'(lambda (e) (cons (car l1) e)) l2)
-      (cartesian-product (cdr l1) l2))
-    nil))
+; maxima versions >=5.43 have an internal cartesian-product function
+; incompatible with this function, therefore we only define it if
+; previously undefined
+(unless (fboundp 'cartesian-product)
+  (defun cartesian-product (l1 l2)
+    (if l1
+      (append
+        (mapcar #'(lambda (e) (cons (car l1) e)) l2)
+        (cartesian-product (cdr l1) l2))
+      nil)))
 
 (defun replicate (n e)
   (if (and (integerp n) (>= n 0))


### PR DESCRIPTION
With maxima release 5.43, cartesian-product was added within maxima and was broken because stack_logic.lisp defined its own incompatible version.

Change it to be only defined if a cartesian-product function is not already defined.

Fixes #924.