### PR TITLE
unit-test-fix - Skip certain asserts if Moodle < 4.1

### DIFF
--- a/tests/docslib_test.php
+++ b/tests/docslib_test.php
@@ -75,6 +75,10 @@ class docslib_test extends qtype_stack_testcase {
 
 
     public function test_stack_docs_render_markdown() {
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
 
         $this->assertEquals("<p>Test</p>\n",
                 stack_docs_render_markdown('Test'));
@@ -83,13 +87,14 @@ class docslib_test extends qtype_stack_testcase {
         $this->assert_content_with_maths_equals("<p><code>\\(x^2\\)</code> gives \\(x^2\\).</p>\n",
                 stack_docs_render_markdown('`\(x^2\)` gives \(x^2\).'));
         // @codingStandardsIgnoreEnd
-
-        $page = 'Watch <iframe width="560" height="315" src="https://www.youtube.com/embed/cpwo-D6EUgA" ' .
-            'frameborder="0" allowfullscreen></iframe> This will help you.';
-        $rendered = "<p>Watch</p>\n\n" .
-            '<iframe width="560" height="315" src="https://www.youtube.com/embed/cpwo-D6EUgA" ' .
-            'frameborder="0" allowfullscreen></iframe>' . "\n\n<p>This will help you.</p>\n";
-        $this->assert_content_with_maths_equals($rendered,
-            stack_docs_render_markdown($page));
+        if (version_compare($currentversion, '4.1.0') >= 0) {
+            $page = 'Watch <iframe width="560" height="315" src="https://www.youtube.com/embed/cpwo-D6EUgA" ' .
+                'frameborder="0" allowfullscreen></iframe> This will help you.';
+            $rendered = "<p>Watch</p>\n\n" .
+                '<iframe width="560" height="315" src="https://www.youtube.com/embed/cpwo-D6EUgA" ' .
+                'frameborder="0" allowfullscreen></iframe>' . "\n\n<p>This will help you.</p>\n";
+            $this->assert_content_with_maths_equals($rendered,
+                stack_docs_render_markdown($page));
+        }
     }
 }

--- a/tests/mathsoutputtex_test.php
+++ b/tests/mathsoutputtex_test.php
@@ -39,6 +39,10 @@ class mathsoutputtex_test extends qtype_stack_testcase {
 
     public function test_tex_rendering() {
         $this->resetAfterTest();
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
         set_config('mathsdisplay', 'tex', 'qtype_stack');
         stack_utils::clear_config_cache();
         filter_set_global_state('mathjaxloader', TEXTFILTER_DISABLED);
@@ -56,10 +60,12 @@ class mathsoutputtex_test extends qtype_stack_testcase {
                 stack_docs_render_markdown('<code>\(x^2\)</code> gives \(x^2\).'));
 
         // Test docs - make sure maths inside <textarea> is not rendered.
-        $this->assertMatchesRegularExpression('~^<p>.*\n' .
+        if (version_compare($currentversion, '4.1.0') >= 0) {
+            $this->assertMatchesRegularExpression('~^<p>.*\n' .
                 'Differentiate \\\\\[x\^2 \+ y\^2\\\\\] with respect to \\\\\(x\\\\\)\..*</p>\n$~',
                 stack_docs_render_markdown('<textarea readonly="readonly" rows="3" cols="50">' . "\n" .
-                        'Differentiate \[x^2 + y^2\] with respect to \(x\).</textarea>'));
+                'Differentiate \[x^2 + y^2\] with respect to \(x\).</textarea>'));
+        }
 
         // Test CAS text with inline maths.
         $this->assertEquals('What is \[x^2\]?', stack_maths::process_display_castext('What is \(x^2\)?'));


### PR DESCRIPTION
Skip 2 asserts in Moodle < 4.1 as format_text ignores noclean option in 4.0.