### PR TITLE
iss1304 - Todo page memory issue

### DIFF
--- a/adminui/todo.php
+++ b/adminui/todo.php
@@ -68,7 +68,7 @@ foreach ($bulktester->get_num_stack_questions_by_context() as $contextid => $num
             core_php_time_limit::raise(60); // Prevent PHP timeouts.
 
             $qtodos = [];
-            $questions = $bulktester->stack_questions_in_category($currentcategoryid);
+            $questions = $bulktester->stack_questions_in_category_with_todo($currentcategoryid);
             if (!$questions) {
                 continue;
             }

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -30,6 +30,7 @@ $string['pluginnamesummary'] = 'STACK provides mathematical questions for the Mo
 
 $string['privacy:metadata']  = 'The STACK question type plugin does not store any personal data.';
 $string['cachedef_parsercache'] = 'STACK parsed Maxima expressions';
+$string['cachedef_librarycache'] = 'STACK question library renders and file structure';
 
 $string['mbstringrequired'] = 'Installing the MBSTRING library is required for STACK.';
 $string['yamlrecommended']  = 'Installing the YAML library is recommended for STACK.';

--- a/stack/bulktester.class.php
+++ b/stack/bulktester.class.php
@@ -102,6 +102,42 @@ class stack_bulk_tester {
     }
 
     /**
+     * Find all stack questions in a given category with a todo block, returning only
+     * the latest version of each question.
+     * @param type $categoryid the id of a question category of interest
+     * @return all stack question ids in any state and any version in the given
+     * category. Each row in the returned list of rows has an id, name and version number.
+     */
+    public function stack_questions_in_category_with_todo($categoryid) {
+        global $DB;
+
+        // See question/engine/bank.php around line 500, but this does not return the last version.
+        $qcparams['readystatus'] = \core_question\local\bank\question_version_status::QUESTION_STATUS_READY;
+        return $DB->get_records_sql_menu("
+                SELECT q.id, q.name AS id2
+                FROM {question} q
+                JOIN {question_versions} qv ON qv.questionid = q.id
+                JOIN {question_bank_entries} qbe ON qbe.id = qv.questionbankentryid
+                JOIN {qtype_stack_options} qso ON qso.questionid = q.id
+                WHERE qbe.questioncategoryid = {$categoryid}
+                       AND q.parent = 0
+                       AND qv.status = :readystatus
+                       AND q.qtype = 'stack'
+                       AND qv.version = (SELECT MAX(v.version)
+                                         FROM {question_versions} v
+                                         JOIN {question_bank_entries} be
+                                         ON be.id = v.questionbankentryid
+                                         WHERE be.id = qbe.id)
+                       AND (
+                            q.questiontext REGEXP '[[][[]todo'
+                            OR q.generalfeedback REGEXP '[[][[]todo'
+                            OR qso.questionnote REGEXP '[[][[]todo'
+                            OR qso.specificfeedback REGEXP '[[][[]todo'
+                            OR qso.questiondescription REGEXP '[[][[]todo'
+                        )", $qcparams);
+    }
+
+    /**
      * Get a list of all the categories within the supplied contextid that
      * contain stack questions in any state and any version.
      * @return an associative array mapping from category id to an object


### PR DESCRIPTION
Not quite sure what the problem is here - could be PHP garbage collection or temporary caching by Moodle. Anyway, loading every current question on the server in quick succession does not lead to happy times.

I've done a quick copy of the initial question retrieval SQL to another function and narrowed down the search to only return questions with '[[todo' in questiontext, generalfeedback, questionnote, specificfeedback or questiondescription (via a join with qtype_stack_options). Presumably that still leaves us with an upper limit on the number of todos but the alternative is a fairly major and messy re-write.

(Also, addition of a missing language string I found while trawling settings.)  