### PR TITLE
Mention `nounand` and `nounor` in Inequalities doc

### DIFF
--- a/doc/en/CAS/Inequalities.md
+++ b/doc/en/CAS/Inequalities.md
@@ -9,6 +9,8 @@ Maxima allows single inequalities, such as \(x-1>y\), and also support for inequ
 You can test if two inequalities are the same using the algebraic equivalence test, see the comments on this below.  
 
 Chained inequalities, for example \(1\leq x \leq2\mbox{,}\) are not permitted.  They must be joined by logical connectives, e.g. "\(x>1\) and \(x<7\)". 
+As `and` and `or` are converted to `nounand` and `nounor` in student answers, you may need to use these forms in the teacher's answer as well.
+For more information, see [Propositional Logic](../Topics/Propositional_Logic.md).
 
 From version 3.6, support for inequalities in Maxima (particularly single variable real inequalities) was substantially improved.
 


### PR DESCRIPTION
In chained inequalities, `EqualComAss` sees `and` and `nounand` as different things. Added a link to the propositional logic page where the distinction is explained.

The wording probably could be improved (and please correct me if I've misunderstood the whole issue), but this might be good to mention &ndash; this PR brought to you by several hours of debugging 😄 We had some exercises from 2020 that used `and`/`or` chained inequalities and `EqualComAss`, and that broke in a (long-due) STACK upgrade.