### PR TITLE
PRT tidy/answer note fix

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -911,19 +911,22 @@ class qtype_stack extends question_type {
         $select = 'questionid = ? AND prtname = ?';
         $select_params[] = $questionid;
         $select_params[] = $from;
+        $currentnodenames = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'nodename', $select, $select_params);
         $trueanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'trueanswernote', $select, $select_params);
         $falseanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'falseanswernote', $select, $select_params);
-        foreach($trueanswernotes as $nodekey => $trueanswernote) {
-            $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . substr($trueanswernote, strlen($from)), 
+        foreach(array_combine($currentnodenames, $trueanswernotes) as $nodename => $trueanswernote) {
+            // TODO : nodekey isn't right, this is just always indexes 0, 1, 2, 3, but if the answer notes have been renamed, these are no longer the defaults
+            $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . '-' . (intval($nodename) + 1) . '-T', 
                 array('questionid' => $questionid, 
                       'prtname' => $from, 
-                      'trueanswernote' => $from . '-' . (intval($nodekey) + 1) . '-T'));
+                      'trueanswernote' => $from . '-' . (intval($nodename) + 1) . '-T'));
+            // TODO : update test data for answer notes as well
         }
-        foreach($falseanswernotes as $nodekey => $falseanswernote) {
-            $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $to . substr($falseanswernote, strlen($from)), 
+        foreach(array_combine($currentnodenames, $falseanswernotes) as $nodename => $falseanswernote) {
+            $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $to . '-' . (intval($nodename) + 1) . '-F', 
                 array('questionid' => $questionid, 
                       'prtname' => $from, 
-                      'falseanswernote' => $from . '-' . (intval($nodekey) + 1) . '-F'));
+                      'falseanswernote' => $from . '-' . (intval($nodename) + 1) . '-F'));
         }
 
         // The PRT name in its nodes.

--- a/questiontype.php
+++ b/questiontype.php
@@ -937,6 +937,20 @@ class qtype_stack extends question_type {
         global $DB;
         $transaction = $DB->start_delegated_transaction();
 
+        // True answer note if default answer note is used.
+        $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $prtname . '-' . (intval($to) + 1) . '-T', 
+                array('questionid' => $questionid, 
+                      'prtname' => $prtname, 
+                      'nodename' => $from, 
+                      'trueanswernote' => $prtname . '-' . (intval($from) + 1) . '-T'));
+
+        // False answer note if default answer note is used.
+        $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $prtname . '-' . (intval($to) + 1) . '-F', 
+                array('questionid' => $questionid, 
+                      'prtname' => $prtname, 
+                      'nodename' => $from, 
+                      'falseanswernote' => $prtname . '-' . (intval($from) + 1) . '-F'));
+
         // The PRT node itself.
         $DB->set_field('qtype_stack_prt_nodes', 'nodename', $to,
                 array('questionid' => $questionid, 'prtname' => $prtname, 'nodename' => $from));
@@ -948,7 +962,7 @@ class qtype_stack extends question_type {
         // False next node links.
         $DB->set_field('qtype_stack_prt_nodes', 'falsenextnode', $to,
                 array('questionid' => $questionid, 'prtname' => $prtname, 'falsenextnode' => $from));
-
+        
         // PRT first node link.
         $DB->set_field('qtype_stack_prts', 'firstnodename', $to,
                 array('questionid' => $questionid, 'name' => $prtname, 'firstnodename' => $from));

--- a/questiontype.php
+++ b/questiontype.php
@@ -970,6 +970,13 @@ class qtype_stack extends question_type {
                       'nodename' => $from, 
                       'falseanswernote' => $prtname . '-' . (intval($from) + 1) . '-F'));
 
+        // Answer notes in question test data if default is used.
+        $DB->set_field('qtype_stack_qtest_expected', 'expectedanswernote', $prtname . '-' . (intval($to) + 1) . '-T',
+        array('questionid' => $questionid, 'prtname' => $prtname, 'expectedanswernote' => $prtname . '-' . (intval($from) + 1) . '-T'));
+
+        $DB->set_field('qtype_stack_qtest_expected', 'expectedanswernote', $prtname . '-' . (intval($to) + 1) . '-F',
+        array('questionid' => $questionid, 'prtname' => $prtname, 'expectedanswernote' => $prtname . '-' . (intval($from) + 1) . '-F'));
+
         // The PRT node itself.
         $DB->set_field('qtype_stack_prt_nodes', 'nodename', $to,
                 array('questionid' => $questionid, 'prtname' => $prtname, 'nodename' => $from));

