### PR TITLE
Better normalise floats for cross compatibility between SBCL and GCL Maxima

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:
@@ -30,31 +30,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # I don't know why, but mariadb is much slower, so mostly use pgsql.
+        # We use a mix of SBCL and GCL, but mostly prefer SBCL as it is faster.
         include:
           - php: '8.0'
             moodle-branch: 'master'
             database: 'pgsql'
+            maxima: 'SBCL'
           - php: '7.4'
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
+            maxima: 'SBCL'
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'
+            maxima: 'GCL'
           - php: '7.3'
             moodle-branch: 'MOODLE_311_STABLE'
             database: 'pgsql'
+            maxima: 'SBCL'
           - php: '7.3'
             moodle-branch: 'MOODLE_310_STABLE'
             database: 'pgsql'
+            maxima: 'SBCL'
           - php: '7.2'
             moodle-branch: 'MOODLE_39_STABLE'
             database: 'mariadb'
+            maxima: 'SBCL'
 
     steps:
-      - name: Install required libraries
+      - name: Install Maxima (${{ matrix.maxima }})
         run: |
-          sudo apt-get install gnuplot maxima maxima-share texinfo
-          maxima --list-avail
+          maxima="${{ (matrix.maxima == 'SBCL' && 'sbcl') || 'gcl' }}"
+          wget http://mirrors.kernel.org/ubuntu/pool/main/r/readline/libreadline7_7.0-3_amd64.deb \
+               https://sourceforge.net/projects/maxima/files/Maxima-Linux/5.42.2-Linux/maxima-common_5.42.2-1_all.deb \
+               https://sourceforge.net/projects/maxima/files/Maxima-Linux/5.42.2-Linux/maxima-${maxima}_5.42.2-1_amd64.deb
+          sudo apt-get install libtinfo5
+          sudo dpkg -i libreadline7_7.0-3_amd64.deb maxima-common_5.42.2-1_all.deb maxima-${maxima}_5.42.2-1_amd64.deb
+
           echo "diff(x^2,x);" | maxima
           echo "build_info();" | maxima
 
@@ -87,11 +99,11 @@ jobs:
 
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
 
-          moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMAVERSION",       "5.41.0");'
+          moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMAVERSION",       "5.42.2");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMAND",       "maxima");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMANDOPT",    "timeout --kill-after=10s 10s ${{ github.workspace }}/maxima_opt_auto -eval '\''(cl-user::run)'\''");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMANDSERVER", "http://pool.home:8080/MaximaPool/MaximaPool");'
-          moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_CASTIMEOUT",          "10");'
+          moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_CASTIMEOUT",          "100");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_MAXIMALIBRARIES",     "stats, distrib, descriptive, simplex");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_CASPREPARSE", "true");'
           moodle-plugin-ci add-config 'define("QTYPE_STACK_TEST_CONFIG_PLATFORM",            "linux-optimised");'

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix: # I don't know why, but mariadb is much slower, so mostly use pgsql.
         include:
-          - php: '7.4'
+          - php: '8.0'
             moodle-branch: 'master'
             database: 'pgsql'
           - php: '7.4'
@@ -56,6 +56,7 @@ jobs:
           sudo apt-get install gnuplot maxima maxima-share texinfo
           maxima --list-avail
           echo "diff(x^2,x);" | maxima
+          echo "build_info();" | maxima
 
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/doc/docslib.php
+++ b/doc/docslib.php
@@ -142,7 +142,7 @@ function stack_docs_render_markdown($page, $preprocess = true) {
         // Don't process the auto-generated answer test output.
         $page = stack_maths::pre_process_docs_page($page);
     }
-    $page = format_text($page, FORMAT_MARKDOWN, array('filter' => false, 'noclean' => true));
+    $page = format_text($page, FORMAT_MARKDOWN, array('filter' => false));
     $page = stack_maths::post_process_docs_page($page);
     return $page;
 }

