### PR TITLE
Api defaults basic

### DIFF
--- a/api/public/cors.php
+++ b/api/public/cors.php
@@ -39,7 +39,10 @@ if (isset($_GET['question'])) {
 if (strpos($scriptname, '..') !== false
     || strpos($scriptname, '/') !== false
     || strpos($scriptname, '\\') !== false) {
-        die("No such script here.");
+        // Give a special exception for sample questions.
+        if (!($is_question && file_exists('../../samplequestions/' . $scriptname))) {
+            die("No such script here.");
+        }
 }
 
 if (file_exists('../../corsscripts/' . $scriptname) || $scriptname === 'styles.css'

--- a/api/public/stackshared.php
+++ b/api/public/stackshared.php
@@ -53,7 +53,7 @@ require_login();
     function processNodes(res, nodes) {
         for (let i = 0; i < nodes.length; i++) {
             const element = nodes[i];
-            if (element.name.indexOf(inputPrefix) === 0 && element.name.indexOf('_val') === -1) {
+            if (element.name.indexOf(inputPrefix) === 0 && !element.name.endsWith('_val')) {
                 if (element.type === 'checkbox' || element.type === 'radio') {
                     if (element.checked) {
                         res[element.name.slice(inputPrefix.length)] = element.value;
@@ -61,6 +61,9 @@ require_login();
                 } else {
                     res[element.name.slice(inputPrefix.length)] = element.value;
                 }
+            }
+            if (element.name.endsWith('_val')) {
+                res[element.name] = element.value;
             }
         }
         return res;

--- a/api/util/StackQuestionLoader.php
+++ b/api/util/StackQuestionLoader.php
@@ -69,43 +69,57 @@ class StackQuestionLoader {
         $question->name = (string) $xmldata->question->name->text ? (string) $xmldata->question->name->text : 'Question';
         $question->questiontext = (string) $xmldata->question->questiontext->text ?
             (string) $xmldata->question->questiontext->text : '<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>';
-        $question->questiontextformat = (string) $xmldata->question->questiontext['format'] ? (string) $xmldata->question->questiontext['format'] : 'html';
-        $question->generalfeedback = (string) $xmldata->question->generalfeedback->text ? (string) $xmldata->question->generalfeedback->text : '';
+        $question->questiontextformat =
+            (string) $xmldata->question->questiontext['format'] ? (string) $xmldata->question->questiontext['format'] : 'html';
+        $question->generalfeedback =
+            (string) $xmldata->question->generalfeedback->text ? (string) $xmldata->question->generalfeedback->text : '';
         $question->generalfeedbackformat = (string) $xmldata->question->generalfeedback['format'];
         $question->defaultmark = (array) $xmldata->question->defaultgrade ? (float) $xmldata->question->defaultgrade : 1.0;
         $question->penalty = (array) $xmldata->question->penalty ? (float) $xmldata->question->penalty : 0.1;
 
         // Based on initialise_question_instance from questiontype.php.
-        $question->stackversion              = (string) $xmldata->question->stackversion->text ? (string) $xmldata->question->stackversion->text : '';
-        $question->questionvariables         = (string) $xmldata->question->questionvariables->text ? (string) $xmldata->question->questionvariables->text : 'ta1:1;';
-        $question->questionnote              = (string) $xmldata->question->questionnote->text ? (string) $xmldata->question->questionnote->text : '{@ta1@}';
-        $question->questionnoteformat        = (string) $xmldata->question->questionnote['format'] ? (string) $xmldata->question->questionnote['format'] : 'html';
-        $question->specificfeedback          = (string) $xmldata->question->specificfeedback->text ? (string) $xmldata->question->specificfeedback->text : '[[feedback:prt1]]';
-        $question->specificfeedbackformat    = (string) $xmldata->question->specificfeedback['format'] ? (string) $xmldata->question->specificfeedback['format'] : 'html';
-        $question->questiondescription       = (string) $xmldata->question->questiondescription->text ? (string) $xmldata->question->questiondescription->text : '';
-        $question->questiondescriptionformat = (string) $xmldata->question->questiondescription['format'] ? (string) $xmldata->question->questiondescription['format'] : 'html';
+        $question->stackversion              =
+            (string) $xmldata->question->stackversion->text ? (string) $xmldata->question->stackversion->text : '';
+        $question->questionvariables         =
+            (string) $xmldata->question->questionvariables->text ? (string) $xmldata->question->questionvariables->text : 'ta1:1;';
+        $question->questionnote              =
+            (string) $xmldata->question->questionnote->text ? (string) $xmldata->question->questionnote->text : '{@ta1@}';
+        $question->questionnoteformat        =
+            (string) $xmldata->question->questionnote['format'] ? (string) $xmldata->question->questionnote['format'] : 'html';
+        $question->specificfeedback          =
+                (string) $xmldata->question->specificfeedback->text ?
+                (string) $xmldata->question->specificfeedback->text : '[[feedback:prt1]]';
+        $question->specificfeedbackformat    =
+                (string) $xmldata->question->specificfeedback['format'] ?
+                (string) $xmldata->question->specificfeedback['format'] : 'html';
+        $question->questiondescription       =
+            (string) $xmldata->question->questiondescription->text ? (string) $xmldata->question->questiondescription->text : '';
+        $question->questiondescriptionformat =
+                (string) $xmldata->question->questiondescription['format'] ?
+                (string) $xmldata->question->questiondescription['format'] : 'html';
         if (isset($xmldata->question->prtcorrect->text)) {
             $question->prtcorrect                = (string) $xmldata->question->prtcorrect->text;
             $question->prtcorrectformat          = (string) $xmldata->question->prtcorrect['format'];
         } else {
-            $question->prtcorrect = get_string('defaultprtcorrectfeedback', null, null);
+            $question->prtcorrect = get_string('defaultprtcorrectfeedback', 'qtype_stack', null);
             $question->prtcorrectformat = 'html';
         }
         if (isset($xmldata->question->prtpartiallycorrect->text)) {
             $question->prtpartiallycorrect = (string)$xmldata->question->prtpartiallycorrect->text;
             $question->prtpartiallycorrectformat = (string)$xmldata->question->prtpartiallycorrect['format'];
         } else {
-            $question->prtpartiallycorrect = get_string('defaultprtpartiallycorrectfeedback', null, null);
+            $question->prtpartiallycorrect = get_string('defaultprtpartiallycorrectfeedback', 'qtype_stack', null);
             $question->prtpartiallycorrectformat = 'html';
         }
         if (isset($xmldata->question->prtincorrect->text)) {
             $question->prtincorrect = (string)$xmldata->question->prtincorrect->text;
             $question->prtincorrectformat = (string)$xmldata->question->prtincorrect['format'];
         } else {
-            $question->prtincorrect = get_string('defaultprtincorrectfeedback', null, null);
+            $question->prtincorrect = get_string('defaultprtincorrectfeedback', 'qtype_stack', null);
             $question->prtincorrectformat = 'html';
         }
-        $question->variantsselectionseed     = (string) $xmldata->question->variantsselectionseed ? (string) $xmldata->question->variantsselectionseed : '';
+        $question->variantsselectionseed     =
+            (string) $xmldata->question->variantsselectionseed ? (string) $xmldata->question->variantsselectionseed : '';
         $question->compiledcache             = [];
 
         $question->options = new \stack_options();
@@ -279,7 +293,8 @@ class StackQuestionLoader {
                 $newnode->truenextnode = (array) $node->truenextnode ? (string) $node->truenextnode : '-1';
                 $newnode->trueanswernote = (string) $node->trueanswernote ? (string) $node->trueanswernote : '';
                 $newnode->truefeedback = (string) $node->truefeedback->text ? (string) $node->truefeedback->text : '';
-                $newnode->truefeedbackformat = (string) $node->truefeedback['format'] ? (string) $node->truefeedback['format'] : 'html';
+                $newnode->truefeedbackformat =
+                    (string) $node->truefeedback['format'] ? (string) $node->truefeedback['format'] : 'html';
 
                 $newnode->falsescoremode = (array) $node->falsescoremode ? (string) $node->falsescoremode : '=';
                 $newnode->falsescore = (array) $node->falsescore ? (string) $node->falsescore : '0.0';
@@ -287,7 +302,8 @@ class StackQuestionLoader {
                 $newnode->falsenextnode = (array) $node->falsenextnode ? (string) $node->falsenextnode : '-1';
                 $newnode->falseanswernote = (string) $node->falseanswernote ? (string) $node->falseanswernote : '';
                 $newnode->falsefeedback = (string) $node->falsefeedback->text ? (string) $node->falsefeedback->text : '';
-                $newnode->falsefeedbackformat = (string) $node->falsefeedback['format'] ? (string) $node->falsefeedback['format'] : 'html';
+                $newnode->falsefeedbackformat =
+                    (string) $node->falsefeedback['format'] ? (string) $node->falsefeedback['format'] : 'html';
 
                 $data->nodes[(int) $node->name] = $newnode;
             }

--- a/api/util/StackQuestionLoader.php
+++ b/api/util/StackQuestionLoader.php
@@ -36,7 +36,7 @@ require_once(__DIR__ . '/../../stack/potentialresponsetreestate.class.php');
 class StackQuestionLoader {
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public static function loadxml($xml, $includetests=false) {
-        // TO-DO: Consider defaults.
+        // TO-DO: Detect if we don't have <quiz><question type="stack"> wrapper and add?
         try {
             $xmldata = new SimpleXMLElement($xml);
         } catch (\Exception $e) {
@@ -67,22 +67,24 @@ class StackQuestionLoader {
         $question->pluginfiles = $files;
 
         // Based on moodles base question type.
-        $question->name = (string) $xmldata->question->name->text;
-        $question->questiontext = (string) $xmldata->question->questiontext->text;
-        $question->questiontextformat = (string) $xmldata->question->questiontext['format'];
-        $question->generalfeedback = (string) $xmldata->question->generalfeedback->text;
+        $question->name = (string) $xmldata->question->name->text ? (string) $xmldata->question->name->text : 'Question';
+        $question->questiontext = (string) $xmldata->question->questiontext->text ?
+            (string) $xmldata->question->questiontext->text : '<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>';
+        $question->questiontextformat = (string) $xmldata->question->questiontext['format'] ? (string) $xmldata->question->questiontext['format'] : 'html';
+        $question->generalfeedback = (string) $xmldata->question->generalfeedback->text ? (string) $xmldata->question->generalfeedback->text : '';
         $question->generalfeedbackformat = (string) $xmldata->question->generalfeedback['format'];
         $question->defaultmark = (array) $xmldata->question->defaultgrade ? (float) $xmldata->question->defaultgrade : 1.0;
         $question->penalty = (array) $xmldata->question->penalty ? (float) $xmldata->question->penalty : 0.1;
 
         // Based on initialise_question_instance from questiontype.php.
-        $question->stackversion              = (string) $xmldata->question->stackversion->text;
-        $question->questionvariables         = (string) $xmldata->question->questionvariables->text;
-        $question->questionnote              = (string) $xmldata->question->questionnote->text;
-        $question->specificfeedback          = (string) $xmldata->question->specificfeedback->text;
-        $question->specificfeedbackformat    = (string) $xmldata->question->specificfeedback['format'];
-        $question->questiondescription       = (string) $xmldata->question->questiondescription->text;
-        $question->questiondescriptionformat = (string) $xmldata->question->questiondescription['format'];
+        $question->stackversion              = (string) $xmldata->question->stackversion->text ? (string) $xmldata->question->stackversion->text : '';
+        $question->questionvariables         = (string) $xmldata->question->questionvariables->text ? (string) $xmldata->question->questionvariables->text : 'ta1:1;';
+        $question->questionnote              = (string) $xmldata->question->questionnote->text ? (string) $xmldata->question->questionnote->text : '{@ta1@}';
+        $question->questionnoteformat        = (string) $xmldata->question->questionnote['format'] ? (string) $xmldata->question->questionnote['format'] : 'html';
+        $question->specificfeedback          = (string) $xmldata->question->specificfeedback->text ? (string) $xmldata->question->specificfeedback->text : '[[feedback:prt1]]';
+        $question->specificfeedbackformat    = (string) $xmldata->question->specificfeedback['format'] ? (string) $xmldata->question->specificfeedback['format'] : 'html';
+        $question->questiondescription       = (string) $xmldata->question->questiondescription->text ? (string) $xmldata->question->questiondescription->text : '';
+        $question->questiondescriptionformat = (string) $xmldata->question->questiondescription['format'] ? (string) $xmldata->question->questiondescription['format'] : 'html';
         if (isset($xmldata->question->prtcorrect->text)) {
             $question->prtcorrect                = (string) $xmldata->question->prtcorrect->text;
             $question->prtcorrectformat          = (string) $xmldata->question->prtcorrect['format'];
@@ -104,7 +106,7 @@ class StackQuestionLoader {
             $question->prtincorrect = get_string('defaultprtincorrectfeedback', null, null);
             $question->prtincorrectformat = 'html';
         }
-        $question->variantsselectionseed     = (string) $xmldata->question->variantsselectionseed;
+        $question->variantsselectionseed     = (string) $xmldata->question->variantsselectionseed ? (string) $xmldata->question->variantsselectionseed : '';
         $question->compiledcache             = [];
 
         $question->options = new \stack_options();
@@ -169,6 +171,14 @@ class StackQuestionLoader {
             $inputmap[(string) $input->name] = $input;
         }
 
+        if (empty($inputmap)) {
+            $defaultinput = new \StdClass();
+            $defaultinput->name = 'ans1';
+            $defaultinput->type = 'algebraic';
+            $defaultinput->tans = 'ta1';
+            $inputmap['ans1'] = $defaultinput;
+        }
+
         $requiredparams = \stack_input_factory::get_parameters_used();
         foreach ($inputmap as $name => $inputdata) {
             $allparameters = [
@@ -195,32 +205,46 @@ class StackQuestionLoader {
                 'options'         => isset($inputdata->options) ? (string) $inputdata->options : '',
             ];
             $parameters = [];
-            foreach ($requiredparams[(string) $inputdata->type] as $paramname) {
+            $inputtype = (string) $inputdata->type ? (string) $inputdata->type : 'algebraic';
+            foreach ($requiredparams[$inputtype] as $paramname) {
                 if ($paramname == 'inputType') {
                     continue;
                 }
                 $parameters[$paramname] = $allparameters[$paramname];
             }
             $question->inputs[$name] = \stack_input_factory::make(
-                (string) $inputdata->type, (string) $inputdata->name, (string) $inputdata->tans, $question->options, $parameters);
+                $inputtype, (string) $inputdata->name, (string) $inputdata->tans, $question->options, $parameters);
         }
 
         $totalvalue = 0;
         $allformative = true;
-        foreach ($xmldata->question->prt as $prtdata) {
+        $questionprt = $xmldata->question->prt;
+        if (empty($questionprt)) {
+            $defaultprt = new \StdClass();
+            $defaultprt->name = 'prt1';
+            $defaultnode = new \StdClass();
+            $defaultnode->name = '0';
+            $defaultnode->sans = 'ans1';
+            $defaultnode->tans = 'ta1';
+            $defaultnode->trueanswernote = 'prt1-1-T';
+            $defaultnode->falseanswernote = 'prt1-1-F';
+            $defaultprt->node = [$defaultnode];
+            $questionprt = [$defaultprt];
+        }
+        foreach ($questionprt as $prtdata) {
             // At this point we do not have the PRT method is_formative() available to us.
-            if (((int) $prtdata->feedbackstyle) > 0) {
-                $totalvalue += (float) $prtdata->value;
+            if (!isset($prtdata->feedbackstyle) || ((int) $prtdata->feedbackstyle) > 0) {
+                $totalvalue += isset($prtdata->value) ? (float) $prtdata->value : 1;
                 $allformative = false;
             }
         }
-        if (count($xmldata->question->prt) > 0 && !$allformative && $totalvalue < 0.0000001) {
+        if (count($questionprt) > 0 && !$allformative && $totalvalue < 0.0000001) {
             throw new \stack_exception('There is an error authoring your question. ' .
                 'The $totalvalue, the marks available for the question, must be positive in question ' .
                 $question->name);
         }
 
-        foreach ($xmldata->question->prt as $prtdata) {
+        foreach ($questionprt as $prtdata) {
             $prtvalue = 0;
             if (!$allformative) {
                 $prtvalue = ((float)$prtdata->value) / $totalvalue;
@@ -233,7 +257,7 @@ class StackQuestionLoader {
             $data->value = (array) $prtdata->value ? (float) $prtdata->value : 1.0;
             $data->firstnodename = null;
 
-            $data->feedbackvariables = (string) $prtdata->feedbackvariables->text;
+            $data->feedbackvariables = (string) $prtdata->feedbackvariables->text ? (string) $prtdata->feedbackvariables->text : '';
 
             $data->nodes = [];
             foreach ($prtdata->node as $node) {
@@ -244,24 +268,24 @@ class StackQuestionLoader {
                 $newnode->answertest = isset($node->answertest) ? (string) $node->answertest : 'AlgEquiv';
                 $newnode->sans = (string) $node->sans;
                 $newnode->tans = (string) $node->tans;
-                $newnode->testoptions = (string) $node->testoptions;
-                $newnode->quiet = self::parseboolean($node->quiet);
+                $newnode->testoptions = (string) $node->testoptions ? (string) $node->testoptions : '';
+                $newnode->quiet = isset($node->quiet) ? self::parseboolean($node->quiet) : false;
 
-                $newnode->truescoremode = (array) $node->truescoremode ? (string) $node->truescoremode : '+';
-                $newnode->truescore = (array) $node->truescore ? (string) $node->truescore : 1.0;
+                $newnode->truescoremode = (array) $node->truescoremode ? (string) $node->truescoremode : '=';
+                $newnode->truescore = (array) $node->truescore ? (string) $node->truescore : '1.0';
                 $newnode->truepenalty = (array) $node->truepenalty ? (string) $node->truepenalty : null;
                 $newnode->truenextnode = (array) $node->truenextnode ? (string) $node->truenextnode : '-1';
-                $newnode->trueanswernote = (string) $node->trueanswernote;
-                $newnode->truefeedback = (string) $node->truefeedback->text;
-                $newnode->truefeedbackformat = (string) $node->truefeedback['format'];
+                $newnode->trueanswernote = (string) $node->trueanswernote ? (string) $node->trueanswernote : '';
+                $newnode->truefeedback = (string) $node->truefeedback->text ? (string) $node->truefeedback->text : '';
+                $newnode->truefeedbackformat = (string) $node->truefeedback['format'] ? (string) $node->truefeedback['format'] : 'html';
 
                 $newnode->falsescoremode = (array) $node->falsescoremode ? (string) $node->falsescoremode : '=';
-                $newnode->falsescore = (array) $node->falsescore ? (string) $node->falsescore : 0.0;
+                $newnode->falsescore = (array) $node->falsescore ? (string) $node->falsescore : '0.0';
                 $newnode->falsepenalty = (array) $node->falsepenalty ? (string) $node->falsepenalty : null;
                 $newnode->falsenextnode = (array) $node->falsenextnode ? (string) $node->falsenextnode : '-1';
-                $newnode->falseanswernote = (string) $node->falseanswernote;
-                $newnode->falsefeedback = (string) $node->falsefeedback->text;
-                $newnode->falsefeedbackformat = (string) $node->falsefeedback['format'];
+                $newnode->falseanswernote = (string) $node->falseanswernote ? (string) $node->falseanswernote : '';
+                $newnode->falsefeedback = (string) $node->falsefeedback->text ? (string) $node->falsefeedback->text : '';
+                $newnode->falsefeedbackformat = (string) $node->falsefeedback['format'] ? (string) $node->falsefeedback['format'] : 'html';
 
                 $data->nodes[(int) $node->name] = $newnode;
             }

--- a/tests/api_controller_test.php
+++ b/tests/api_controller_test.php
@@ -240,6 +240,29 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(0, count($this->output->iframes));
     }
 
+    public function test_default(): void {
+        $this->requestdata['questionDefinition'] = stack_api_test_data::get_question_string('empty');
+        $this->requestdata['answers'] = (array) json_decode(stack_api_test_data::get_answer_string('empty'));
+        $this->requestdata['inputName'] = 'ans1';
+        $rc = new RenderController();
+        $rc->__invoke($this->request, $this->response, []);
+        $this->assertEquals('<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>', $this->output->questionrender);
+        $vc = new ValidationController();
+        $vc->__invoke($this->request, $this->response, []);
+        $this->assertStringContainsString('Your last answer was interpreted as follows:', $this->output->validation);
+        $this->assertStringContainsString('\[ 1 \]', $this->output->validation);
+        $gc = new GradingController();
+        $gc->__invoke($this->request, $this->response, []);
+        $this->assertEquals(true, $this->output->isgradable);
+        $this->assertEquals(1, $this->output->score);
+        $this->assertEquals(1, $this->output->scores->prt1);
+        $this->assertEquals(1, $this->output->scores->total);
+        $this->assertEquals(1, $this->output->scoreweights->prt1);
+        $this->assertEquals(1, $this->output->scoreweights->total);
+        $this->assertEquals('[[feedback:prt1]]', $this->output->specificfeedback);
+        $this->assertStringContainsString('correct', $this->output->prts->prt1);
+    }
+
     public function test_grade_scores(): void {
 
         $this->requestdata['questionDefinition'] = stack_api_test_data::get_question_string('multipleanswers');

--- a/tests/api_stackquestionloader_test.php
+++ b/tests/api_stackquestionloader_test.php
@@ -132,5 +132,29 @@ final class api_stackquestionloader_test extends qtype_stack_testcase {
         $ql = new StackQuestionLoader();
         $question = $ql->loadXML($xml)['question'];
         $this->assertEquals('Question', $question->name);
+        $this->assertEquals('Correct answer, well done.', $question->prtcorrect);
+        $this->assertEquals('html', $question->prtcorrectformat);
+        $this->assertEquals('-1', $question->prts['prt1']->get_nodes_summary()[0]->truenextnode);
+        $this->assertEquals('prt1-1-T', $question->prts['prt1']->get_nodes_summary()[0]->trueanswernote);
+        $this->assertEquals(1, $question->prts['prt1']->get_nodes_summary()[0]->truescore);
+        $this->assertEquals('=', $question->prts['prt1']->get_nodes_summary()[0]->truescoremode);
+        $this->assertEquals('-1', $question->prts['prt1']->get_nodes_summary()[0]->falsenextnode);
+        $this->assertEquals('prt1-1-F', $question->prts['prt1']->get_nodes_summary()[0]->falseanswernote);
+        $this->assertEquals(0, $question->prts['prt1']->get_nodes_summary()[0]->falsescore);
+        $this->assertEquals('=', $question->prts['prt1']->get_nodes_summary()[0]->falsescoremode);
+        $this->assertEquals(false, $question->prts['prt1']->get_nodes_summary()[0]->quiet);
+        $this->assertEquals('ATAlgEquiv(ans1,ta1)', $question->prts['prt1']->get_nodes_summary()[0]->answertest);
+        $this->assertEquals($question->inputs['ans1']->get_parameter('mustVerify'), get_config('qtype_stack', 'inputmustverify'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('showValidation'),
+                get_config('qtype_stack', 'inputshowvalidation'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('insertStars'), get_config('qtype_stack', 'inputinsertstars'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('forbidFloats'),
+                get_config('qtype_stack', 'inputforbidfloat'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('lowestTerms'),
+                get_config('qtype_stack', 'inputrequirelowestterms'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('sameType'),
+                get_config('qtype_stack', 'inputcheckanswertype'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('forbidWords'), get_config('qtype_stack', 'inputforbidwords'));
+        $this->assertEquals($question->inputs['ans1']->get_parameter('boxWidth'), get_config('qtype_stack', 'inputboxsize'));
     }
 }

--- a/tests/api_stackquestionloader_test.php
+++ b/tests/api_stackquestionloader_test.php
@@ -125,4 +125,12 @@ final class api_stackquestionloader_test extends qtype_stack_testcase {
         $this->assertEquals($question->inputs['ans1']->get_parameter('forbidWords'), 'test');
         $this->assertEquals($question->inputs['ans1']->get_parameter('boxWidth'), 30);
     }
+
+    public function test_question_loader_base_question(): void {
+        global $CFG;
+        $xml = stack_api_test_data::get_question_string('empty');
+        $ql = new StackQuestionLoader();
+        $question = $ql->loadXML($xml)['question'];
+        $this->assertEquals('Question', $question->name);
+    }
 }

--- a/tests/fixtures/apifixtures.class.php
+++ b/tests/fixtures/apifixtures.class.php
@@ -26,6 +26,11 @@
 class stack_api_test_data {
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     protected static array $questiondata = [
+        'empty' =>
+           '<quiz>
+              <question type="stack">	
+              </question>
+            </quiz>',
         'matrices' =>
            '<quiz>
                 <question type="stack">

--- a/tests/fixtures/apifixtures.class.php
+++ b/tests/fixtures/apifixtures.class.php
@@ -1744,6 +1744,7 @@ class stack_api_test_data {
     protected static array $answers = [
         'matrices_correct' => '{"ans1_sub_0_0": "35", "ans1_sub_0_1": "30", "ans1_sub_1_0": "28", "ans1_sub_1_1": "24"}',
         'multiple_mixed' => '{"ans1": "3", "ans2": "1", "ans3": "0", "ans4": "0"}',
+        'empty' => '{"ans1": "1"}'
     ];
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function


### PR DESCRIPTION
- Add defaults for everything in the API question loader. It should now be possible for the API to fill in the blanks if a partial XML file is used. If there are no inputs, a single algebraic input will be created. If there are no PRTs a single AlgEquiv node will be created.
- Fix bug where API could not access the STACK library after previous code tidy.