### PR TITLE
Iss 1041 - Sort PRT nodes for display

### DIFF
--- a/stack/graphlayout/graph.php
+++ b/stack/graphlayout/graph.php
@@ -357,6 +357,7 @@ class stack_abstract_graph {
      * @return array node name => stack_abstract_graph_node the list of all nodes.
      */
     public function get_nodes() {
+        uasort($this->nodes, fn($a, $b) => $a->name > $b->name);
         return $this->nodes;
     }
 

--- a/stack/graphlayout/graph.php
+++ b/stack/graphlayout/graph.php
@@ -357,7 +357,8 @@ class stack_abstract_graph {
      * @return array node name => stack_abstract_graph_node the list of all nodes.
      */
     public function get_nodes() {
-        uasort($this->nodes, fn($a, $b) => $a->name > $b->name);
+        // ISS-1041 Fix issue with nodes being retrieved with names sorted as strings.
+        uasort($this->nodes, fn($a, $b) => $a->name - $b->name);
         return $this->nodes;
     }
 

--- a/tidyquestionform.php
+++ b/tidyquestionform.php
@@ -70,7 +70,9 @@ class qtype_stack_tidy_question_form extends moodleform {
             $mform->addElement('static', $prtname . 'graph', '',
                     stack_abstract_graph_svg_renderer::render($graph, $prtname . 'graphsvg'));
 
-            foreach ($prt->get_nodes_summary() as $nodekey => $notused) {
+            $nodes = $prt->get_nodes_summary();
+            uasort($nodes, fn($a, $b) => $a->nodename - $b->nodename);
+            foreach ($nodes as $nodekey => $notused) {
                 $mform->addElement('text', 'nodename_' . $prtname . '_' . $nodekey,
                         stack_string('newnameforx', $nodekey + 1), array('size' => 20));
                 $mform->setDefault('nodename_' . $prtname . '_' . $nodekey, $newnames[$nodekey + 1]);


### PR DESCRIPTION
Nodes are being display 1, 2, 11, 12, 3, 4, 5, 6, 7, 8, 9, 10

The node names are stored as strings but are always integers. However, the stored name is one less than the displayed name (and indeed any new name entered on the tidy page). This is the reason for the bizarre sort order - string sort on an integer combined with an off-by-one issue.

Unfortunately, as maths is being done on the names, adding a leading zero isn't going to work. The order of creation is also not preserved in the DB when a new version of the question is created as the new node records are saved in the mangled order.

Simplest solution is to sort nodes when they're requested.