### PR TITLE
Fix rendering error when `$question->specificfeedbackinstantiated` is `null`

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -206,6 +206,10 @@ class qtype_stack_renderer extends qtype_renderer {
             $question->castextprocessor = new castext2_qa_processor($qa);
         }
 
+        if ($question->specificfeedbackinstantiated === null) {
+            // Invalid question, otherwise this would be here.
+            return '';
+        }
         $feedbacktext = $question->specificfeedbackinstantiated->get_rendered($question->castextprocessor);
         if (!$feedbacktext) {
             return '';


### PR DESCRIPTION
Just experienced a rendering error in production, when attempting to resume a quiz preview. So far I was not able to cleanly reproduce this bug, but from what I gathered after a cursory look through the relevant code, I have an idea what the offending part is and how to fix it.

Here is the stack trace:

```
PHP message: Default exception handler: Fehler: Call to a member function get_rendered() on null Debug:
Error code: generalexceptionmessage
* line 209 of /question/type/stack/renderer.php: Error thrown
* line 193 of /question/type/stack/renderer.php: call to qtype_stack_renderer->stack_specific_feedback_errors_only()
* line 428 of /question/engine/renderer.php: call to qtype_stack_renderer->feedback()
* line 112 of /question/engine/renderer.php: call to core_question_renderer->outcome()
* line 113 of /question/behaviour/behaviourbase.php: call to core_question_renderer->question()
* line 907 of /question/engine/questionattempt.php: call to question_behaviour->render()
* line 461 of /question/engine/questionusage.php: call to question_attempt->render()
* line 1783 of /mod/quiz/attemptlib.php: call to question_usage_by_activity->render_question()
* line 1745 of /mod/quiz/attemptlib.php: call to quiz_attempt->render_question_helper()
* line 187 of /mod/quiz/renderer.php: call to quiz_attempt->render...
```

The version of `qtype_stack` used is `4.4.4` on Moodle `4.1.4`.

As far as I can tell, the `specificfeedbackinstantiated` property can be `null`, which is why this is explicitly checked here in the `stack_specific_feedback` method:

https://github.com/maths/moodle-qtype_stack/blob/abc74a0fea442dccfeab95091915ab660bd5a03d/renderer.php#L255-L259

But in the `stack_specific_feedback_errors_only` method right above there no such check is being done, which causes the error.

https://github.com/maths/moodle-qtype_stack/blob/abc74a0fea442dccfeab95091915ab660bd5a03d/renderer.php#L201-L209

To be honest, I have no idea what exactly those methods have to do or when/how exactly they are called. I am simply drawing a conclusion by analogy because I see how this `specificfeedbackinstantiated` property is handled in a seemingly related method. So I cannot speak to whether or not it makes sense that it is `null` there in the first place because I do not know the context. I hope this still makes sense.

Thus, all I did was copy that check and early `return` from below.

If there is anything else I can do here, let me know. If I completely missed the mark with this PR, feel free to close this of course and consider this a vague issue report instead.