### PR TITLE
Iss1287 - Differentiate headers in edit form

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -57,7 +57,8 @@ jobs:
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'mariadb'
             maxima: 'GCL'
-            moodle-app: true
+          # App CI currently broken for PHP 7.4 - Issue MOBILE-4694.
+            moodle-app: null
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'

--- a/edit_stack_form.php
+++ b/edit_stack_form.php
@@ -436,14 +436,14 @@ class qtype_stack_edit_form extends question_edit_form {
      */
     protected function definition_input($inputname, MoodleQuickForm $mform, $counts) {
 
-        $mform->addElement('header', $inputname . 'header', stack_string('inputheading', $inputname));
+        $mform->addElement('header', $inputname . 'inputheader', stack_string('inputheading', $inputname));
 
         $qtype = new qtype_stack();
         if ($counts[$qtype::INPUTS] == 0 && $counts[$qtype::VALIDATIONS] == 0) {
             $mform->addElement('static', $inputname . 'warning', '', stack_string('inputwillberemoved', $inputname));
             $mform->addElement('advcheckbox', $inputname . 'deleteconfirm', '', stack_string('inputremovedconfirm'));
             $mform->setDefault($inputname . 'deleteconfirm', 0);
-            $mform->setExpanded($inputname . 'header');
+            $mform->setExpanded($inputname . 'inputheader');
         }
 
         $mform->addElement('select', $inputname . 'type', stack_string('inputtype'), $this->typechoices);
@@ -545,13 +545,13 @@ class qtype_stack_edit_form extends question_edit_form {
      */
     protected function definition_prt($prtname, MoodleQuickForm $mform, $count, $graph, $inputnames) {
 
-        $mform->addElement('header', $prtname . 'header', stack_string('prtheading', $prtname));
+        $mform->addElement('header', $prtname . 'prtheader', stack_string('prtheading', $prtname));
 
         if ($count == 0) {
             $mform->addElement('static', $prtname . 'prtwarning', '', stack_string('prtwillberemoved', $prtname));
             $mform->addElement('advcheckbox', $prtname . 'prtdeleteconfirm', '', stack_string('prtremovedconfirm'));
             $mform->setDefault($prtname . 'prtdeleteconfirm', 0);
-            $mform->setExpanded($prtname . 'header');
+            $mform->setExpanded($prtname . 'prtheader');
         }
 
         $mform->addElement('text', $prtname . 'value', stack_string('questionvalue'), ['size' => 3]);

--- a/tests/parsons_block_test.php
+++ b/tests/parsons_block_test.php
@@ -34,11 +34,14 @@ defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/../locallib.php');
 require_once(__DIR__ . '/fixtures/test_base.php');
 require_once(__DIR__ . '/../stack/cas/castext2/castext2_evaluatable.class.php');
+require_once(__DIR__ . '/../stack/cas/castext2/blocks/iframe.block.php');
 require_once(__DIR__ . '/../stack/cas/castext2/utils.php');
 require_once(__DIR__ . '/../stack/cas/keyval.class.php');
 require_once(__DIR__ . '/../stack/cas/cassession2.class.php');
 require_once(__DIR__ . '/../stack/cas/secure_loader.class.php');
 require_once(__DIR__ . '/../lang/multilang.php');
+
+use stack_cas_castext2_iframe;
 
 // Unit tests for {@link stack_cas_castext2_parsons}.
 
@@ -52,6 +55,9 @@ class parsons_block_test extends qtype_stack_testcase {
      * @covers \qtype_stack\stack_cas_castext2_parsons
      */
     public function test_basic_parsons_block() {
+        // This needs reset as the class variable must be being upped in a different
+        // test and the value is bleeding through.
+        stack_cas_castext2_iframe::register_counter('///IFRAME_COUNT///');
         $raw = '[[parsons]]{' .
             '"1":"Assume that \\(n\\) is odd.",' .
             '"2":"Then there exists an \\(m\\in\\mathbb{Z}\\) such that \\(n=2m+1\\).", ' .


### PR DESCRIPTION
Expand div IDs to differentiate sections in the edit form when opening and closing.

Fix CI while I'm here:
- iframes use a couple of sneaky class parameters to control what's going on. These can persist between tests and need reset  if their value is essential to the test.
- Behat for the Moodle App is no longer compatible with PHP 7.4. I've raised an issue and switched off our checks for Moodle 4.1 for now.
#1287 