### PR TITLE
Add trim to fix filename path returned by zip::getNameIndex function

### DIFF
--- a/stack/cas/connector.server.class.php
+++ b/stack/cas/connector.server.class.php
@@ -74,7 +74,8 @@ class stack_cas_connection_server extends stack_cas_connection_base {
             $zip = new ZipArchive();
             $zip->open($ziptemp);
             for ($i = 0; $i < $zip->numFiles; $i++) {
-                $filenameinzip = $zip->getNameIndex($i);
+                // In some PHP versions, zip::getNameIndex returns filename with leading '/', hence trim.
+                $filenameinzip = trim($zip->getNameIndex($i), '/');
 
                 if ($filenameinzip === 'OUTPUT') {
                     // This one contains the output from maxima.

--- a/stack/cas/connector.server_proxy.class.php
+++ b/stack/cas/connector.server_proxy.class.php
@@ -99,7 +99,8 @@ class stack_cas_connection_server_proxy extends stack_cas_connection_base {
             $zip = new ZipArchive();
             $zip->open($ziptemp);
             for ($i = 0; $i < $zip->numFiles; $i++) {
-                $filenameinzip = $zip->getNameIndex($i);
+                // In some PHP versions, zip::getNameIndex returns filename with leading '/', hence trim.
+                $filenameinzip = trim($zip->getNameIndex($i), '/');
 
                 if ($filenameinzip === 'OUTPUT') {
                     // This one contains the output from maxima.


### PR DESCRIPTION
Hi Chris,

In some of the PHP versions, we see the following warning for stack questions with images. The function zip::getNameIndex() is returning the filename with a leading '/', thus setting the incorrect filepath, resulting in images not being displayed.

Error: 
Warning: file_put_contents(/efs/moodledata/stack/plots//stackplot-9809-1-3924935062-16894435.svg): Failed to open stream: No such file or directory in /var/www/html/moodle/question/type/stack/stack/cas/connector.server.class.php on line 86

Could you please review the fix?

Thanks,
Anupama