### PR TITLE
Update mock class names

### DIFF
--- a/tests/api_controller_test.php
+++ b/tests/api_controller_test.php
@@ -84,7 +84,7 @@ class api_controller_test extends qtype_stack_testcase {
             $methods[] = $method->name;
         }
         $this->request = $this->getMockBuilder(RequestInt::class)
-            ->setMockClassName('Request')
+            ->setMockClassName('RequestTest')
             ->setMethods($methods)
             ->getMock();
         // Need to use callback so data can be altered in each test.
@@ -101,7 +101,7 @@ class api_controller_test extends qtype_stack_testcase {
         }
 
         $this->response = $this->getMockBuilder(ResponseInt::class)
-            ->setMockClassName('Response')
+            ->setMockClassName('ResponseTest')
             ->setMethods($methods)
             ->getMock();
 
@@ -112,7 +112,7 @@ class api_controller_test extends qtype_stack_testcase {
         }
 
         $this->result = $this->getMockBuilder(StreamInt::class)
-            ->setMockClassName('StreamInterface')
+            ->setMockClassName('StreamInterfaceTest')
             ->setMethods($methods)
             ->getMock();
 
@@ -252,7 +252,7 @@ class api_controller_test extends qtype_stack_testcase {
         $this->requestdata['fileid'] = 1;
 
         $dc = $this->getMockBuilder(DownloadController::class)
-            ->setMockClassName('DownloadController')
+            ->setMockClassName('DownloadControllerTest')
             ->setMethods(['set_headers'])
             ->getMock();
 


### PR DESCRIPTION
### Summary
This pull request resolves the unit test failures when the `mod_turnitintooltwo` plugin is installed.

Resolves issue https://github.com/maths/moodle-qtype_stack/issues/1355

### Testing

1. Install https://github.com/turnitin/moodle-mod_turnitintooltwo (Optional)
2. With PHPUnit initialised, execute the following from your root Moodle directory:
`
php vendor/bin/phpunit question/type/stack/tests/api_controller_test.php
`
3. Confirm all tests pass.