### PR TITLE
Correct Parson's input type for matching problems

### DIFF
--- a/doc/en/Authoring/Matching.md
+++ b/doc/en/Authoring/Matching.md
@@ -7,15 +7,25 @@ The combinations of these two parameters define three possible layout configurat
 2. **Column grouping** (`[[parsons columns="n"]] [[/parsons]]`) : If `columns="n"` is specified and `rows` is unspecified, this will lay out `n` _vertically arranged_ answer lists that items must be dragged to and an additional vertical available list that items must be dragged from. In this case, the lists can be arbitrary length and must be grown from the top downwards just as in the **Proof** layout. Via the reorientation button, the student is able to switch orientation between this and a row grouping setting (where answer lists are arranged as rows that are arbitrary length and grow from the left rightwards).
 4. **Grid** (`[[parsons columns="n" rows="m"]] [[/parsons]]`) : If both `columns="n"` and `rows="m"` are specified, then this will lay out an `m` by `n` answer grid that items must be dragged to and a vertical available list that items must be dragged from. In this case, individual items can be passed to any position in the grid. The user also has the option to re-orient the grid to have `m` columns and `n` rows via the reorientation button.
 
-The basic usage of all four modes are the exact same as [the Proof case](Parsons.md#authoring-json-within-the-question-text-itself), one can just modify the block parameters as specified. For example
+The basic usage of all four modes are the exact same as [the Proof case](Parsons.md#Basic-usage), one can just modify the block parameters as specified. For example:
+
+#### Question variables
+
+```
+stack_include_contrib("matchlib.mac");
+
+steps: [
+    ["f", "\\(y = x^2\\)"],
+    ["g", "\\(y = x^3\\)"],
+    ["quad", "Quadratic"],
+    ["cubic", "Cubic"],
+]
+```
+
+#### Question text
 ```
 [[parsons columns="2"]]
-{
-    "f" : "\\(y = x^2\\)",
-    "g" : "\\(y = x^3\\)",
-    "quad" : "Quadratic",
-    "cubic" : "Cubic",
-}
+{# match_encode(steps) #}
 [[/parsons]]
 ```
 ## Clone mode
@@ -31,15 +41,25 @@ The re-orientation button allows the student to switch between vertical and hori
 By default, answer lists in groupings and grid layouts will get default headers indexed by positive whole numbers. The available list will get a default header of "Drag from here:". These will become row indexes in **Row grouping** layout, or when the user presses the re-orient button.
 
 Answer list headers can be changed by assigning the key `"headers"` key an an array of strings containing the new headers. The single header for the available list can be changed by assigning the `"available_header"` key to a string.
+
+#### Question variables
+
+```
+stack_include_contrib("matchlib.mac");
+
+steps: [
+    ["f", "\\(y = x^2\\)"],
+    ["g", "\\(y = x^3\\)"],
+    ["quad", "Quadratic"],
+    ["cubic", "Cubic"],
+]
+```
+
+#### Question text 
 ```
 [[parsons columns="2"]]
 {
-    "steps": {
-        "f" : "\\(y = x^2\\)",
-        "g" : "\\(y = x^3\\)",
-        "quad" : "Quadratic",
-        "cubic" : "Cubic",
-    },
+    "steps" : {# match_encode(steps) #},
     "headers" : ["Equation", "Type"],
     "available_header" : "Available items"
 }
@@ -57,10 +77,7 @@ To change this, one can pass an index to the JSON as follows:
 ```
 [[parsons columns="1" rows="2"]]
 {
-    "steps": {
-        "quad" : "Quadratic",
-        "cubic" : "Cubic",
-    },
+    "steps": {# match_encode(steps) #},
     "headers" : ["Type"]
     "available_header" : "Available items"
     "index" : ["Equation", "\\(y = x^2\\)", "\\(y = x^3\\)"]

--- a/doc/en/Topics/Matching.md
+++ b/doc/en/Topics/Matching.md
@@ -131,7 +131,7 @@ steps : [
     ["sin", "\\(f(x) = \\sin(x)\\)"],
     ["abs", "\\(f(x) = |x|\\)"],
     ["sqrt", "\\(f(x) = \\sqrt{|x|}\\)"],
-    ["rec", "\\(f(x) = \\left\{\\begin{array}{ll}1/x &, x\\neq 0 \\\\ 0&, x=0\\end{array}\\right.\\)"],
+    ["rec", "\\(f(x) = \\left\\{\\begin{array}{ll}1/x &, x\\neq 0 \\\\ 0&, x=0\\end{array}\\right.\\)"],
     ["sgn", "\\(f(x) = \\text{sgn}(x)\\)"]
 ];
 
@@ -143,7 +143,7 @@ headers: [
     "Discontinuous"
 ];
 
-ans: [
+ta: [
     ["sq", "sin"], 
     ["abs", "sqrt"], 
     ["rec", "sgn"]
@@ -181,7 +181,7 @@ A question note is required due to the random permutation of `steps`. We use:
 ### Input: ans1
 
 1. The _Input type_ field should be **Parsons**.
-2. The _Model answer_ field should construct a JSON object from the teacher's answer `ans` using `match_answer(ans, steps)`.
+2. The _Model answer_ field should be a list `[ta, steps, 3]` containing the teacher answer, all possible steps and the number of columns.
 3. Set the option _Student must verify_ to "no".
 4. Set the option _Show the validation_ to "no".
 
@@ -199,7 +199,7 @@ In this case, the order _within_ a column really doesn't matter, but the order o
 So we may convert the columns of `sans` and `ans` to sets in feedback variables using `match_column_set` from `matchlib.mac`.
 ```
 sans: match_column_set(sans);
-ans: match_column_set(ans);
+tans: match_column_set(ta);
 ```
 We can then do a regular algebraic equivalence test between `sans` and `ans`. You should turn the node to `Quiet: Yes`, otherwise the student will see unhelpful code if they the answer wrong.
 
@@ -249,7 +249,7 @@ headers: [
   "\\(d^2/d^2x\\)"
 ];
 
-ans: [
+ta: [
   ["f", "g"], 
   ["dfdx", "dgdx"], 
   ["df2d2x", "dg2d2x"]
@@ -285,7 +285,8 @@ A question note is required due to the random permutation of `steps`. We use:
 ### Input: ans1
 
 1. The _Input type_ field should be **Parsons**.
-2. The _Model answer_ field should construct a JSON object from the teacher's answer `ta` using `match_answer(ans, steps, true)`.
+2. The _Model answer_ field should be a list `[ta, steps, 3, 2]` containing the teacher answer, all possible steps, the number of columns, 
+and the number of rows.
 3. Set the option _Student must verify_ to "no".
 4. Set the option _Show the validation_ to "no".
 
@@ -302,7 +303,7 @@ This provides the student response as a two-dimensional array of the same format
 At this point the author may choose to assess by comparing `sans` and `ans` as they see fit. In this case, the _order of the rows themselves_ really doesn't matter, but the order of the rows does of course. So we may convert the list of rows of `sans` and `ans` to a set in feedback variables using `match_set_row` from `matchlib.mac`.
 ```
 sans: match_set_row(sans);
-ans: match_set_row(ans);
+tans: match_set_row(ta);
 ```
 We can then do a regular algebraic equivalence test between `sans` and `ans`. 
 You should turn the node to `Quiet: Yes`, otherwise the student will see unhelpful code if they the answer wrong.
@@ -344,7 +345,7 @@ index: [
   "\\(y = x^3\\)"
 ]
 
-ans: [
+ta: [
   ["dfdx", "dgdx"], 
   ["df2d2x", "dg2d2x"]
 ];
@@ -376,7 +377,8 @@ A question note is required due to the random permutation of `steps`. We use:
 This is exactly the same as Example 2. 
 
 1. The _Input type_ field should be **Parsons**.
-2. The _Model answer_ field should construct a JSON object from the teacher's answer `ta` using `match_answer(ans, steps, true)`.
+2. The _Model answer_ field should be a list `[ta, steps, 2, 2]` containing the teacher answer, all possible steps, the number of columns, 
+and the number of rows.
 3. Set the option _Student must verify_ to "no".
 4. Set the option _Show the validation_ to "no".
 
@@ -386,9 +388,9 @@ As in Example 2, we first extract the two-dimensional array of used items from t
 ```
 sans: match_decode(ans1, true);
 ```
-At this point the author may choose to assess by comparing `sans` and `ans` as they see fit. 
-Since we have fixed the order of both dimensions, there is only one correct answer which is given by `ans`. 
-Hence we have a basic PRT which tests only algebraic equivalence between `sans` and `ans`. 
+At this point the author may choose to assess by comparing `sans` and `ta` as they see fit. 
+Since we have fixed the order of both dimensions, there is only one correct answer which is given by `ta`. 
+Hence we have a basic PRT which tests only algebraic equivalence between `sans` and `ta`. 
 As always, turn the node to `Quiet: Yes`, otherwise the student will see unhelpful code if they the answer wrong.
 
 ## Example 4 : Using images
@@ -417,7 +419,7 @@ steps: random_permutation(steps);
 
 headers: ["Function", "\\(d/dx\\)", "\\(d^2/d^2x\\)"];
 
-ans: [
+ta: [
   ["f", "g"], 
   ["dfdx", "dgdx"], 
   ["df2d2x", "dg2d2x"]

--- a/samplequestions/Parsons-examples.xml
+++ b/samplequestions/Parsons-examples.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <quiz>
-<!-- question: 36690  -->
+<!-- question: 0  -->
+  <question type="category">
+    <category>
+      <text>$course$/top/Default for Parsons</text>
+    </category>
+    <info format="moodle_auto_format">
+      <text>The default category for questions shared in context 'Parsons'.</text>
+    </info>
+    <idnumber></idnumber>
+  </question>
+
+<!-- question: 151  -->
   <question type="stack">
     <name>
       <text>irrational-power-irrational (illustrates re-use of strings)</text>
@@ -8,16 +19,12 @@
     <questiontext format="html">
       <text><![CDATA[<p>Prove: {@thm@}</p>
 [[parsons input="ans1" clone="true" height="550px"]]
-{# stackjson_stringify(proof_steps) #}
+{# parsons_encode(proof_steps) #}
 [[/parsons ]]
-
-<p style="display:none">[[input:ans1]] [[validation:ans1]]</p>
-<p style="display:none">[[input:ans2]] [[validation:ans2]]</p>]]></text>
+<p>[[input:ans1]] [[validation:ans1]]</p>]]></text>
     </questiontext>
     <generalfeedback format="html">
-      <text><![CDATA[This is the proof, written with some structure
-{@proof_display(tal[2], proof_steps)@}
-Notice this proof has two sub-proofs, which can occur in any order.  Therefore we have two correct versions of this proof.
+      <text><![CDATA[Notice this proof has two sub-proofs, which can occur in any order.  Therefore we have two correct versions of this proof.
 <table><tr>
 <td><div class="proof">{@proof_display_para(tal[1], proof_steps)@}</div></td>
 <td><div class="proof">{@proof_display_para(tal[2], proof_steps)@}</div></td>
@@ -29,7 +36,7 @@ Can you see the differences between these proofs?]]></text>
     <hidden>0</hidden>
     <idnumber></idnumber>
     <stackversion>
-      <text>2023111600</text>
+      <text>2024092500</text>
     </stackversion>
     <questionvariables>
       <text><![CDATA[stack_include("contribl://prooflib.mac");
@@ -40,13 +47,12 @@ ta:proof_keys_sub(ta, proof_steps);
 
 proof_steps:random_permutation(proof_steps);
 
-tal:proof_alternatives(ta);
-]]></text>
+tal:proof_alternatives(ta);]]></text>
     </questionvariables>
     <specificfeedback format="html">
       <text>[[feedback:prt1]]</text>
     </specificfeedback>
-    <questionnote>
+    <questionnote format="html">
       <text>{@map(first, proof_steps)@}</text>
     </questionnote>
     <questiondescription format="moodle_auto_format">
@@ -65,6 +71,7 @@ tal:proof_alternatives(ta);
       <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
     </prtincorrect>
     <decimals>.</decimals>
+    <scientificnotation>*10</scientificnotation>
     <multiplicationsign>dot</multiplicationsign>
     <sqrtsign>1</sqrtsign>
     <complexno>i</complexno>
@@ -74,26 +81,8 @@ tal:proof_alternatives(ta);
     <variantsselectionseed></variantsselectionseed>
     <input>
       <name>ans1</name>
-      <type>string</type>
-      <tans>proof_parsons_key_json(ta, [])</tans>
-      <boxsize>15</boxsize>
-      <strictsyntax>1</strictsyntax>
-      <insertstars>0</insertstars>
-      <syntaxhint></syntaxhint>
-      <syntaxattribute>0</syntaxattribute>
-      <forbidwords></forbidwords>
-      <allowwords></allowwords>
-      <forbidfloat>1</forbidfloat>
-      <requirelowestterms>0</requirelowestterms>
-      <checkanswertype>0</checkanswertype>
-      <mustverify>0</mustverify>
-      <showvalidation>0</showvalidation>
-      <options>hideanswer</options>
-    </input>
-    <input>
-      <name>ans2</name>
-      <type>string</type>
-      <tans>proof_display(ta, proof_steps)</tans>
+      <type>parsons</type>
+      <tans>[ta, proof_steps]</tans>
       <boxsize>15</boxsize>
       <strictsyntax>1</strictsyntax>
       <insertstars>0</insertstars>
@@ -114,9 +103,8 @@ tal:proof_alternatives(ta);
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>sa:proof_parsons_interpret(ans1);
-[pd,saa]:proof_assessment(sa, proof_alternatives(ta));
-</text>
+        <text>sa:parsons_decode(ans1);
+[pd,saa]:proof_assessment(sa, proof_alternatives(ta));</text>
       </feedbackvariables>
       <node>
         <name>0</name>
@@ -150,11 +138,7 @@ tal:proof_alternatives(ta);
       <description>Test case assuming the teacher's input gets full marks.</description>
       <testinput>
         <name>ans1</name>
-        <value>proof_parsons_key_json(ta, [])</value>
-      </testinput>
-      <testinput>
-        <name>ans2</name>
-        <value>proof_display(ta, proof_steps)</value>
+        <value>apply(parsons_answer,[ta, proof_steps])</value>
       </testinput>
       <expected>
         <name>prt1</name>
@@ -165,7 +149,7 @@ tal:proof_alternatives(ta);
     </qtest>
   </question>
 
-<!-- question: 35561  -->
+<!-- question: 149  -->
   <question type="stack">
     <name>
       <text>log-two-three-irrational</text>
@@ -174,24 +158,21 @@ tal:proof_alternatives(ta);
       <text><![CDATA[<p>Prove: {@thm@}</p>
 <p>Drag those strings needed to construct a correct proof.</p>
 [[parsons input="ans1" height="650px"]]
-{# stackjson_stringify(proof_steps) #}
+{# parsons_encode(proof_steps) #}
 [[/parsons ]]
 <p>(You can drag to re-order or remove strings.  Double tap to add at the end, or remove.)
 
-<p style="display:none">[[input:ans1]] [[validation:ans1]]</p>
-<p style="display:none">[[input:ans2]] [[validation:ans2]]</p>]]></text>
+<p>[[input:ans1]] [[validation:ans1]]</p>]]></text>
     </questiontext>
     <generalfeedback format="html">
-      <text><![CDATA[This is the proof, written with some structure
-<p>Prove: {@thm@}</p>
-{@proof_display(first(tal), proof_steps)@}]]></text>
+      <text></text>
     </generalfeedback>
     <defaultgrade>1.0000000</defaultgrade>
     <penalty>0.1000000</penalty>
     <hidden>0</hidden>
     <idnumber></idnumber>
     <stackversion>
-      <text>2023111600</text>
+      <text>2024092500</text>
     </stackversion>
     <questionvariables>
       <text><![CDATA[stack_include("contribl://prooflib.mac");
@@ -201,13 +182,12 @@ ta:proof_ans;
 proof_steps:append(proof_steps,wrong_steps);
 proof_steps:random_permutation(proof_steps);
 
-tal:proof_alternatives(ta);
-]]></text>
+tal:proof_alternatives(ta);]]></text>
     </questionvariables>
     <specificfeedback format="html">
       <text>[[feedback:prt1]]</text>
     </specificfeedback>
-    <questionnote>
+    <questionnote format="html">
       <text>{@map(first, proof_steps)@}</text>
     </questionnote>
     <questiondescription format="moodle_auto_format">
@@ -226,6 +206,7 @@ tal:proof_alternatives(ta);
       <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
     </prtincorrect>
     <decimals>.</decimals>
+    <scientificnotation>*10</scientificnotation>
     <multiplicationsign>dot</multiplicationsign>
     <sqrtsign>1</sqrtsign>
     <complexno>i</complexno>
@@ -235,26 +216,8 @@ tal:proof_alternatives(ta);
     <variantsselectionseed></variantsselectionseed>
     <input>
       <name>ans1</name>
-      <type>string</type>
-      <tans>proof_parsons_key_json(ta, proof_steps)</tans>
-      <boxsize>15</boxsize>
-      <strictsyntax>1</strictsyntax>
-      <insertstars>0</insertstars>
-      <syntaxhint></syntaxhint>
-      <syntaxattribute>0</syntaxattribute>
-      <forbidwords></forbidwords>
-      <allowwords></allowwords>
-      <forbidfloat>1</forbidfloat>
-      <requirelowestterms>0</requirelowestterms>
-      <checkanswertype>0</checkanswertype>
-      <mustverify>0</mustverify>
-      <showvalidation>0</showvalidation>
-      <options>hideanswer</options>
-    </input>
-    <input>
-      <name>ans2</name>
-      <type>string</type>
-      <tans>proof_display(ta, proof_steps_prune(proof_steps))</tans>
+      <type>parsons</type>
+      <tans>[ta, proof_steps]</tans>
       <boxsize>15</boxsize>
       <strictsyntax>1</strictsyntax>
       <insertstars>0</insertstars>
@@ -275,9 +238,8 @@ tal:proof_alternatives(ta);
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>sa:proof_parsons_interpret(ans1);
-[pd,saa]:proof_assessment(sa, proof_alternatives(ta));
-</text>
+        <text>sa:parsons_decode(ans1);
+[pd,saa]:proof_assessment(sa, proof_alternatives(ta));</text>
       </feedbackvariables>
       <node>
         <name>0</name>
@@ -320,11 +282,7 @@ tal:proof_alternatives(ta);
       <description>Test case assuming the teacher's input gets full marks.</description>
       <testinput>
         <name>ans1</name>
-        <value>proof_parsons_key_json(ta, [])</value>
-      </testinput>
-      <testinput>
-        <name>ans2</name>
-        <value>proof_display(ta, proof_steps)</value>
+        <value>apply(parsons_answer,[ta, proof_steps])</value>
       </testinput>
       <expected>
         <name>prt1</name>
@@ -335,7 +293,7 @@ tal:proof_alternatives(ta);
     </qtest>
   </question>
 
-<!-- question: 36692  -->
+<!-- question: 153  -->
   <question type="stack">
     <name>
       <text>Parsons plot</text>
@@ -343,7 +301,7 @@ tal:proof_alternatives(ta);
     <questiontext format="html">
       <text><![CDATA[Arrange the plots in order of increasing algebraic degree.
 [[ parsons input="ans1" height="1000px"]]
-{# stackjson_stringify(proof_steps) #}
+{# parsons_encode(proof_steps) #}
 [[/parsons]]
 <p style="display:none">[[input:ans1]] [[validation:ans1]]</p>]]></text>
     </questiontext>
@@ -355,7 +313,7 @@ tal:proof_alternatives(ta);
     <hidden>0</hidden>
     <idnumber></idnumber>
     <stackversion>
-      <text>2023111600</text>
+      <text>2024092500</text>
     </stackversion>
     <questionvariables>
       <text><![CDATA[stack_include("contribl://prooflib.mac");
@@ -366,14 +324,12 @@ proof_steps:[
   [ "C", plot(x^2,[x,-1,1],[size,180,180],[margin,1.7],[yx_ratio, 1],[plottags,false])],
   [ "D", plot(x^3,[x,-1,1],[size,180,180],[margin,1.7],[yx_ratio, 1],[plottags,false])]
 ];
-proof_steps:random_permutation(proof_steps);
-
-]]></text>
+proof_steps:random_permutation(proof_steps);]]></text>
     </questionvariables>
     <specificfeedback format="html">
       <text>[[feedback:prt1]]</text>
     </specificfeedback>
-    <questionnote>
+    <questionnote format="html">
       <text>{@map(first, proof_steps)@}</text>
     </questionnote>
     <questiondescription format="html">
@@ -392,6 +348,7 @@ proof_steps:random_permutation(proof_steps);
       <text><![CDATA[<span style="font-size: 1.5em; color:red;"><i class="fa fa-times"></i></span> Incorrect answer.]]></text>
     </prtincorrect>
     <decimals>.</decimals>
+    <scientificnotation>*10</scientificnotation>
     <multiplicationsign>dot</multiplicationsign>
     <sqrtsign>1</sqrtsign>
     <complexno>i</complexno>
@@ -401,8 +358,8 @@ proof_steps:random_permutation(proof_steps);
     <variantsselectionseed></variantsselectionseed>
     <input>
       <name>ans1</name>
-      <type>string</type>
-      <tans>proof_parsons_key_json(ta, [])</tans>
+      <type>parsons</type>
+      <tans>[ta, proof_steps]</tans>
       <boxsize>15</boxsize>
       <strictsyntax>1</strictsyntax>
       <insertstars>0</insertstars>
@@ -415,7 +372,7 @@ proof_steps:random_permutation(proof_steps);
       <checkanswertype>0</checkanswertype>
       <mustverify>0</mustverify>
       <showvalidation>0</showvalidation>
-      <options>hideanswer</options>
+      <options></options>
     </input>
     <prt>
       <name>prt1</name>
@@ -423,9 +380,8 @@ proof_steps:random_permutation(proof_steps);
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>sa:proof_parsons_interpret(ans1);
-[pd,saa]:proof_assessment(sa, proof_alternatives(ta));
-</text>
+        <text>sa:parsons_decode(ans1);
+[pd,saa]:proof_assessment(sa, proof_alternatives(ta));</text>
       </feedbackvariables>
       <node>
         <name>0</name>
@@ -463,7 +419,7 @@ proof_steps:random_permutation(proof_steps);
       <description>Test case assuming the teacher's input gets full marks.</description>
       <testinput>
         <name>ans1</name>
-        <value>proof_parsons_key_json(ta, [])</value>
+        <value>apply(parsons_answer,[ta, proof_steps])</value>
       </testinput>
       <expected>
         <name>prt1</name>

--- a/stack/input/parsons/parsons.class.php
+++ b/stack/input/parsons/parsons.class.php
@@ -20,8 +20,6 @@ require_once(__DIR__ . '/../string/string.class.php');
 
 class stack_parsons_input extends stack_string_input {
 
-    protected $types;
-
     /**
      * If new functionality is added to the Parson's block that require new answer functions then they should be added to
      * the following two functions.

--- a/stack/input/parsons/parsons.class.php
+++ b/stack/input/parsons/parsons.class.php
@@ -23,19 +23,19 @@ class stack_parsons_input extends stack_string_input {
     protected $types;
 
     /**
-     * If new functionality is added to the Parson's block that require new answer functions then they should be added to 
-     * the following two functions. 
-     * 
-     * Each if clause should test the fully evaluated input. For example, in Parson's questions 
-     * for proof, this full evaluated input looks like `[proof..., [["a", "A"], ["b", "B"]]]`. So we can test it by 
-     * checking the existence of proof near the beginning. Each if clause should then return an array of two elements of the 
-     * form `[answer_function, required_args]` according to the relevant Maxima answer function. For example in proof questions, 
-     * the answer function `proof_answer` takes two arguments, which are already included in the evaluated input `$in`. 
-     * 
-     * NOTE: If the input does NOT represent a valid JSON, 
-     * then it should be added before any lines in which the key contains `json_decode`. Similarly any clauses involving 
+     * If new functionality is added to the Parson's block that require new answer functions then they should be added to
+     * the following two functions.
+     *
+     * Each if clause should test the fully evaluated input. For example, in Parson's questions
+     * for proof, this full evaluated input looks like `[proof..., [["a", "A"], ["b", "B"]]]`. So we can test it by
+     * checking the existence of proof near the beginning. Each if clause should then return an array of two elements of the
+     * form `[answer_function, required_args]` according to the relevant Maxima answer function. For example in proof questions,
+     * the answer function `proof_answer` takes two arguments, which are already included in the evaluated input `$in`.
+     *
+     * NOTE: If the input does NOT represent a valid JSON,
+     * then it should be added before any lines in which the key contains `json_decode`. Similarly any clauses involving
      * `json_decode` should go at the end.
-     * 
+     *
      * @param string $in
      * @return array
      */
@@ -52,13 +52,13 @@ class stack_parsons_input extends stack_string_input {
     }
 
     /**
-     * Analogous to `answer_function` above but works for unevaluated inputs. So these are never valid JSONs. On the other hand 
+     * Analogous to `answer_function` above but works for unevaluated inputs. So these are never valid JSONs. On the other hand
      * since they are unevaluated we can safely assume any commas represent list delimiters, so we can mostly explode and implode.
-     * 
-     * NOTE: These will be checked in the order they are given in the return array. If the input does NOT represent a valid JSON, 
-     * then it should be added before any lines in which the key contains `json_decode`. Similarly any keys involving 
+     *
+     * NOTE: These will be checked in the order they are given in the return array. If the input does NOT represent a valid JSON,
+     * then it should be added before any lines in which the key contains `json_decode`. Similarly any keys involving
      * `json_decode` should go at the end of the array.
-     * 
+     *
      * @param string $in
      * @return array
      */
@@ -133,7 +133,7 @@ class stack_parsons_input extends stack_string_input {
         [$answerfun, $args] = $this::answer_function($in);
 
         // Extract actual correct answer from the steps.
-        $ta = 'apply(' . $answerfun . ',' . $args . ')'; 
+        $ta = 'apply(' . $answerfun . ',' . $args . ')';
         $cs = stack_ast_container::make_from_teacher_source($ta);
         $at1 = new stack_cas_session2([$cs], null, 0);
         $at1->instantiate();

--- a/stack/input/parsons/parsons.class.php
+++ b/stack/input/parsons/parsons.class.php
@@ -31,7 +31,7 @@ class stack_parsons_input extends stack_string_input {
      * the answer function `proof_answer` takes two arguments, which are already included in the evaluated input `$in`.
      *
      * NOTE: If the input does NOT represent a valid JSON,
-     * then it should be added before any lines in which the key contains `json_decode`. Similarly any clauses involving
+     * then it should be added before any lines in which the if-clause `json_decode`. Similarly any clauses involving
      * `json_decode` should go at the end.
      *
      * @param string $in

--- a/stack/maxima/contrib/matchlib.mac
+++ b/stack/maxima/contrib/matchlib.mac
@@ -121,6 +121,11 @@ match_answer(ans, steps, [rows]) := block([akeys, ukeys],
 );
 
 /*
+ * Alias for for the column-only usage `match_answer(ans_steps)` of `match_answer`.
+ */
+group_answer(ans, steps) := match_answer(ans, steps);
+
+/*
  * Use this to turn a row-grouped answer into a column-grouped answer and vice-versa.
  * 
  * Note that model answers for matching problems in STACK should always be written by grouping 

--- a/stack/maxima/proof.mac
+++ b/stack/maxima/proof.mac
@@ -112,6 +112,24 @@ parsons_answer(proof_ans, proof_steps) := block([pkeys],
 /******************************************************************/
 
 /*
+ * Hashes the first element of each sublist in a two-dimensional steps array using Base64 hashing. 
+ *
+ * It will turn `[["a", "b"], ["c", "d"], ["e", "f"]]` into `[["YQ==", "b"], ["Yg==", "d"], ["ZQ==", "f"]]`.
+ */
+hash_keys_array(steps) := block(
+  return(map(lambda([item], join([base64(first(item))], rest(item, 1))), steps))
+);
+
+/*
+ * Hashes all strings in a two-dimensional steps array using Base64 hashing. 
+ *
+ * It will turn `[["a", "b"], ["c", "d"], ["e", "f"]]` into `[["YQ==", "Yg=="], ["Yg==", "ZA=="], ["ZQ==", "Zg=="]]`.
+ */
+hash_2d_array(arr) := block(
+    return(map(lambda([l], map(base64, l)), arr))
+);
+
+/*
  *  Return the step "k" from the proof "pf".
  */
 proof_getstep(k, pf) := block([keylist],
@@ -228,3 +246,61 @@ proof_line_disp(ex1, ex2):= sconcat("<div class='proof-line'>",    ex1, ex2, "</
 proof_comment_disp(ex):=    sconcat("<div class='proof-comment'>", ex,       "</div>");
 proof_column_disp(ex):=     sconcat("<div class='proof-column'>",  ex,       "</div>");
 proof_column_disp2(ex):=    sconcat("<div class='proof-column2'>", ex,       "</div>");
+
+/******************************************************************/
+/*                                                                */
+/*  Matching functions                                            */
+/*                                                                */
+/******************************************************************/
+
+/*
+ * Auxiliary function.
+ *
+ * Takes a list of hashed answer keys and the full 2d steps array and returns the the all used hashed keys and unusued hashed keys.
+ * Needed to create a "teacher's answer" in JSON format, including unused text.
+ */
+match_keys_used_unused_hash(ans, steps) := block([tkeys],
+  tkeys:map(first, hash_keys_array(steps)),
+  skeys:hash_2d_array(ans),
+  return([skeys, listdifference(tkeys, ev(unique(flatten(skeys)), simp))])
+);
+
+/*
+ * Use this to transform the teacher's answer into the shape expected by the Parson's block.
+ * Returns an array of `[answer_keys, unused_keys]`, where `unused_keys` is always a flat
+ * list of keys that are in the question but not inside `ans`.
+ * 
+ * If only `columns` has been specified in the `parsons` block, then use 
+ * this function as `match_reshape_hash(ans1)`. This will return `answer_keys` as an 
+ * array of shape `(columns, 1, ?)` if, where `?` represents variable dimension.
+ * 
+ * If both `rows` and `columns` have been specified in the `parson` block, then 
+ * use this function as `match_reshape_hash(ans1, true)`. This will 
+ * return `answer_keys` as an array of shape `(columns, rows, 1)`.
+ */
+match_reshape_hash(ans, steps, [rows]) := block([tkeys, akeys],
+  tkeys: match_keys_used_unused_hash(ans, steps),
+  if rows=[] then akeys: map(lambda([keys], [keys]), first(tkeys)) 
+    else akeys:map(lambda([keys], map(lambda([k], [k]), keys)), first(tkeys)),
+  return([akeys, second(tkeys)])
+);
+
+/*
+ * Use this to transform the teacher's answer into the JSON format expected by the `Model answer` field.
+ * 
+ * If only `columns` has been specified in the `parsons` block, then use 
+ * this function as `match_answer(ans1)`. 
+ *
+ * If both `rows` and `columns` have been specified in the `parson` block, then 
+ * use this function as `match_answer(ans1, true)`. 
+ */
+match_answer(ans, steps, [rows]) := block([akeys, ukeys],
+  if rows=[] then [akeys, ukeys]: match_reshape_hash(ans, steps)
+    else [akeys, ukeys]: match_reshape_hash(ans, steps, rows),
+  sconcat("[[{\"used\":", stackjson_stringify(akeys), ", \"available\":", stackjson_stringify(ukeys), "}, 0]]")
+);
+
+/*
+ * Alias for for the column-only usage `match_answer(ans_steps)` of `match_answer`.
+ */
+group_answer(ans, steps) := match_answer(ans, steps);


### PR DESCRIPTION
This PR mainly addresses issues with using Parson's input type for test cases and matching problems.
- Fix automatic test case behaviour in the Parson's input for all types of use.
- Add cases for the grouping and matching style problems in the input type Maxima calls as these require different Maxima functions.
- Refactor of the Parson's input type to allow for (currently) three types "proof", "group", "match", corresponding to the Maxima answer functions `parsons_answer`, `group_answer`, `match_answer`. If further additions are made in this way to the Parson's block, then they only need to be added to the top two functions in the input type and the rest of the input type should work.
- Update documentation for matching problems.
- Update the Parson's sample questions.