### PR TITLE
Update validators.mac

### DIFF
--- a/stack/maxima/contrib/validators.mac
+++ b/stack/maxima/contrib/validators.mac
@@ -31,3 +31,13 @@ validate_underscore(ex) := if is(sposition("_", string(ex)) = false) then ""
 /* Add in unit-test cases using STACK's s_test_case function.  At least two please! */
 s_test_case(validate_underscore(1+a1), "");
 s_test_case(validate_underscore(1+a_1), "Underscore characters are not permitted in this input.");
+
+/* The student may only use single-character variable names in their answer. */
+/* This is intended for use when Insert Stars is turned off, but we still want to indicate to students that they may have forgotten a star */
+validate_all_one_letter_variables(ex) := if not(is(ev(lmax(map(lambda([ex2],slength(string(ex2))),listofvars(ex))),simp)>1)) then ""
+        else "Only single-character variable names are permitted in this input. Perhaps you forgot to use an asterisk (*) somewhere, or perhaps you used a Greek letter.";
+
+s_test_case(validate_all_one_letter_variables(1, "");
+s_test_case(validate_all_one_letter_variables((A*x+B)/(x^2+1) + C/x), "");
+s_test_case(validate_all_one_letter_variables((Ax+B)/(x^2+1) + C/x), "Only single-character variable names are permitted in this input. Perhaps you forgot to use an asterisk (*) somewhere, or perhaps you used a Greek letter.");
+s_test_case(validate_all_one_letter_variables((theta*x+B)/(x^2+1) + C/x), "Only single-character variable names are permitted in this input. Perhaps you forgot to use an asterisk (*) somewhere, or perhaps you used a Greek letter.");


### PR DESCRIPTION
Added validate_all_one_letter_variables which invalidates any answer with variable names > 1 character (including Greek letters - not intended, but also likely to not be a problem).