### PR TITLE
Iss1393 - Issues with response analysis page

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -182,5 +182,5 @@ jobs:
 
       - name: Behat features
         if: ${{ always() }}
-        run: moodle-plugin-ci behat --profile chrome
+        run: moodle-plugin-ci behat --profile chrome --auto-rerun 6
 

--- a/questiontestreport.php
+++ b/questiontestreport.php
@@ -67,7 +67,7 @@ echo $OUTPUT->header();
 
 // Get quizzes in which the course is used.
 // Add data for creating quiz selection dropdown.
-$quizzes = stack_question_report::get_relevant_quizzes($questionid);
+$quizzes = stack_question_report::get_relevant_quizzes($questionid, (int) $question->contextid);
 $quizoutput = [];
 foreach ($quizzes as $contextid => $quiz) {
     $quiz->url = new moodle_url('/question/type/stack/questiontestreport.php',

--- a/questiontestreport.php
+++ b/questiontestreport.php
@@ -30,6 +30,7 @@ require_once(__DIR__.'/../../../config.php');
 require_once($CFG->libdir . '/questionlib.php');
 require_once(__DIR__ . '/vle_specific.php');
 require_once(__DIR__ . '/stack/questionreport.class.php');
+require_login();
 
 // Get the parameters from the URL.
 $questionid = required_param('questionid', PARAM_INT);
@@ -49,6 +50,7 @@ question_require_capability_on($questiondata, 'view');
 $canedit = question_has_capability_on($questiondata, 'edit');
 
 // Initialise $PAGE.
+$PAGE->set_context($context);
 $PAGE->set_url('/question/type/stack/questiontestreport.php', $urlparams);
 $title = stack_string('basicquestionreport');
 $PAGE->set_title($title);

--- a/stack/questionreport.class.php
+++ b/stack/questionreport.class.php
@@ -30,6 +30,9 @@ class stack_random_question_loader extends random_question_loader {
     public function get_filtered_question_ids(array $filters):array {
       return parent::get_filtered_question_ids($filters);
     }
+    public function get_question_ids($categoryid, $includesubcategories, $tagids = []):array {
+        return parent::get_question_ids($categoryid, $includesubcategories, $tagids);
+      }
   }
 
 /**
@@ -742,8 +745,15 @@ class stack_question_report {
         foreach ($randomquizzes as $randomquiz) {
             // Don't bother checking if the question is already in the quiz.
             if (!isset($quizzes[$randomquiz->quizcontextid])) {
-                $filter = JSON_decode($randomquiz->filtercondition, true)['filter'];
-                $ids = $randomloader->get_filtered_question_ids($filter);
+                $filter = JSON_decode($randomquiz->filtercondition, true);
+                $ids = [];
+                if (isset($filter['filter'])) {
+                    $filter = $filter['filter'];
+                    $ids = $randomloader->get_filtered_question_ids($filter);
+                } else if ($filter['questioncategoryid']) {
+                    // This is for Moodle 4.0, 4.1.
+                    $ids = $randomloader->get_question_ids($filter['questioncategoryid'], $filter['includingsubcategories'], (isset($filter['tags'])) ? $filter['tags'] : []);
+                }
                 if (in_array($questionid, $ids)) {
                     $quizzes[$randomquiz->quizcontextid] = $randomquiz;
                 }

--- a/templates/questionreport.mustache
+++ b/templates/questionreport.mustache
@@ -132,7 +132,7 @@
   </p>
 
   <!-- Dashboard and preview links -->
-  <p><a href="{{general.testquestionlink}}">{{#str}} runquestiontests, qtype_stack {{/str}}</a> <a href="{{general.previewquestionlink}}">{{#pix}} t/preview, core, {{#str}} preview, core {{/str}} {{/pix}}</a></p>
+  <p><a href="{{{general.testquestionlink}}}">{{#str}} runquestiontests, qtype_stack {{/str}}</a> <a href="{{{general.previewquestionlink}}}">{{#pix}} t/preview, core, {{#str}} preview, core {{/str}} {{/pix}}</a></p>
 
   <!-- Tab headers -->
   <ul class="nav nav-tabs" id="myTab" role="tablist">

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -1,0 +1,54 @@
+@qtype @qtype_stack
+Feature: Test analysis response page
+  As a teacher
+  In order to analyse student responses
+  I need to open the analysis reposnse page
+
+  Background:
+    Given I set up STACK using the PHPUnit configuration
+    Given the following "users" exist:
+      | username |
+      | teacher  |
+      | student  |
+    And the following "courses" exist:
+      | fullname | shortname |
+      | Course 1 | C1        |
+    And the following "course enrolments" exist:
+      | user    | course | role           |
+      | teacher | C1     | editingteacher |
+      | student | C1     | student        |
+    And the following "question categories" exist:
+      | contextlevel | reference | name           |
+      | Course       | C1        | Test questions |
+    And the following "questions" exist:
+      | questioncategory | qtype  | name                                     | template               |
+      | Test questions   | stack  | Test question 1                          | algebraic_input        |
+      | Test questions   | stack  | Test question 2                          | algebraic_input        |
+      | Test questions   | random | Random (Test questions)                  |                        |
+    And the following "activities" exist:
+      | activity   | name   | course | idnumber |
+      | quiz       | Quiz 1 | C1     | quiz1    |
+    And quiz "Quiz 1" contains the following questions:
+      | question                | page |
+      | Random (Test questions) | 1    |
+
+  @javascript
+  Scenario: Analyse a question
+    Given I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
+    And I press "Attempt quiz"
+    And I set the input "ans1" to "a*b" in the STACK question
+    And I wait until "Your last answer was interpreted as follows" "text" exists
+    And I follow "Finish attempt ..."
+    And I press "Submit all and finish"
+    And I click on "Submit all and finish" "button" in the "Submit all your answers and finish?" "dialogue"
+    And I follow "Finish review"
+    And I wait until "Re-attempt quiz" "text" exists
+    And I wait "5" seconds
+    When I am on the "C1 > Test question 1" "qtype_stack > analysis" page logged in as "teacher"
+    Then I should see "Type in {@ta@}."
+    And I click on "select option:nth-child(2)" "css_element"
+    And I should see "ATAlgEquiv(ans1,ta)"
+    And I follow "Variants"
+    And I should see "## prt1: 1 (100.00%); # = 1 | prt1-1-T"
+
+

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -45,6 +45,8 @@ Feature: Test analysis response page
     And I follow "Finish review"
     And I wait until "Re-attempt quiz" "text" exists
     And I wait "15" seconds
+    And I log out
+    And I log in as "teacher"
     When I am on the "C1 > Test question 1" "qtype_stack > analysis" page logged in as "teacher"
     Then I should see "Type in {@ta@}."
     And I click on "select option:nth-child(2)" "css_element"

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -36,7 +36,6 @@ Feature: Test analysis response page
   Scenario: Analyse a question
     Given the site is running Moodle version 4.1 or higher
     And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
-    And the site is running Moodle version 4.0 or higher
     And I press "Attempt quiz"
     And I set the input "ans1" to "a*b" in the STACK question
     And I wait until "Your last answer was interpreted as follows" "text" exists
@@ -57,7 +56,6 @@ Feature: Test analysis response page
   Scenario: Analyse a question
     Given the site is running Moodle version 4.0 or lower
     And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
-    And the site is running Moodle version 4.0 or higher
     And I press "Attempt quiz"
     And I set the input "ans1" to "a*b" in the STACK question
     And I wait until "Your last answer was interpreted as follows" "text" exists

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -55,7 +55,7 @@ Feature: Test analysis response page
 
   @javascript
   Scenario: Analyse a question
-    Given the site is running Moodle version 4.0
+    Given the site is running Moodle version 4.0 or lower
     And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
     And the site is running Moodle version 4.0 or higher
     And I press "Attempt quiz"
@@ -73,5 +73,3 @@ Feature: Test analysis response page
     And I should see "ATAlgEquiv(ans1,ta)"
     And I follow "Variants"
     And I should see "## prt1: 1 (100.00%); # = 1 | prt1-1-T"
-
-

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -44,7 +44,7 @@ Feature: Test analysis response page
     And I click on "Submit all and finish" "button" in the "Submit all your answers and finish?" "dialogue"
     And I follow "Finish review"
     And I wait until "Re-attempt quiz" "text" exists
-    And I wait "10" seconds
+    And I wait "15" seconds
     When I am on the "C1 > Test question 1" "qtype_stack > analysis" page logged in as "teacher"
     Then I should see "Type in {@ta@}."
     And I click on "select option:nth-child(2)" "css_element"

--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -34,7 +34,9 @@ Feature: Test analysis response page
 
   @javascript
   Scenario: Analyse a question
-    Given I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
+    Given the site is running Moodle version 4.1 or higher
+    And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
+    And the site is running Moodle version 4.0 or higher
     And I press "Attempt quiz"
     And I set the input "ans1" to "a*b" in the STACK question
     And I wait until "Your last answer was interpreted as follows" "text" exists
@@ -43,7 +45,28 @@ Feature: Test analysis response page
     And I click on "Submit all and finish" "button" in the "Submit all your answers and finish?" "dialogue"
     And I follow "Finish review"
     And I wait until "Re-attempt quiz" "text" exists
-    And I wait "5" seconds
+    And I wait "10" seconds
+    When I am on the "C1 > Test question 1" "qtype_stack > analysis" page logged in as "teacher"
+    Then I should see "Type in {@ta@}."
+    And I click on "select option:nth-child(2)" "css_element"
+    And I should see "ATAlgEquiv(ans1,ta)"
+    And I follow "Variants"
+    And I should see "## prt1: 1 (100.00%); # = 1 | prt1-1-T"
+
+  @javascript
+  Scenario: Analyse a question
+    Given the site is running Moodle version 4.0
+    And I am on the "Quiz 1" "mod_quiz > View" page logged in as "student"
+    And the site is running Moodle version 4.0 or higher
+    And I press "Attempt quiz"
+    And I set the input "ans1" to "a*b" in the STACK question
+    And I wait until "Your last answer was interpreted as follows" "text" exists
+    And I follow "Finish attempt ..."
+    And I press "Submit all and finish"
+    And I click on "Submit all and finish" "button" in the "Confirmation" "dialogue"
+    And I follow "Finish review"
+    And I wait until "Re-attempt quiz" "text" exists
+    And I wait "10" seconds
     When I am on the "C1 > Test question 1" "qtype_stack > analysis" page logged in as "teacher"
     Then I should see "Type in {@ta@}."
     And I click on "select option:nth-child(2)" "css_element"

--- a/tests/responseanalysis_test.php
+++ b/tests/responseanalysis_test.php
@@ -728,7 +728,7 @@ final class responseanalysis_test extends qtype_stack_testcase {
         $quizzes = stack_question_report::get_relevant_quizzes($q3->id, $quiz1contextid);
         $this->assertEquals(0, count($quizzes));
 
-        // Quiz 1: Add q1. Add q3 as part of random selection
+        // Quiz 1: Add q1. Add q3 as part of random selection.
         \quiz_add_quiz_question($q->id, $quiz1);
         global $CFG;
         if ($CFG->version > 2023042411) {

--- a/tests/responseanalysis_test.php
+++ b/tests/responseanalysis_test.php
@@ -22,6 +22,7 @@ use test_question_maker;
 defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/../stack/questionreport.class.php');
 require_once(__DIR__ . '/fixtures/test_base.php');
+global $CFG;
 require_once($CFG->dirroot . '/mod/quiz/tests/quiz_question_helper_test_trait.php');
 
 define ('RESPONSETS', '# = 0 | thing1_true | prt1-1-T');

--- a/tests/responseanalysis_test.php
+++ b/tests/responseanalysis_test.php
@@ -734,7 +734,11 @@ final class responseanalysis_test extends qtype_stack_testcase {
         \quiz_add_quiz_question($q->id, $quiz2);
         \quiz_add_quiz_question($q2->id, $quiz2);
         // Quiz 3: Add q1 and q2 as part of random selection.
-        $this->add_random_questions($quiz3->id, 0, $qcategory->id, 1);
+        if (method_exists($this, 'add_random_questions')) {
+            $this->add_random_questions($quiz3->id, 0, $qcategory->id, 1);
+        } else {
+            quiz_add_random_questions($quiz3, 0, $qcategory->id, 1, false);
+        }
 
         if (class_exists('\mod_quiz\quiz_settings')) {
             $quizobj = \mod_quiz\quiz_settings::create($quiz1->id);

--- a/tests/responseanalysis_test.php
+++ b/tests/responseanalysis_test.php
@@ -734,22 +734,25 @@ final class responseanalysis_test extends qtype_stack_testcase {
         \quiz_add_quiz_question($q->id, $quiz2);
         \quiz_add_quiz_question($q2->id, $quiz2);
         // Quiz 3: Add q1 and q2 as part of random selection.
-        if (method_exists($this, 'add_random_questions')) {
+        global $CFG;
+        if ($CFG->version > 2022041900) {
             $this->add_random_questions($quiz3->id, 0, $qcategory->id, 1);
         } else {
-            quiz_add_random_questions($quiz3, 0, $qcategory->id, 1, false);
+            \quiz_add_random_questions($quiz3, 0, $qcategory->id, 1, false);
         }
 
         if (class_exists('\mod_quiz\quiz_settings')) {
-            $quizobj = \mod_quiz\quiz_settings::create($quiz1->id);
-            $quizobj = \mod_quiz\quiz_settings::create($quiz2->id);
-            $quizobj = \mod_quiz\quiz_settings::create($quiz3->id);
+            $quizobj1 = \mod_quiz\quiz_settings::create($quiz1->id);
+            $quizobj2 = \mod_quiz\quiz_settings::create($quiz2->id);
+            $quizobj3 = \mod_quiz\quiz_settings::create($quiz3->id);
         } else {
-            $quizobj = \quiz::create($quiz1->id);
-            $quizobj = \quiz::create($quiz2->id);
-            $quizobj = \quiz::create($quiz3->id);
+            $quizobj1 = \quiz::create($quiz1->id);
+            $quizobj2 = \quiz::create($quiz2->id);
+            $quizobj3 = \quiz::create($quiz3->id);
         }
-        \mod_quiz\structure::create_for_quiz($quizobj);
+        \mod_quiz\structure::create_for_quiz($quizobj1);
+        \mod_quiz\structure::create_for_quiz($quizobj2);
+        \mod_quiz\structure::create_for_quiz($quizobj3);
         $quizzes = stack_question_report::get_relevant_quizzes($q->id, $contextid);
         $quiznames = array_column($quizzes, 'name');
         $this->assertEquals(3, count($quizzes));


### PR DESCRIPTION
#1393

- I've created a Behat test for the RA page in the hope of avoiding future problems like the jQuery issue.
- I've upped the number of repeats for Behat tests in the CI as this test and some of the App specific ones are struggling if GitHub is tired. (In this one, it's somehow possible to load the analysis page before the student's response has been recorded if things are running slowly.)
- URLs should be fixed.
- Including quizzes where the question is included as part of a random selection: This was gnarly. The random questions are stored as a filter meaning some involved computation is required to check each one for a given question. I've tried to restrict the number of checks as much as possible and there is some caching involved so performance should be fine in most cases. If someone had a lot of quizzes all taking random questions from a selection of subcategories of the same context as the question to be analysed, things might chug.