### PR TITLE
Update security-map.json

### DIFF
--- a/stack/cas/security-map.json
+++ b/stack/cas/security-map.json
@@ -7510,7 +7510,7 @@
       "function": "?"
   },
   "stringdisp": {
-      "variable": "f"
+      "variable": "t"
   },
   "stringout": {
       "function": "f",


### PR DESCRIPTION
Can we allow the variable "stringdisp" for teachers or are there any security or design concerns about this? 
I never use string functions or variables for calculations, but sometimes they could be useful for feedback. I often define a ternary function like _ternary(bool, exp1, exp2)_ anyway and it is sometimes clearer to use this function than an [[if]] [[else]] [[/if]] construction, e.g. in a singular/plural situation. Example: _{#n#} parameters are correct_ is grammatically wrong when n=1. So I like to write _{#n#} {#ternary(n=1,"parameter is", "parameters are")#} correct_, but then I get unwanted quotes in the feedback. There are surely many other ways to solve such problems, but an easy way would be to allow "stringdisp".