### PR TITLE
Fix PHP8.2 deprecated error for trim in questiontestreport.php

### DIFF
--- a/questiontestreport.php
+++ b/questiontestreport.php
@@ -138,7 +138,7 @@ foreach ($result as $qattempt) {
     if (!array_key_exists($qattempt->variant, $summary)) {
         $summary[$qattempt->variant] = array();
     }
-    $rsummary = trim($qattempt->responsesummary);
+    $rsummary = trim($qattempt->responsesummary ?? '');
     if ($rsummary !== '') {
         if (array_key_exists($rsummary, $summary[$qattempt->variant])) {
             $summary[$qattempt->variant][$rsummary] += 1;


### PR DESCRIPTION
Hi Chris,

We have noticed some PHP deprecation errors related to PHP8.2 trim function on 'Analyze responses' page (questiontestreport.php). Could you please review the fix?

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/stack/questiontestreport.php on line 141

Thanks,
Anupama