### PR TITLE
Extend STACK-maxima-sandbox: 

### DIFF
--- a/doc/en/CAS/STACK-Maxima_sandbox.md
+++ b/doc/en/CAS/STACK-Maxima_sandbox.md
@@ -39,6 +39,7 @@ An alternative approach on a Microsoft operating system is to copy the contents 
     %USERPROFILE%/Maxima/stacklocal.mac
 
 Using `load("stacklocal")` in any worksheet will load the STACK environement.
+On Linux you can copy the file `stacklocal.mac` to your home directory `~/.maxima/`.
 
 ### Using the answer tests
 
@@ -98,6 +99,57 @@ ensure it contains the following lines, possibly modified to reflect the directo
 
 Other versions of Maxima are similar.
 
+## Using preconfigured files on Linux and Windows
+
+Here you will find some notes to support you to install and use  the  STACK Sandbox in Maxima including the plotting options. The good note is, that Gnuplot is delivered with Maxima on Windows. We can use it. For Linux you will find a file `moodle-qtype_stack_master/stack/maxima/stacklocallinux.mac` and for Window `moodle-qtype_stack_master/stack/maxima/stacklocalwin.mac`. Goal is to use the commands `load("stacklocalwin.mac")` or `load("stacklocallinux.mac")` in your Maxima worksheets.
+
+### Preparation
+
+The Maxima variable  `maxima_userdir` returns the user Maxima directory on your Linux or Windows machine. This is used to reduce the installation effort and no admin rights are needed.
+
+Unzip the zip-file `moodle-qtype_stack-master.zip` in your `maxima_userdir`, so that the code resides in `maxima_userdir/moodle-qtype_stack_master/`.
+Create the additional directories:
+  1. `maxima_userdir/moodle-qtype_stack_master/tmp/`
+  2. `maxima_userdir/plots/`
+  2. `maxima_userdir/tmp/`
+
+
+On Windows the directories are afterwords
+  1. `%USERPROFILE%\maxima\moodle-qtype_stack_master\`
+  1. `%USERPROFILE%\maxima\moodle-qtype_stack_master\tmp\`
+  1. `%USERPROFILE%\maxima\plots\`
+  1. `%USERPROFILE%\maxima\tmp\`
+
+On Linux the directories are afterwords
+  1. `~/.maxima/moodle-qtype_stack_master/`
+  1. `~/.maxima/moodle-qtype_stack_master/tmp/`
+  1. `~/.maxima/plots/`
+  1. `~/.maxima/tmp/`
+
+To use the STACK Sandbox in Maxima, just copy the file `stacklocalwin.mac` or `stacklocallinux.mac` into your `maxima_userdir`. Thus it is available for the `load` command. 
+
+If git is available on your machine, you got to `maxima_userdir` in terminal an run the command `git pull https://github.com/maths/moodle-qtype_stack/` and move `moodle-qtype_stack` to `moodle-qtype_stack-master`.
+
+### Troubleshouting
+
+Sometimes one has to adjust the path to the directory where the svg are saved. Please try 
+`IMAGE_DIR:sconcat(maxima_userdir,"/plots/")` if `IMAGE_DIR:sconcat(maxima_userdir,"/plots")` does not work. (And vice versa).
+
+
+### Lets plot
+
+To show the plots produced by STACK a small loop way is used. STACK stores the plot in an SVG file, which is written to a temporary directory. To show the plots an html file `maxima_userdir/plots/test.html` is used. To generate the file use  `add2HTML(string,fileappend)` is used.
+The code looks like:
+```
+load("stacklocalwin.mac");
+res:plot(cos(x),[x,0,6]);
+add2HTML(res,false);
+showHTML();
+```
+A file `testPlot.wxm` is in `stack/maxima/` included.
+
+If you are not using Firefox on your Linux, you can adjust your browser in `stacklocallinux.mac`.
+
 ## Reflecting the settings on your server
 
 The healtcheck page (Moodle admin access only) displays the contents of the Maxima configuration file which is written to the sever.  This contains Maxima commands to update the path (which you probably don't want to copy) and also the function `STACK_SETUP(ex)` which configures your particular version of STACK.  You may want to replace `STACK_SETUP(ex)` in the sandbox with `STACK_SETUP(ex)` from the Moodle server. For most users this should not be needed, and is most useful for advanced debugging where significant differences between versions matters.
@@ -107,3 +159,5 @@ It is more important to match the version of the STACK code you downloaded from 
     https://stack-demo.maths.ed.ac.uk/demo/question/type/stack/doc/doc.php/
 
 shows the version of the STACK code the demo site is running. 
+
+`{@stackmaximaversion@}` and `{@MAXIMA_VERSION@}` in a question text will return the STACK and Maxima version installed on your LMS.

--- a/stack/maxima/stacklocallinux.mac
+++ b/stack/maxima/stacklocallinux.mac
@@ -1,0 +1,47 @@
+/* Download Maxima 5.44.0 https://altushost-swe.dl.sourceforge.net/project/maxima/Maxima-Windows/5.44.0-Windows/maxima-clisp-sbcl-5.44.0-win64.exe */
+maximaplatform:"linux";
+stacklocation:sconcat(maxima_userdir,"/moodle-qtype_stack-master");
+stacktmplocation:sconcat(maxima_userdir,"/moodle-qtype_stack-master/tmp");
+file_search_maxima:append( [sconcat(stacklocation, "/stack/maxima/###.{mac,mc}")] , file_search_maxima);
+file_search_lisp:append( [sconcat(stacklocation, "/stack/maxima/###.{lisp}")] , file_search_lisp);
+file_search_maxima:append( [sconcat(stacktmplocation, "/###.{mac,mc}")] , file_search_maxima);
+file_search_lisp:append( [sconcat(stacktmplocation, "/###.{lisp}")] , file_search_lisp);
+
+STACK_SETUP(ex):=block(
+    MAXIMA_VERSION_NUM_EXPECTED:0,
+    MAXIMA_PLATFORM:"linux",
+    maxima_tempdir:sconcat(maxima_userdir,"/tmp"),
+    IMAGE_DIR:sconcat(maxima_userdir,"/plots/"),
+    PLOT_SIZE:[450,300],
+    PLOT_TERMINAL:"svg",
+    PLOT_TERM_OPT:"dynamic font \",11\" linewidth 1.2",
+    DEL_CMD:"rm",
+    GNUPLOT_CMD:"gnuplot",
+    URL_BASE:sconcat("file:///",IMAGE_DIR),
+    
+    MAXIMA_VERSION_EXPECTED:"default",
+    /* Define units available in STACK. */
+    stack_unit_si_prefix_code:[y, z, a, f, p, n, u, m, c, d, da, h, k, M, G, T, P, E, Z, Y],
+    stack_unit_si_prefix_multiplier:[10^-24, 10^-21, 10^-18, 10^-15, 10^-12, 10^-9, 10^-6, 10^-3, 10^-2, 10^-1, 10, 10^2, 10^3, 10^6, 10^9, 10^12, 10^15, 10^18, 10^21, 10^24],
+    stack_unit_si_prefix_tex:["\\mathrm{y}", "\\mathrm{z}", "\\mathrm{a}", "\\mathrm{f}", "\\mathrm{p}", "\\mathrm{n}", "\\mu ", "\\mathrm{m}", "\\mathrm{c}", "\\mathrm{d}", "\\mathrm{da}", "\\mathrm{h}", "\\mathrm{k}", "\\mathrm{M}", "\\mathrm{G}", "\\mathrm{T}", "\\mathrm{P}", "\\mathrm{E}", "\\mathrm{Z}", "\\mathrm{Y}"],
+    stack_unit_si_unit_code:[m, l, L, g, t, s, h, Hz, Bq, cd, N, Pa, cal, Cal, Btu, eV, J, W, A, ohm, C, V, F, S, Wb, T, H, Gy, rem, Sv, lx, lm, mol, M, kat, rad, sr, K, VA, eV],
+    stack_unit_si_unit_conversions:[m, m^3/1000, m^3/1000, kg/1000, 1000*kg, s, s*3600, 1/s, 1/s, cd, (kg*m)/s^2, kg/(m*s^2), 4.2*J, 4200*J, 1055*J, 1.602177e-19*J, (kg*m^2)/s^2, (kg*m^2)/s^3, A, (kg*m^2)/(s^3*A^2), s*A, (kg*m^2)/(s^3*A), (s^4*A^2)/(kg*m^2), (s^3*A^2)/(kg*m^2), (kg*m^2)/(s^2*A), kg/(s^2*A), (kg*m^2)/(s^2*A^2), m^2/s^2, 0.01*Sv, m^2/s^2, cd/m^2, cd, mol, mol/(m^3/1000), mol/s, rad, sr, K, (kg*m^2)/(s^3), 1.602176634E-19*J],
+    stack_unit_si_unit_tex:["\\mathrm{m}", "\\mathrm{l}", "\\mathrm{L}", "\\mathrm{g}", "\\mathrm{t}", "\\mathrm{s}", "\\mathrm{h}", "\\mathrm{Hz}", "\\mathrm{Bq}", "\\mathrm{cd}", "\\mathrm{N}", "\\mathrm{Pa}", "\\mathrm{cal}", "\\mathrm{cal}", "\\mathrm{Btu}", "\\mathrm{eV}", "\\mathrm{J}", "\\mathrm{W}", "\\mathrm{A}", "\\Omega", "\\mathrm{C}", "\\mathrm{V}", "\\mathrm{F}", "\\mathrm{S}", "\\mathrm{Wb}", "\\mathrm{T}", "\\mathrm{H}", "\\mathrm{Gy}", "\\mathrm{rem}", "\\mathrm{Sv}", "\\mathrm{lx}", "\\mathrm{lm}", "\\mathrm{mol}", "\\mathrm{M}", "\\mathrm{kat}", "\\mathrm{rad}", "\\mathrm{sr}", "\\mathrm{K}", "\\mathrm{VA}", "\\mathrm{eV}"],
+    stack_unit_other_unit_code:[min, amu, u, mmHg, bar, ha, cc, gal, mbar, atm, torr, rev, deg, rpm, au, Da, Np, B, dB, day, year, hp, in, ft, yd, mi, lb],
+    stack_unit_other_unit_conversions:[s*60, amu, amu, 133.322387415*Pa, 10^5*Pa, 10^4*m^2, m^3*10^(-6), 3.785*l, 10^2*Pa, 101325*Pa, 101325/760*Pa, 2*pi*rad, pi*rad/180, pi*rad/(30*s), 149597870700*m, 1.660539040E-27*kg, Np, B, dB, 86400*s, 3.156e7*s, hp, in, 12*in, 36*in, 5280*12*in, lb],
+    stack_unit_other_unit_tex:["\\mathrm{min}", "\\mathrm{amu}", "\\mathrm{u}", "\\mathrm{mmHg}", "\\mathrm{bar}", "\\mathrm{ha}", "\\mathrm{cc}", "\\mathrm{gal}", "\\mathrm{mbar}", "\\mathrm{atm}", "\\mathrm{torr}", "\\mathrm{rev}", "\\mathrm{{}^{o}}", "\\mathrm{rpm}", "\\mathrm{au}", "\\mathrm{Da}", "\\mathrm{Np}", "\\mathrm{B}", "\\mathrm{dB}", "\\mathrm{day}", "\\mathrm{year}", "\\mathrm{hp}", "\\mathrm{in}", "\\mathrm{ft}", "\\mathrm{yd}", "\\mathrm{mi}", "\\mathrm{lb}"],
+    true)$
+
+/* Load the main libraries. */
+load("stackmaxima.mac")$
+load("stats")$
+load("distrib")$
+load("descriptive")$
+print(sconcat("[ STACK-Maxima started, library version ", stackmaximaversion, " ]"))$
+/* Optional but useful. */
+display2d:true;
+simp:true;
+print(sconcat("States: display2d=",display2d,", simp=",simp,", debug=",debug))$
+/* Function to show the generated image, helper file IMAGE_DIR/test.html */
+add2HTML(string,fileappend):=(FILEOUT:file_output_append,file_output_append:fileappend,stringout(sconcat(IMAGE_DIR,"test.html"),sconcat(string,"<br/>")),file_output_append:FILEOUT)$
+showHTML():=(system(sconcat("firefox ",IMAGE_DIR,"test.html")))$

--- a/stack/maxima/stacklocalwin.mac
+++ b/stack/maxima/stacklocalwin.mac
@@ -1,0 +1,47 @@
+	/* Download Maxima 5.44.0 https://altushost-swe.dl.sourceforge.net/project/maxima/Maxima-Windows/5.44.0-Windows/maxima-clisp-sbcl-5.44.0-win64.exe */
+maximaplatform:"win";
+stacklocation:sconcat(maxima_userdir,"/moodle-qtype_stack-master");
+stacktmplocation:sconcat(maxima_userdir,"/moodle-qtype_stack-master/tmp");
+file_search_maxima:append( [sconcat(stacklocation, "/stack/maxima/###.{mac,mc}")] , file_search_maxima);
+file_search_lisp:append( [sconcat(stacklocation, "/stack/maxima/###.{lisp}")] , file_search_lisp);
+file_search_maxima:append( [sconcat(stacktmplocation, "/###.{mac,mc}")] , file_search_maxima);
+file_search_lisp:append( [sconcat(stacktmplocation, "/###.{lisp}")] , file_search_lisp);
+
+STACK_SETUP(ex):=block(
+    MAXIMA_VERSION_NUM_EXPECTED:0,
+    MAXIMA_PLATFORM:"win",
+    maxima_tempdir:sconcat(maxima_userdir,"/tmp/"),
+    IMAGE_DIR:sconcat(maxima_userdir,"/plots/"),
+    PLOT_SIZE:[450,300],
+    PLOT_TERMINAL:"svg",
+    PLOT_TERM_OPT:"dynamic font \",11\" linewidth 1.2",
+    DEL_CMD:"del",
+    GNUPLOT_CMD:sconcat("c:/maxima-",build_info()@version,"/gnuplot/bin/gnuplot.exe"),
+    URL_BASE:sconcat("file:///",IMAGE_DIR),
+    
+    MAXIMA_VERSION_EXPECTED:"default",
+    /* Define units available in STACK. */
+    stack_unit_si_prefix_code:[y, z, a, f, p, n, u, m, c, d, da, h, k, M, G, T, P, E, Z, Y],
+    stack_unit_si_prefix_multiplier:[10^-24, 10^-21, 10^-18, 10^-15, 10^-12, 10^-9, 10^-6, 10^-3, 10^-2, 10^-1, 10, 10^2, 10^3, 10^6, 10^9, 10^12, 10^15, 10^18, 10^21, 10^24],
+    stack_unit_si_prefix_tex:["\\mathrm{y}", "\\mathrm{z}", "\\mathrm{a}", "\\mathrm{f}", "\\mathrm{p}", "\\mathrm{n}", "\\mu ", "\\mathrm{m}", "\\mathrm{c}", "\\mathrm{d}", "\\mathrm{da}", "\\mathrm{h}", "\\mathrm{k}", "\\mathrm{M}", "\\mathrm{G}", "\\mathrm{T}", "\\mathrm{P}", "\\mathrm{E}", "\\mathrm{Z}", "\\mathrm{Y}"],
+    stack_unit_si_unit_code:[m, l, L, g, t, s, h, Hz, Bq, cd, N, Pa, cal, Cal, Btu, eV, J, W, A, ohm, C, V, F, S, Wb, T, H, Gy, rem, Sv, lx, lm, mol, M, kat, rad, sr, K, VA, eV],
+    stack_unit_si_unit_conversions:[m, m^3/1000, m^3/1000, kg/1000, 1000*kg, s, s*3600, 1/s, 1/s, cd, (kg*m)/s^2, kg/(m*s^2), 4.2*J, 4200*J, 1055*J, 1.602177e-19*J, (kg*m^2)/s^2, (kg*m^2)/s^3, A, (kg*m^2)/(s^3*A^2), s*A, (kg*m^2)/(s^3*A), (s^4*A^2)/(kg*m^2), (s^3*A^2)/(kg*m^2), (kg*m^2)/(s^2*A), kg/(s^2*A), (kg*m^2)/(s^2*A^2), m^2/s^2, 0.01*Sv, m^2/s^2, cd/m^2, cd, mol, mol/(m^3/1000), mol/s, rad, sr, K, (kg*m^2)/(s^3), 1.602176634E-19*J],
+    stack_unit_si_unit_tex:["\\mathrm{m}", "\\mathrm{l}", "\\mathrm{L}", "\\mathrm{g}", "\\mathrm{t}", "\\mathrm{s}", "\\mathrm{h}", "\\mathrm{Hz}", "\\mathrm{Bq}", "\\mathrm{cd}", "\\mathrm{N}", "\\mathrm{Pa}", "\\mathrm{cal}", "\\mathrm{cal}", "\\mathrm{Btu}", "\\mathrm{eV}", "\\mathrm{J}", "\\mathrm{W}", "\\mathrm{A}", "\\Omega", "\\mathrm{C}", "\\mathrm{V}", "\\mathrm{F}", "\\mathrm{S}", "\\mathrm{Wb}", "\\mathrm{T}", "\\mathrm{H}", "\\mathrm{Gy}", "\\mathrm{rem}", "\\mathrm{Sv}", "\\mathrm{lx}", "\\mathrm{lm}", "\\mathrm{mol}", "\\mathrm{M}", "\\mathrm{kat}", "\\mathrm{rad}", "\\mathrm{sr}", "\\mathrm{K}", "\\mathrm{VA}", "\\mathrm{eV}"],
+    stack_unit_other_unit_code:[min, amu, u, mmHg, bar, ha, cc, gal, mbar, atm, torr, rev, deg, rpm, au, Da, Np, B, dB, day, year, hp, in, ft, yd, mi, lb],
+    stack_unit_other_unit_conversions:[s*60, amu, amu, 133.322387415*Pa, 10^5*Pa, 10^4*m^2, m^3*10^(-6), 3.785*l, 10^2*Pa, 101325*Pa, 101325/760*Pa, 2*pi*rad, pi*rad/180, pi*rad/(30*s), 149597870700*m, 1.660539040E-27*kg, Np, B, dB, 86400*s, 3.156e7*s, hp, in, 12*in, 36*in, 5280*12*in, lb],
+    stack_unit_other_unit_tex:["\\mathrm{min}", "\\mathrm{amu}", "\\mathrm{u}", "\\mathrm{mmHg}", "\\mathrm{bar}", "\\mathrm{ha}", "\\mathrm{cc}", "\\mathrm{gal}", "\\mathrm{mbar}", "\\mathrm{atm}", "\\mathrm{torr}", "\\mathrm{rev}", "\\mathrm{{}^{o}}", "\\mathrm{rpm}", "\\mathrm{au}", "\\mathrm{Da}", "\\mathrm{Np}", "\\mathrm{B}", "\\mathrm{dB}", "\\mathrm{day}", "\\mathrm{year}", "\\mathrm{hp}", "\\mathrm{in}", "\\mathrm{ft}", "\\mathrm{yd}", "\\mathrm{mi}", "\\mathrm{lb}"],
+    true)$
+
+/* Load the main libraries. */
+load("stackmaxima.mac")$
+load("stats")$
+load("distrib")$
+load("descriptive")$
+print(sconcat("[ STACK-Maxima started, library version ", stackmaximaversion, " ]"))$
+/* Optional but useful. */
+display2d:true;
+simp:true;
+print(sconcat("States: display2d=",display2d,", simp=",simp,", debug=",debug))$
+/* Function to show the generated image, helper file IMAGE_DIR/test.html */
+add2HTML(string,fileappend):=(FILEOUT:file_output_append,file_output_append:fileappend,stringout(sconcat(IMAGE_DIR,"test.html"),sconcat(string,"<br/>")),file_output_append:FILEOUT)$
+showHTML():=(system(sconcat(IMAGE_DIR,"test.html")))$

--- a/stack/maxima/testPlotLinux.wxm
+++ b/stack/maxima/testPlotLinux.wxm
@@ -1,0 +1,65 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 22.04.0 ] */
+/* [wxMaxima: input   start ] */
+quit();
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("stacklocalwin.mac");
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Test STACK
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rand(matrix([5,5],[5,5]));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Directory for maxima plot2d (gnuplot file)
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+res2d:plot2d(sin(x),[x,0,6]);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Call the STACK plot command
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+res:plot(cos(x),[x,0,6]);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Add the resulting string the file maxima_userdir/test.html. Since it should be a fresh file, we use fileappend:false.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+add2HTML(res,false);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+To open the file you can call
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+showHTML();
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 22.04.0"$