--- a/questiontype.php
+++ b/questiontype.php
@@ -908,9 +908,11 @@ class qtype_stack extends question_type {
                 array('questionid' => $questionid, 'prtname' => $from));
 
         // The PRT name in node answer notes if defaults are being used.
-        $select = 'questionid="' . $questionid . '" AND prtname="' . $from . '"';
-        $trueanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'trueanswernote', $select);
-        $falseanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'falseanswernote', $select);
+        $select = 'questionid = ? AND prtname = ?';
+        $select_params[] = $questionid;
+        $select_params[] = $from;
+        $trueanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'trueanswernote', $select, $select_params);
+        $falseanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'falseanswernote', $select, $select_params);
         foreach($trueanswernotes as $nodekey => $trueanswernote) {
             $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . substr($trueanswernote, strlen($from)), 
                 array('questionid' => $questionid, 

--- a/questiontype.php
+++ b/questiontype.php
@@ -907,10 +907,27 @@ class qtype_stack extends question_type {
         $DB->set_field('qtype_stack_qtest_expected', 'prtname', $to,
                 array('questionid' => $questionid, 'prtname' => $from));
 
+        // The PRT name in node answer notes if defaults are being used.
+        $select = 'questionid="' . $questionid . '" AND prtname="' . $from . '"';
+        $trueanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'trueanswernote', $select);
+        $falseanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'falseanswernote', $select);
+        foreach($trueanswernotes as $nodekey => $trueanswernote) {
+            $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . substr($trueanswernote, 4), 
+                array('questionid' => $questionid, 
+                      'prtname' => $from, 
+                      'trueanswernote' => $from . '-' . (intval($nodekey) + 1) . '-T'));
+        }
+        foreach($falseanswernotes as $nodekey => $falseanswernote) {
+            $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $to . substr($falseanswernote, 4), 
+                array('questionid' => $questionid, 
+                      'prtname' => $from, 
+                      'falseanswernote' => $from . '-' . (intval($nodekey) + 1) . '-F'));
+        }
+
         // The PRT name in its nodes.
         $DB->set_field('qtype_stack_prt_nodes', 'prtname', $to,
                 array('questionid' => $questionid, 'prtname' => $from));
-
+        
         // The PRT itself.
         $DB->set_field('qtype_stack_prts', 'name', $to,
                 array('questionid' => $questionid, 'name' => $from));

--- a/questiontype.php
+++ b/questiontype.php
@@ -912,13 +912,13 @@ class qtype_stack extends question_type {
         $trueanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'trueanswernote', $select);
         $falseanswernotes = $DB->get_fieldset_select('qtype_stack_prt_nodes', 'falseanswernote', $select);
         foreach($trueanswernotes as $nodekey => $trueanswernote) {
-            $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . substr($trueanswernote, 4), 
+            $DB->set_field('qtype_stack_prt_nodes', 'trueanswernote', $to . substr($trueanswernote, strlen($from)), 
                 array('questionid' => $questionid, 
                       'prtname' => $from, 
                       'trueanswernote' => $from . '-' . (intval($nodekey) + 1) . '-T'));
         }
         foreach($falseanswernotes as $nodekey => $falseanswernote) {
-            $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $to . substr($falseanswernote, 4), 
+            $DB->set_field('qtype_stack_prt_nodes', 'falseanswernote', $to . substr($falseanswernote, strlen($from)), 
                 array('questionid' => $questionid, 
                       'prtname' => $from, 
                       'falseanswernote' => $from . '-' . (intval($nodekey) + 1) . '-F'));


### PR DESCRIPTION
* Fix to Issue #929 in which default answer notes were not updating when performing question tidy to rename nodes.
* Also addressed analogous issue whereby default answer notes are not updating when performing question tidy to rename PRT.