### PR TITLE
Wip694609

### DIFF
--- a/question.php
+++ b/question.php
@@ -1600,7 +1600,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         }
         $pat = '/\[\[todo/';
         foreach ($tocheck as $field => $text) {
-            if (preg_match($pat, $text)) {
+            if (preg_match($pat, $text ?? '')) {
                 $warnings[] = stack_string_error('todowarning', array('field' => $field));
             }
         }

--- a/question.php
+++ b/question.php
@@ -1458,7 +1458,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         foreach ($patterns as $checkpat) {
             if ($stackversion < $checkpat['ver']) {
                 foreach ($qfields as $field) {
-                    if (strstr($this->$field, $checkpat['pat'])) {
+                    if (strstr($this->$field ?? '', $checkpat['pat'])) {
                         $a = array('pat' => $checkpat['pat'], 'ver' => $checkpat['ver'], 'qfield' => stack_string($field));
                         $err = stack_string('stackversionerror', $a);
                         if (array_key_exists('alt', $checkpat)) {
@@ -1516,7 +1516,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         $fields = array('questiontext', 'specificfeedback', 'generalfeedback', 'questiondescription');
         foreach ($fields as $field) {
             $text = $this->$field;
-            $filesexpected = preg_match($pat, $text);
+            $filesexpected = preg_match($pat, $text ?? '');
             $filesfound    = $fs->get_area_files($context->id, 'question', $field, $this->id);
             if (!$filesexpected && $filesfound != array()) {
                 $errors[] = stack_string('stackfileuseerror', stack_string($field));

--- a/stack/questiontestresult.php
+++ b/stack/questiontestresult.php
@@ -205,7 +205,7 @@ class stack_question_test_result {
      * @return bool whether the answer notes match sufficiently.
      */
     protected function test_answer_note($expected, $actual) {
-        $lastactual = array_pop($actual);
+        $lastactual = array_pop($actual) ?? '';
         if ('NULL' == $expected) {
             return '' == trim($lastactual);
         }


### PR DESCRIPTION
Hi Chris,

We have noticed the following PHP 8.1 deprecation errors. I have fixed these in two commits - 

•	[Fix PHP8.1 stack deprecation errors](https://github.com/maths/moodle-qtype_stack/commit/60ecd9378e11cda3d4287f4c2035b5b84a04b571) – These errors were noticed when running the automated tests on stack version 2023060500.
1.	Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in …\question\type\stack\question.php on line 1520
2.	Deprecated: strstr(): Passing null to parameter #1 ($haystack) of type string is deprecated in …\question\type\stack\question.php on line 1462
3.	Deprecated: trim(): Passing null to parameter #1 ($string) of type string is  deprecated in …\question\type\stack\stack\questiontestresult.php on line 212

•	[Fix PHP8.1 deprecation error in todo block - question.php](https://github.com/maths/moodle-qtype_stack/commit/aa842040d2d8b9c1afbbe6f6599719a9b6a212eb) – Noticed this error when I executed the tests against dev branch (the code related to “//3. Check for todo blocks” - is not yet merged into master). I was not sure whether or the right way to create a request for this. Hence fixed as a separate commit.
1.	Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in …\question\type\stack\question.php on line 1603
Hope this sounds OK. Could you please review the changes and let me know if they are fine?

Thanks,
Anupama