### PR TITLE
Add minimal working example for manual navigation on website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,18 @@ plugins:
     - exclude:
         glob:
             - de/*
+            - dev/*
             - en/Site_map.md
     - redirects:
         redirect_maps:
             'index.md': 'en/index.md'
+nav:
+    - Home: 'en/index.md'
+    - Authoring quick start: 
+      - 'en/AbInitio/index.md'
+      - 'en/AbInitio/Authoring_quick_start_1.md'
+      - 'en/AbInitio/Authoring_quick_start_2.md'
+    - Specialist tools:
+      - 'en/Specialist_tools/index.md'
+      - Drag and Drop:
+        - 'en/Specialist_tools/Drag_and_drop/index.md'


### PR DESCRIPTION
This changes navigation on docs.stack-assessment.org to be manual, and adds the first few pages to nav. This will mean navigation is not limited to alphabetical order.