### PR TITLE
Update validators.mac

### DIFF
--- a/stack/maxima/contrib/validators.mac
+++ b/stack/maxima/contrib/validators.mac
@@ -57,3 +57,21 @@ s_test_case(validate_all_one_letter_variables(1), "");
 s_test_case(validate_all_one_letter_variables((A*x+B)/(x^2+1) + C/x), "");
 s_test_case(validate_all_one_letter_variables((Ax+B)/(x^2+1) + C/x), "Only single-character variable names are permitted in this input. Perhaps you forgot to use an asterisk (*) somewhere, or perhaps you used a Greek letter.");
 s_test_case(validate_all_one_letter_variables((theta*x+B)/(x^2+1) + C/x), "Only single-character variable names are permitted in this input. Perhaps you forgot to use an asterisk (*) somewhere, or perhaps you used a Greek letter.");
+
+/* This provides more detailed feedback for students who try to enter fully closed or open intervals using [] or () instead of cc(a,b) or oo(a,b). */
+/* It is intended for early courses where students might be new to using this written notation and STACK. */
+/* This does not work well with "Check type of response" turned on, and provides slightly awkward feedback when students take a union of multiple intervals with incorrect syntax. */
+validate_interval_syntax(ex):= block(
+  if ev(listp(ex),simp) then return(sconcat("To give a closed interval, use <code>cc(",first(args(ex)),",",second(args(ex)),")</code>, not <code>[",first(args(ex)),",",second(args(ex)),"]</code>. "))
+  else if ev(ntuplep(ex),simp) then return(sconcat("To give an open interval, use <code>oo(",first(args(ex)),",",second(args(ex)),")</code>, not <code>[",first(args(ex)),",",second(args(ex)),"]</code>. "))
+  else if is(safe_op(ex)="%union") then apply(sconcat, map(validate_interval_syntax, args(ex)))
+  else return("")
+);
+
+s_test_case(validate_interval_syntax(cc(1,2)), "");
+s_test_case(validate_interval_syntax(oo(1,2)), "");
+s_test_case(validate_interval_syntax(%union(cc(1,2),oo(2,3))), "");
+s_test_case(validate_interval_syntax([1,2]), "To give a closed interval, use <code>cc(1,2)</code>, not <code>[1,2]</code>. ");
+s_test_case(validate_interval_syntax(ntuple(1,2)), "To give an open interval, use <code>oo(1,2)</code>, not <code>[1,2]</code>. ");
+s_test_case(validate_interval_syntax(%union([1,2],ntuple(2,3))), "To give a closed interval, use <code>cc(1,2)</code>, not <code>[1,2]</code>. To give an open interval, use <code>oo(1,2)</code>, not <code>[1,2]</code>. ");
+s_test_case(validate_interval_syntax(%union([1,2],%union(oo(1,2),[2,3]))), "To give a closed interval, use <code>cc(1,2)</code>, not <code>[1,2]</code>. To give a closed interval, use <code>cc(2,3)</code>, not <code>[2,3]</code>. ");


### PR DESCRIPTION
Added `validate_interval_syntax`, a way to give more detailed feedback for students who are new to real intervals and try to input `[a,b]` or `(a,b)`.