### PR TITLE
Fix PHP deprecated errors and warnings

### DIFF
--- a/question.php
+++ b/question.php
@@ -1575,7 +1575,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         if ($stackversion < $checkpat['ver']) {
             $pat = '~/\*.*?\*/~s';
             foreach ($castextfields as $field) {
-                if (preg_match($pat, $this->$field)) {
+                if (preg_match($pat, $this->$field ?? '')) {
                     $errors[] = stack_string('stackversioncomment', ['qfield' => stack_string($field)]);
                 }
             }

--- a/stack/questiontestresult.php
+++ b/stack/questiontestresult.php
@@ -32,37 +32,37 @@ class stack_question_test_result {
     /**
      * @var array input name => actual value put into this input.
      */
-    public $inputvalues;
+    public $inputvalues = [];
 
     /**
      * @var array input name => modified value of this input.
      */
-    public $inputvaluesmodified;
+    public $inputvaluesmodified = [];
 
     /**
      * @var array input name => the displayed value of that input.
      */
-    public $inputdisplayed;
+    public $inputdisplayed = [];
 
     /**
      * @var array input name => any errors created by invalid input.
      */
-    public $inputerrors;
+    public $inputerrors = [];
 
      /**
       * @var array input name => the input statues. One of the stack_input::STATUS_... constants.
       */
-    public $inputstatuses;
+    public $inputstatuses = [];
 
      /**
       * @var array prt name => stack_potentialresponse_tree_state object
       */
-    public $actualresults;
+    public $actualresults = [];
 
      /**
       * @var array prt name => debuginfo
       */
-    public $debuginfo;
+    public $debuginfo = [];
 
     /**
      * @var float Store the question penalty to check defaults.


### PR DESCRIPTION
Hi Chris, 

We have noticed the below PHP deprecated error and a warning in some of our questions. Could you please review the fix for the same?

Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/html/moodle/question/type/stack/question.php on line 1572

Warning: foreach() argument must be of type array|object, null given in /var/www/html/moodle/question/type/stack/stack/questiontestresult.php on line 114

Thanks,
Anupama