### PR TITLE
Fix function call type errors in `stack_dropdown_input`

### DIFF
--- a/stack/input/dropdown/dropdown.class.php
+++ b/stack/input/dropdown/dropdown.class.php
@@ -244,7 +244,9 @@ class stack_dropdown_input extends stack_input {
                     // In case we see CASText2 values we need to postproc them.
                     $tmp = castext2_parser_utils::string_to_list($display, true);
                     $tmp = castext2_parser_utils::unpack_maxima_strings($tmp);
-                    $ddlvalues[$key]['display'] = castext2_parser_utils::postprocess_parsed($tmp);
+                    $holder = new castext2_placeholder_holder();
+                    $ddlvalues[$key]['display'] = castext2_parser_utils::postprocess_parsed($tmp, null, $holder);
+                    $ddlvalues[$key]['display'] = $holder->replace($ddlvalues[$key]['display']);
                 } else {
                     $cs = stack_ast_container::make_from_teacher_source($display);
                     if ($cs->get_valid()) {
@@ -255,7 +257,8 @@ class stack_dropdown_input extends stack_input {
                 if ($ddlvalues[$key]['correct']) {
                     if (substr($display, 0, 9) === '["%root",') {
                         $tmp = castext2_parser_utils::unpack_maxima_strings($display);
-                        $correctanswerdisplay[] = castext2_parser_utils::postprocess_parsed($tmp);
+                        $holder = new castext2_placeholder_holder();
+                        $correctanswerdisplay[] = castext2_parser_utils::postprocess_parsed($tmp, null, $holder);
                     } else {
                         $correctanswerdisplay[] = $display;
                     }
@@ -326,7 +329,10 @@ class stack_dropdown_input extends stack_input {
                 // And now we need to care about holders.
                 $holder = new castext2_placeholder_holder();
                 $ddlvalues[$key]['display'] = castext2_parser_utils::postprocess_mp_parsed(
-                    $at1->get_by_key('val'.$key)->get_evaluated(), $holder);
+                    $at1->get_by_key('val'.$key)->get_evaluated(),
+                    null,
+                    $holder,
+                );
                 $ddlvalues[$key]['display'] = $holder->replace($ddlvalues[$key]['display']);
             } else if (substr($display, 0, 1) == '"') {
                 $ddlvalues[$key]['display'] = stack_utils::maxima_string_to_php_string($display);


### PR DESCRIPTION
a1a3fef introduced bugs that make some quizzes unusable.

I cannot reliably say, which types of questions exactly are affected, but I don't think this reproducibility is required in this case.

The bugs in question are simple `TypeError`s caused by wrong calls of the [`castext2_parser_utils::postprocess_mp_parsed`](https://github.com/maths/moodle-qtype_stack/blob/48bf1be50ac9321e3235f2169b965c5deaf077e1/stack/cas/castext2/utils.php#L140) and [`castext2_parser_utils::postprocess_parsed`](https://github.com/maths/moodle-qtype_stack/blob/48bf1be50ac9321e3235f2169b965c5deaf077e1/stack/cas/castext2/utils.php#L132) methods from within [`stack/input/dropdown/dropdown.class.php`](https://github.com/maths/moodle-qtype_stack/blob/48bf1be50ac9321e3235f2169b965c5deaf077e1/stack/input/dropdown/dropdown.class.php). Specifically the former is what caught my eye and caused major problems.

The second argument to both methods must be `castext2_processor|null`, but at the call site it is passed a `castext2_placeholder_holder`. The third argument must be a `castext2_placeholder_holder`, but the third argument is missing.

Here is the full stack trace:

```
castext2_parser_utils::postprocess_mp_parsed(): Argument #2 ($processor) must be of type ?castext2_processor, castext2_placeholder_holder given, called in [dirroot]/question/type/stack/stack/input/dropdown/dropdown.class.php on line 328

line 140 of /question/type/stack/stack/cas/castext2/utils.php: TypeError thrown
line 328 of /question/type/stack/stack/input/dropdown/dropdown.class.php: call to castext2_parser_utils::postprocess_mp_parsed()
line 561 of /question/type/stack/question.php: call to stack_dropdown_input->adapt_to_model_answer()
line 511 of /question/type/stack/question.php: call to qtype_stack_question->adapt_inputs()
line 346 of /question/type/stack/question.php: call to qtype_stack_question->initialise_question_from_seed()
line 364 of /question/behaviour/behaviourbase.php: call to qtype_stack_question->start_attempt()
line 1069 of /question/engine/questionattempt.php: call to question_behaviour->init_first_step()
line 604 of /question/engine/questionusage.php: call to question_attempt->start()
line 269 of /mod/quiz/locallib.php: call to question_usage_by_activity->start_all_questions()
line 2059 of /mod/quiz/locallib.php: call to quiz_start_new_attempt()
line 110 of /mod/quiz/startattempt.php: call to quiz_prepare_and_start_new_attempt()
```

Before that commit, the second parameter `$processor` of both `postprocess_mp_parsed` and `postprocess_parsed` had a default value of `null` and there was no third `$holder` parameter. At the call site in question it used to be called with just one argument. Therefore I assume that the author simply forgot to add the `null` explicitly before the new `$holder` argument. See line 329:

https://github.com/maths/moodle-qtype_stack/blob/48bf1be50ac9321e3235f2169b965c5deaf077e1/stack/input/dropdown/dropdown.class.php#L325-L330

Then I noticed that there were two other calls of `castext2_parser_utils::postprocess_parsed` in the same file that had not been adjusted at all. I assume they should follow similar logic to the `postprocess_mp_parsed` call, so I did my best to fix those call sites as well, but since I don't understand the semantics here at all, I am not sure about this.

This patch at least fixes the problem at our end. I hope I thought of everything. Please let me know, if I should add/change anything.

PS: If you could tell me, why only some quizzes are affected by this, I would appreciate it.