### PR TITLE
Fix PHP8.1 deprecation error of str_replace in mathsoutputbase.class.php

### DIFF
--- a/stack/mathsoutput/mathsoutputbase.class.php
+++ b/stack/mathsoutput/mathsoutputbase.class.php
@@ -86,7 +86,7 @@ abstract class stack_maths_output {
         }
 
         $text = str_replace('!ploturl!',
-                moodle_url::make_file_url('/question/type/stack/plot.php', '/'), $text);
+                moodle_url::make_file_url('/question/type/stack/plot.php', '/'), $text ?? '');
 
         $text = stack_fact_sheets::display($text, $renderer);
 


### PR DESCRIPTION
Hi Chris,

Thanks for merging the fix for the earlier issue. We have seen one more PHP8.1 deprecation error related to str_replace in stack/mathsoutput/mathsoutputbase.class.php. Could you please review the fix?

Error:
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/moodle/question/type/stack/stack/mathsoutput/mathsoutputbase.class.php on line 89

Thanks,
Anupama 