--- a/tests/castext_test.php
+++ b/tests/castext_test.php
@@ -1203,6 +1203,9 @@ class castext_test extends qtype_stack_testcase {
         // On old Maxima, you get back \(9.999999999999999e-7\).
         $this->skip_if_old_maxima('5.32.1');
 
+        // For some reason 5.41.0 returns \(9.999999999999999e-7\) too.
+        $this->skip_if_new_maxima('5.40.0');
+
         $st = 'Decimal number {@0.000001@}.';
 
         $a2 = array('stackfltfmt:"~e"');

--- a/tests/fixtures/test_base.php
+++ b/tests/fixtures/test_base.php
@@ -162,16 +162,28 @@ abstract class qtype_stack_testcase extends advanced_testcase {
 
     /**
      * Different versions of Maxima output floats in slighly different ways.
-     * Revert some of those irrelevant differences.
-     * We always expect the E in 3.0E8 to be upper case.
-     * Upper case is used to avoid a conflict with the base of the natural logarithms.
+     * Normalise some of those irrelevant differences.
+     *
+     * 1. Normalise E in 3.0E8 to be upper case (to avoid conflict with Euler's Number)
+     * 2. Normalise the coefficient to be < 10
+     *
+     * For example, the string: "Avogadro's number is 60.220e22 and the speed of light
+     * is about 30e7" will be normalised to "Avagardo's number is 6.022E23 and the speed
+     * of light is about 3E8".
+     *
+     * It also preserves the number of decimals and presence of a '+' sign.
+     * For example 30.0e9 becomes 3.0E10 and 3e+10 becomes 3E+11.
      */
     public static function prepare_actual_maths_floats($content) {
-
-        // We don't add in a trailing zero at this point as that would break a decimal places display function test.
-        $content = preg_replace('~(-?\b\d+(?:\.\d*)?)e([-+]?\d+\b)~', '$1E$2', $content);
-
-        return $content;
+        return preg_replace_callback(
+            '~(-?\b\d+(?:\.\d*)?)[eE]([-+]?\d+\b)~',
+            function(array $matches): string {
+                $decimals = strlen(explode('.', $matches[1])[1] ?? '') ?: 0;
+                $fixedbase = sprintf("%.${decimals}E", (float)$matches[0]);
+                return strpos($matches[2], '+') !== false ? $fixedbase : str_replace('+', '', $fixedbase);
+            },
+            $content
+        );
     }
 
     /**

--- a/tests/mathsoutputtex_test.php
+++ b/tests/mathsoutputtex_test.php
@@ -54,10 +54,9 @@ class mathsoutputtex_test extends qtype_stack_testcase {
                 .'<a .*alt="x\^2".*</(a|script)> \.</p>\n$~',
                 stack_docs_render_markdown('<code>\(x^2\)</code> gives \(x^2\).'));
 
-        // Test docs - make sure maths inside <textarea> is not rendered, and <textarea> is retained.
-        $expectation = '<p><textarea readonly="readonly" rows="3" cols="50">' . "\n" .
-            'Differentiate \[x^2 + y^2\] with respect to \(x\).</textarea></p>' . "\n";
-        $this->assertEquals($expectation,
+        // Test docs - make sure maths inside <textarea> is not rendered.
+        $this->assertMatchesRegularExpression('~^<p>.*\n' .
+                'Differentiate \\\\\\\\\[x\^2 \+ y\^2\\\\\\\\\] with respect to \\\\\\\\\(x\\\\\\\\\)\..*</p>\n$~',
                 stack_docs_render_markdown('<textarea readonly="readonly" rows="3" cols="50">' . "\n" .
                         'Differentiate \[x^2 + y^2\] with respect to \(x\).</textarea>'));
 


### PR DESCRIPTION
**Note**: This branch should resolve https://github.com/maths/moodle-qtype_stack/issues/720 and should be considered a "better" fix than https://github.com/maths/moodle-qtype_stack/pull/721 - as it allows tests to pass regardless of the specific Lisp compiler used to compile Maxima. Additionally it adds some misc CI and PHPUnit fixes.

**Background**
When using Maxima compiled under SBCL (which is used by [maximapool-docker](https://github.com/catalyst/maximapool-docker) for performance reasons), the CAS returns different values for scientific notation compared to Maxima compiled under GCL (which is what you get from Ubuntu/Debian's repositories). To see this; compare the results of the expression `scientific_notation(0.000000000001)` in Maxima compiled against GCL vs SBCL:

**GCL**
````
wget https://sourceforge.net/projects/maxima/files/Maxima-Linux/5.42.0-Linux/maxima-gcl_5.42.0-1_amd64.deb https://sourceforge.net/projects/maxima/files/Maxima-Linux/5.42.0-Linux/maxima-common_5.42.0-1_all.deb/download
sudo dpkg -i maxima-common_5.42.0-1_all.deb maxima-gcl_5.42.0-1_amd64.deb
````

Evaluate the expression:

```
 echo "scientific_notation(0.000000000001);" | maxima
```

The response is `scientific_notation(1.0E-12)`

**SBCL**
```
sudo apt-get purge maxima-common
wget https://sourceforge.net/projects/maxima/files/Maxima-Linux/5.42.0-Linux/maxima-sbcl_5.42.0-1_amd64.deb
sudo dpkg -i maxima-common_5.42.0-1_all.deb maxima-sbcl_5.42.0-1_amd64.deb  
```

Evaluate the expression:

```
 echo "scientific_notation(0.000000000001);" | maxima
```

The response is `scientific_notation(9.999999999999999e-13)` (although somehow in unit tests this becomes 10e-13).

**To see why this is a problem**
1. With SBCL Maxima  still installed, install Moodle with qtype_stack:
```
git clone git@github.com:maths/moodle-qbehaviour_adaptivemultipart.git question/behaviour/adaptivemultipart
git clone git@github.com:maths/moodle-qbehaviour_dfcbmexplicitvaildate.git question/behaviour/dfcbmexplicitvaildate
git clone git@github.com:maths/moodle-qbehaviour_dfexplicitvaildate.git question/behaviour/dfexplicitvaildate
git clone git@github.com:maths/moodle-qtype_stack.git question/type/stack
```
2. Update `config.php` with the following lines:
```define("QTYPE_STACK_TEST_CONFIG_MAXIMAVERSION",       "5.42.0");
define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMAND",       "maxima");
define("QTYPE_STACK_TEST_CONFIG_CASTIMEOUT",          "10");
define("QTYPE_STACK_TEST_CONFIG_MAXIMALIBRARIES",     "stats, distrib, descriptive, simplex");
define("QTYPE_STACK_TEST_CONFIG_CASPREPARSE", "true");
define("QTYPE_STACK_TEST_CONFIG_CASRESULTSCACHE",     "db");
define("QTYPE_STACK_TEST_CONFIG_PLOTCOMMAND",         "");
define("QTYPE_STACK_TEST_CONFIG_CASDEBUGGING",        "0");
define("QTYPE_STACK_TEST_CONFIG_PLATFORM",            "linux");
define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMANDSERVER", "");
define("QTYPE_STACK_TEST_CONFIG_MAXIMACOMMANDOPT",    "");
```
3. Setup PHPUnit and run the following:
```
vendor/bin/phpunit --testsuite=qtype_stack_testsuite --stop-on-failure --filter='test_scientific_notation'
```

The same error will be observed when using maximapool-docker, as that uses SBCL Maxima.

There is some pre-existing code in `test_base::prepare_actual_maths_floats` to handle situations where different Maxima setups return different values. So the most logical thing to me is to extend that code to normalise the coefficient of numbers using scientific notation. Which is what this patch does. This way the test pass when using GCL (which is what GHA is using) or SBCL Maxima.

**Testing**
1. Checkout this branch for `qtype_stack`:
```
cd question/type/stack
git remote add catalyst git@github.com:catalyst/moodle-qtype_stack.git
git fetch catalyst phpunit-fixes
git checkout phpunit-fixes
```

2. Run `vendor/bin/phpunit --testsuite=qtype_stack_testsuite --stop-on-failure --filter='test_scientific_notation'` on both SBCL and GCL Maxima and ensure there are no failures. No change to `config.php` is needed. Just change Maxima like so:

For GCL:
```
sudo apt-get purge maxima-common
sudo dpkg -i maxima-common_5.42.0-1_all.deb maxima-gcl_5.42.0-1_amd64.deb
```

For SBCL:
```
sudo apt-get purge maxima-common
sudo dpkg -i maxima-common_5.42.0-1_all.deb maxima-sbcl_5.42.0-1_amd64.deb
```

You can check which version of Maxima your system is using like so: `echo "build_info();" | maxima`