### PR TITLE
Iss 1110 - CASchat URI too long

### DIFF
--- a/adminui/caschat.php
+++ b/adminui/caschat.php
@@ -39,6 +39,8 @@ require_login();
 
 // Get the parameters from the URL.
 $questionid = optional_param('questionid', null, PARAM_INT);
+$qubaid = optional_param('qubaid', '', PARAM_RAW);
+$slot = optional_param('slot', '', PARAM_RAW);
 
 if (!$questionid) {
     $context = context_system::instance();
@@ -47,8 +49,15 @@ if (!$questionid) {
     $urlparams = array();
 } else {
     // Load the necessary data.
+    if ($qubaid) {
+        // ISS-1110 If question usage by activity has been supplied, load the question
+        // from that so we can load correct responses later.
+        $quba = question_engine::load_questions_usage_by_activity(optional_param('qubaid', '', PARAM_RAW));
+        $question = $quba->get_question($slot);
+    } else {
+        $question = question_bank::load_question($questionid);
+    }
     $questiondata = $DB->get_record('question', array('id' => $questionid), '*', MUST_EXIST);
-    $question = question_bank::load_question($questionid);
 
     // Process any other URL parameters, and do require_login.
     list($context, $seed, $urlparams) = qtype_stack_setup_question_test_page($question);
@@ -66,10 +75,29 @@ $debuginfo = '';
 $errs = '';
 $varerrs = array();
 
-$vars   = optional_param('maximavars', '', PARAM_RAW);
-$inps   = optional_param('inputs', '', PARAM_RAW);
-$string = optional_param('cas', '', PARAM_RAW);
-$simp   = optional_param('simp', '', PARAM_RAW);
+if ($qubaid !== '' && optional_param('initialise', '', PARAM_RAW) === 'yes') {
+    // ISS-1110 Handle calls from questiontestrun.php.
+    if ($question->options->get_option('simplify')) {
+        $simp = 'on';
+    } else {
+        $simp = '';
+    }
+    $questionvarsinputs = '';
+    foreach ($question->get_correct_response() as $key => $val) {
+        if (substr($key, -4, 4) !== '_val') {
+            $questionvarsinputs .= "\n{$key}:{$val};";
+        }
+    }
+
+    $vars = $question->questionvariables;
+    $inps   = $questionvarsinputs;
+    $string = $question->generalfeedback;
+} else {
+    $vars   = optional_param('maximavars', '', PARAM_RAW);
+    $inps   = optional_param('inputs', '', PARAM_RAW);
+    $string = optional_param('cas', '', PARAM_RAW);
+    $simp   = optional_param('simp', '', PARAM_RAW);
+}
 $savedb = false;
 $savedmsg = '';
 if (trim(optional_param('action', '', PARAM_RAW)) == trim(stack_string('savechat'))) {

--- a/adminui/caschat.php
+++ b/adminui/caschat.php
@@ -49,7 +49,7 @@ if (!$questionid) {
     $urlparams = array();
 } else {
     // Load the necessary data.
-    if ($qubaid) {
+    if ($qubaid !== '') {
         // ISS-1110 If question usage by activity has been supplied, load the question
         // from that so we can load correct responses later.
         $quba = question_engine::load_questions_usage_by_activity(optional_param('qubaid', '', PARAM_RAW));
@@ -75,7 +75,7 @@ $debuginfo = '';
 $errs = '';
 $varerrs = array();
 
-if ($qubaid !== '' && optional_param('initialise', '', PARAM_RAW) === 'yes') {
+if ($qubaid !== '' && optional_param('initialise', '', PARAM_RAW)) {
     // ISS-1110 Handle calls from questiontestrun.php.
     if ($question->options->get_option('simplify')) {
         $simp = 'on';

--- a/questiontestrun.php
+++ b/questiontestrun.php
@@ -139,7 +139,7 @@ $chatparams = $urlparams;
 // ISS-1110 Rather than send parts of the question, save the quba and
 // supply the qubaid and slot so the details can be loaded on the caschat page.
 // This avoids a long URI causing an Apache error.
-$chatparams['initialise'] = 'yes';
+$chatparams['initialise'] = true;
 $chatparams['qubaid'] = $quba->get_id();
 $chatparams['slot'] = $slot;
 $chatlink = new moodle_url('/question/type/stack/adminui/caschat.php', $chatparams);

--- a/questiontestrun.php
+++ b/questiontestrun.php
@@ -122,6 +122,7 @@ if (!is_null($seed)) {
 
 $slot = $quba->add_question($question, $question->defaultmark);
 $quba->start_question($slot);
+question_engine::save_questions_usage_by_activity($quba);
 
 // Prepare the display options.
 $options = question_display_options();
@@ -133,26 +134,14 @@ if ($qversion !== null) {
     echo html_writer::tag('p', stack_string('version') . ' ' . $qversion);
 }
 
-// Add a link to the cas chat to facilitate editing the general feedback.
-if ($question->options->get_option('simplify')) {
-    $simp = 'on';
-} else {
-    $simp = '';
-}
-
-$questionvarsinputs = '';
-foreach ($question->get_correct_response() as $key => $val) {
-    if (substr($key, -4, 4) !== '_val') {
-        $questionvarsinputs .= "\n{$key}:{$val};";
-    }
-}
-
 // We've chosen not to send a specific seed since it is helpful to test the general feedback in a random context.
 $chatparams = $urlparams;
-$chatparams['maximavars'] = $question->questionvariables;
-$chatparams['inputs'] = $questionvarsinputs;
-$chatparams['simp'] = $simp;
-$chatparams['cas'] = $question->generalfeedback;
+// ISS-1110 Rather than send parts of the question, save the quba and
+// supply the qubaid and slot so the details can be loaded on the caschat page.
+// This avoids a long URI causing an Apache error.
+$chatparams['initialise'] = 'yes';
+$chatparams['qubaid'] = $quba->get_id();
+$chatparams['slot'] = $slot;
 $chatlink = new moodle_url('/question/type/stack/adminui/caschat.php', $chatparams);
 
 $links = array();


### PR DESCRIPTION
Passing question variables, etc, as part of the URI when moving from the STACK dashboard to the CASchat page can cause an Apache error if the URI is too long.

There doesn't seem to be a good way of sending a POST request within Moodle that I can find, though. I tried a hidden form but that led to problems making the link look right. Instead, I've saved the quba (required for images showing on the dashboard anyway) and just passed the required info to load the question/attempt data on the CASchat page.