--- a/stack/maxima/testPlotWin.wxm
+++ b/stack/maxima/testPlotWin.wxm
@@ -1,0 +1,60 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 22.04.0 ] */
+/* [wxMaxima: input   start ] */
+load("stacklocalwin.mac");
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Test STACK
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+rand(matrix([5,5],[5,5]));
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Directory for maxima plot2d (gnuplot file)
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+res2d:plot2d(sin(x),[x,0,6]);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Call the STACK plot command
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+res:plot(cos(x),[x,0,6]);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Add the resulting string the file maxima_userdir/plots/test.html. Since it should be a fresh file, we use fileappend:false.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+add2HTML(res,false);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+To open the file you can call
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+showHTML();
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 22.04.0"$


### PR DESCRIPTION
Adding a suggestion to configure the sandbox in the page STACK-Maxima_sandbox.

## Idea: 

Use the maxima user dir, the access inside Maxima is independent from Windows or Linux
add the plot generation based on gnuplot.

## Plotting: Add four files to stack/maxima/

- Config files for Windows and Linux (stacklocalwin.mac, stacklocallinux.mac)
- Testing: testPlotWin.wmx, testPlotLinux.wmx
Copy the files into 


Realization:
create directores `maxima_userdir/plots/` and `maxima_userdir/tmp/` and adjust variables `maxima_tempdir`, `IMAGE_DIR` and `URL_BASE`. On Windows gnuplot comes with Maxima, the path is obtained by `sconcat("c:/maxima-",build_info()@version,"/gnuplot/bin/gnuplot.exe")` 

To show the images, a file `test.html`in `maxima_userdir/plots/` is generated by a new command `add2HTML(string,fileappend)`. The file can be opened by `showHTML()`. The command `add2HTML` allows to add as the output of `plot` as arbitrary strings.
On Linux `showHTML()` expects Firefox, but the commandline can be adjusted in `stacklocallinux.mac`.

### Note
The flag `maximaplatform` is not used; before the evaluation of `STACK_SETUP` it seems to be reset in `stack_reset`.

