### PR TITLE
Fix PHP8.1 deprectation error for trim in question.php

### DIFF
--- a/question.php
+++ b/question.php
@@ -1492,7 +1492,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
             }
 
             $options = $input->get_parameter('options');
-            if (trim($options) !== '') {
+            if (trim($options ?? '') !== '') {
                 $options = explode(',', $options);
                 foreach ($options as $opt) {
                     $opt = strtolower(trim($opt));


### PR DESCRIPTION
Hi Chris,

This a one more small fix to resolve the PHP8.1 deprecation error. Could you please review?

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/stack/question.php on line 1495

Thanks,
Anupama