### PR TITLE
api-build - Add info about pre-built Docker image

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,7 +18,7 @@ The image requires maxima to be available via http. The URL can be configured vi
 version: "4.0"
 services:
   maxima:
-    image: mathinstitut/goemaxima:2023121100-latest
+    image: mathinstitut/goemaxima:2024072400-latest
     tmpfs:
       - "/tmp"
     restart: unless-stopped
@@ -31,7 +31,7 @@ services:
       GOEMAXIMA_QUEUE_LEN: 32
     read_only: true
   stack:
-    image: URL to be confirmed
+    image: stackmaths/stackapi:2024072400-latest
     restart: unless-stopped
     ports:
       - '3080:80'
@@ -281,7 +281,9 @@ At this point a user should just need a working Docker setup and an up-to-date `
 
 This will download the goemaxima and stack-api images and run the containers in an enclosing container. Obviously, config will be the same as for whoever built the stack-api Docker image.
 
-Version numbers will need to match the latest STACK release in `docker-compose.dev.yml`, `docker-compose.yml`, `config_sample.txt` and `config.php`.
+Version numbers will need to match the latest STACK release in `docker-compose.dev.yml`, `docker-compose.yml`, `config_sample.txt` and `config.php`. **(Remember: config.php needs updated locally before building.)**
+
+Pre-built API images are available on Docker Hub at `stackmaths/stackapi`.
 
 ### High level overview
 

--- a/api/docker/docker-compose.yml
+++ b/api/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     read_only: true
   stack:
     # Location of published STACK API image goes here.
-    image:
+    image: stackmaths/stackapi:2024072400-latest
     restart: unless-stopped
     ports:
       - '3080:80'


### PR DESCRIPTION
I've put a pre-built image on Docker Hub and Sam Fearn has tried it out. This updates docs and docker-compose.yml to include the details. Could also be merged into master.