### PR TITLE
Behat fix

### DIFF
--- a/tests/behat/backup.feature
+++ b/tests/behat/backup.feature
@@ -19,10 +19,16 @@ Feature: Test duplicating a quiz containing STACK questions
       | quiz       | Test quiz | C1     | quiz     |
     And quiz "Test quiz" contains the following questions:
       | Dropdown (shuffle)  | 1 |
+    And the following config values are set as admin:
+    | config | value |
+    | enableasyncbackup | true |
 
   @javascript
   Scenario: Backup and restore a course containing a STACK question
-    When I am on the "Course 1" course page logged in as admin
+    When I am logged in as admin
+    And I navigate to "Courses > Asynchronous backup/restore" in site administration
+    And I click on "Save changes" "button"
+    And I am on the "Course 1" course page logged in as admin
     And I backup "Course 1" course using this options:
       | Confirmation | Filename | test_backup.mbz |
     And I restore "test_backup.mbz" backup into a new course using this options:

--- a/tests/behat/restore_demo.feature
+++ b/tests/behat/restore_demo.feature
@@ -8,7 +8,12 @@ Feature: Test restoring a backup including STACK questions
     Given the following "courses" exist:
       | fullname            | shortname |
       | Demonstrating STACK | STACK     |
+    And the following config values are set as admin:
+      | config | value |
+      | enableasyncbackup | true |
     And I log in as "admin"
+    And I navigate to "Courses > Asynchronous backup/restore" in site administration
+    And I click on "Save changes" "button"
     And I navigate to "Courses > Restore course" in site administration
 
   @javascript @_file_upload

--- a/tests/behat/restore_reveal_question.feature
+++ b/tests/behat/restore_reveal_question.feature
@@ -8,7 +8,12 @@ Feature: Test restoring and testing an individual STACK question from the sample
     Given the following "courses" exist:
       | fullname            | shortname |
       | Demonstrating STACK | STACK     |
+    And the following config values are set as admin:
+      | config | value |
+      | enableasyncbackup | true |
     And I log in as "admin"
+    And I navigate to "Courses > Asynchronous backup/restore" in site administration
+    And I click on "Save changes" "button"
     And I navigate to "Courses > Restore course" in site administration
 
   @javascript @_file_upload

--- a/tests/walkthrough_adaptive_test.php
+++ b/tests/walkthrough_adaptive_test.php
@@ -4292,8 +4292,9 @@ class walkthrough_adaptive_test extends qtype_stack_walkthrough_test_base {
     }
 
     public function test_input_validator() {
-
+        global $USER;
         $this->resetAfterTest();
+        $USER->lang = '';
         set_config('lang', 'en');
 
         $q = test_question_maker::make_question('stack', 'validator');
@@ -4374,8 +4375,10 @@ class walkthrough_adaptive_test extends qtype_stack_walkthrough_test_base {
     }
 
     public function test_input_validator_jp() {
+        global $USER;
         // This language is not in the question, so should default back to English.
         $this->resetAfterTest();
+        $USER->lang = '';
         set_config('lang', 'jp');
 
         $q = test_question_maker::make_question('stack', 'validator');
@@ -4456,8 +4459,10 @@ class walkthrough_adaptive_test extends qtype_stack_walkthrough_test_base {
     }
 
     public function test_input_validator_fi() {
+        global $USER;
         // This language is in the question.
         $this->resetAfterTest();
+        $USER->lang = '';
         set_config('lang', 'fi');
 
         $q = test_question_maker::make_question('stack', 'validator');
@@ -4674,8 +4679,9 @@ class walkthrough_adaptive_test extends qtype_stack_walkthrough_test_base {
     }
 
     public function test_input_validator_texput() {
-
+        global $USER;
         $this->resetAfterTest();
+        $USER->lang = '';
         set_config('lang', 'en');
 
         $q = test_question_maker::make_question('stack', 'validator');


### PR DESCRIPTION
Issue was newer versions of Moodle default to async backup - this breaks the Behat tests. I had to set the config (and then oddly go into the admin page and save it to make it stick but oh well).

Language issue on the unit tests was user setting taking priority over config setting. I now blank the user setting to reinstate previous behaviour.