### PR TITLE
Fix silly typo in oumaths filter integration

### DIFF
--- a/stack/mathsoutput/mathsoutputoumaths.class.php
+++ b/stack/mathsoutput/mathsoutputoumaths.class.php
@@ -34,7 +34,7 @@ class stack_maths_output_oumaths extends stack_maths_output_filter_base {
      */
     public static function filter_is_installed() {
         global $CFG;
-        return file_exists($CFG->dirroot . '/filter/maths/filter.php');
+        return file_exists($CFG->dirroot . '/filter/oumaths/filter.php');
     }
 
     protected function initialise_delimiters() {


### PR DESCRIPTION
This is something that is probably only of interest to the OU, but we just found this silly typo, so fixing it.