### PR TITLE
Fix PHP deprecated error in inputbase.class.php

### DIFF
--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -171,7 +171,7 @@ abstract class stack_input {
      */
     protected function internal_contruct() {
         $options = $this->get_parameter('options');
-        if (trim($options) != '') {
+        if (trim($options ?? '') != '') {
             $options = explode(',', $options);
             foreach ($options as $option) {
                 $option = strtolower(trim($option));


### PR DESCRIPTION
Hi Chris, 

We found some PHP deprecated error when updated to PHP 8.1. Hence have done a small change to fix the same in stack/input/inputbase.class.php. Could you please review?

I have done the change assuming that the minimum supported PHP version for STACK is PHP 7.4 or later. I hope that is OK.

Thanks,
Anupama.