### PR TITLE
Fix to update interaction with oumaths text filters for Moodle 4.5

### DIFF
--- a/stack/mathsoutput/mathsoutputoumaths.class.php
+++ b/stack/mathsoutput/mathsoutputoumaths.class.php
@@ -30,15 +30,6 @@ require_once(__DIR__ . '/mathsoutputfilterbase.class.php');
  */
 class stack_maths_output_oumaths extends stack_maths_output_filter_base {
 
-    /**
-     * Add description here.
-     * @return boolean is the OU maths filter installed?
-     */
-    public static function filter_is_installed() {
-        global $CFG;
-        return file_exists($CFG->dirroot . '/filter/oumaths/filter.php');
-    }
-
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     protected function initialise_delimiters() {
         $this->displaystart = '&lt;tex mode="display"&gt;';
@@ -51,11 +42,14 @@ class stack_maths_output_oumaths extends stack_maths_output_filter_base {
     protected function make_filter() {
         global $CFG;
 
-        if (!self::filter_is_installed()) {
-            throw new coding_exception('The OU maths filter is not installed.');
+        if (class_exists('\filter_oumaths\text_filter')) {
+            return new \filter_oumaths\text_filter(context_system::instance(), []);
+        } else if (file_exists($CFG->dirroot . '/filter/oumaths/filter.php')) {
+            // Once Moodle 4.5 is the lowest supported version of Moodle.
+            require_once($CFG->libdir . '/filterlib.php');
+            require_once($CFG->dirroot . '/filter/oumaths/filter.php');
+            return new filter_oumaths(context_system::instance(), []);
         }
-
-        require_once($CFG->dirroot . '/filter/oumaths/filter.php');
-        return new filter_oumaths(context_system::instance(), []);
+        throw new coding_exception('The OU maths filter is not installed.');
     }
 }


### PR DESCRIPTION
Hi Chris,

We noticed the issue using oumaths filter with Moodle 4.5, as now the filters are moved to be in namespaced class filter_name\text_filter. Could you please review?

 I have verified that its been fixed for tex and mathjax filters.

Thanks,
Anu 