### PR TITLE
iss-1120 - Fix restore of old questions causing all restores to fail

### DIFF
--- a/backup/moodle2/restore_qtype_stack_plugin.class.php
+++ b/backup/moodle2/restore_qtype_stack_plugin.class.php
@@ -300,15 +300,15 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
                 if ($node->truenextnode == -1) {
                     $left = null;
                 } else {
-                    $left = $node->truenextnode + 1;
+                    $left = (int) $node->truenextnode + 1;
                 }
                 if ($node->falsenextnode == -1) {
                     $right = null;
                 } else {
-                    $right = $node->falsenextnode + 1;
+                    $right = (int) $node->falsenextnode + 1;
                 }
 
-                $graph->add_node($node->nodename + 1, $node->description, $left, $right);
+                $graph->add_node((int) $node->nodename + 1, $node->description, $left, $right);
             }
             try {
                 $graph->layout();


### PR DESCRIPTION
I think this was triggered by an attempt to restore a really old and/or broken STACK question that was missing some fields. Previously with PHP 7, blank string fields would have been evaluated to 0 when attempting to perform maths but PHP 8 is more picky so the tidy up after importing such a question now fails. That tidy up is run on all restores so it keeps failing.

Casting to int forces evaluation to 0 and reinstates the old behaviour.