### PR TITLE
Update Maxima installation instructions

### DIFF
--- a/doc/en/Installation/index.md
+++ b/doc/en/Installation/index.md
@@ -41,19 +41,19 @@ to `filter_mathjaxloader | mathjaxconfig` in the filter settings: Dashboard > Si
 
 ## 2. Install gnuplot and Maxima
 
-Ensure gcc, gnuplot and [Maxima](http://maxima.sourceforge.net) are installed on your server.  Currently Maxima 5.38.1 to 5.47.0 are supported.  Please contact the developers to request support for other versions.  (Newer versions will be supported, and prompts to test them are welcome.)
+Ensure gcc, gnuplot and [Maxima](http://maxima.sourceforge.net) are installed on your server.  Currently Maxima 5.38.1 to 5.47.0 are supported.  Please contact the developers to request support for other versions.  (Newer versions will be supported, and prompts to test them are welcome.)  We currently recommend that you use any version of Maxima after 5.43.0.
 
-We currently recommend that you use any version of Maxima after 5.43.0.
+Maxima can be installed via a package manager on most Linux distributions (e.g. `sudo apt-get install maxima` on Debian/Ubuntu), [downloaded](http://maxima.sourceforge.net/download.html) as a self-contained installer program for Windows, or [compiled from source](Maxima.md).
+
+To check your version of maxima, run `maxima --version`.  If Moodle is set up using Apache, STACK will run maxima through the Apache user (`www-data/apache2`).  To check that this works, run maxima as the apache user (e.g. `sudo -u www-data maxima`).  Later versions of maxima create a cache and thus the executing user needs to have write access to a temporary folder, see [#731](https://github.com/maths/moodle-qtype_stack/issues/731) for more details and troubleshooting.
+
+Alternatively, Maxima can also be run on a separate server via [GoeMaxima](https://github.com/mathinstitut/goemaxima) or [MaximaPool](https://github.com/maths/stack_util_maximapool).
 
 Please note 
 
 * Please avoid versions 5.37.x which are known to have a minor bug which affects STACK. In particular with `simp:false`, \(s^{-1}\) is transformed into \(1/s\).  This apparently minor change makes it impossible to distinguish between the two forms.  This causes all sorts of problems.  Do not use Maxima 5.37.1 to 5.37.3.
 * Older versions of Maxima:  in particular, Maxima 5.23.2 has some differences which result in \(1/\sqrt{x} \neq \sqrt{1/x}\), and similar problems.  This means that we have an inconsistency between questions between versions of maxima.   Of course, we can argue about which values of \(x\) make \(1/\sqrt{x} = \sqrt{1/x}\), but currently the unit tests and assumption is that these expressions should be considered to be algebraically equivalent!   So, older versions of Maxima are not supported for a reason.  Please test thoroughly if you try to use an older version, and expect some errors in the mathematical parts of the code.
 * If you install more than one version of Maxima then you will need to tell STACK which version to use.  Otherwise just use the "default" option.
-
-The documentation on [Installing Maxima](Maxima.md) includes code for compiling Maxima from source.
-
-Maxima can also be [downloaded](http://maxima.sourceforge.net/download.html) as a self-contained installer program for Windows, RPMs for Linux or as source for all platforms.
 
 Instructions for installing a more recent version of Maxima on CentOS 6 are available on the [Moodle forum](https://moodle.org/mod/forum/discuss.php?d=270956)  (Oct 2014).
 


### PR DESCRIPTION
Installing maxima seems to have been an issue for a few people I have talked to lately. I updated the instructions to:
- present the installation via a package manager first (compiling from source seemed troublesome for some, but it was listed first)
- Point towards a commonly observed issue of the apache user not being able to run maxima (related issue linked)
- Instructions on how to check whether maxima is running fine and which version you're running
- Mention GoeMaxima/MaximaPool as alternatives.

I wonder if it is worth mentioning how to deal with dockerized Moodle setups? I don't know docker well enough to tell how to add STACK to a dockerized Moodle installation, but there are forks/setups to add some form of maxima to the setup:
- https://github.com/SvenKirschbaum/moodle-docker (local maxima, intended for dev; previous commits have GoeMaxima)
- https://github.com/istride/moodle-docker (GoeMaxima, intended for production)