### PR TITLE
api-check - Update version numbers and docs

### DIFF
--- a/api/docker/docker-compose.dev.yml
+++ b/api/docker/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "4.0"
 services:
   maxima:
-    image: mathinstitut/goemaxima:2024072400-latest
+    image: mathinstitut/goemaxima:2024111500-latest
     tmpfs:
       - "/tmp"
     restart: unless-stopped

--- a/api/docker/docker-compose.yml
+++ b/api/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "4.0"
 services:
   maxima:
-    image: mathinstitut/goemaxima:2024072400-latest
+    image: mathinstitut/goemaxima:2024111500-latest
     tmpfs:
       - "/tmp"
     restart: unless-stopped
@@ -15,7 +15,7 @@ services:
     read_only: true
   stack:
     # Location of published STACK API image goes here.
-    image: stackmaths/stackapi:2024072400-latest
+    image: stackmaths/stackapi:2024111500-latest
     restart: unless-stopped
     ports:
       - '3080:80'

--- a/doc/en/Developer/Releasing.md
+++ b/doc/en/Developer/Releasing.md
@@ -47,7 +47,7 @@ Unless you want to discuss something confidential with the developers, please do
   * Create `maximalocal.mac.template` as described in `Adding_new_version.md` in goemaxima docs (or just copy from previous goemaxima version).
   * In `buildimage.sh` set `maximaver` and `sbclver` e.g. `maximaver="5.45.1" sbclver="2.2.6"`. (`maximaver` should match `maximalocal.mac.template`)
   * `./buildweb.sh` (You may need to install `go` first: `sudo snap install go --classic`).
-  * `.buildimage.s 2024072400` (If Docker struggles to fetch metadata `sudo vi ~/.docker/config.json` and change `credsStore` to `credStore`).
+  * `./buildimage.sh 2024072400` (If Docker struggles to fetch metadata `sudo vi ~/.docker/config.json` and change `credsStore` to `credStore`).
   * You should have now created a `goemaxima:2024072400-dev` image locally.
 * Temporarily update STACK API locally:
   * Update maxima image in STACK API to `goemaxima:2024072400-dev` in `docker-compose.dev.yml`.


### PR DESCRIPTION
I've done some testing and everything that previously worked in the API seems to be working.

I have access to more questions via the STACK library now, though, and the bad news is that the include block has never worked. I suggest we leave it for now and I fix it at a later date. Anyone using the API can build a new image from DEV if they really need the fix before our next release. The include block also works fine in the STACK library within Moodle. 