### PR TITLE
ISS1422 - Moodle core unit test failures on restore

### DIFF
--- a/backup/moodle2/backup_qtype_stack_plugin.class.php
+++ b/backup/moodle2/backup_qtype_stack_plugin.class.php
@@ -68,12 +68,12 @@ class backup_qtype_stack_plugin extends backup_qtype_plugin {
                 ]);
 
         $stackprts = new backup_nested_element('stackprts');
-        //ISS1422 - Change firstnode to firstnodename to match DB. Looks like the field was added later and there's
+        // ISS1422 - Change firstnode to firstnodename to match DB. Looks like the field was added later and there's
         // code to fill it in on restore if it isn't in the backup file... which it never has been.
         $stackprt = new backup_nested_element('stackprt', ['id'],
                 ['name', 'value', 'autosimplify', 'feedbackstyle', 'feedbackvariables', 'firstnodename']);
 
-        //ISS1422 - Add description. Presumably should be here.
+        // ISS1422 - Add description. Presumably should be here.
         $stackprtnodes = new backup_nested_element('stackprtnodes');
         $stackprtnode = new backup_nested_element('stackprtnode', ['id'],
                 [

--- a/backup/moodle2/backup_qtype_stack_plugin.class.php
+++ b/backup/moodle2/backup_qtype_stack_plugin.class.php
@@ -68,13 +68,16 @@ class backup_qtype_stack_plugin extends backup_qtype_plugin {
                 ]);
 
         $stackprts = new backup_nested_element('stackprts');
+        //ISS1422 - Change firstnode to firstnodename to match DB. Looks like the field was added later and there's
+        // code to fill it in on restore if it isn't in the backup file... which it never has been.
         $stackprt = new backup_nested_element('stackprt', ['id'],
-                ['name', 'value', 'autosimplify', 'feedbackstyle', 'feedbackvariables', 'firstnode']);
+                ['name', 'value', 'autosimplify', 'feedbackstyle', 'feedbackvariables', 'firstnodename']);
 
+        //ISS1422 - Add description. Presumably should be here.
         $stackprtnodes = new backup_nested_element('stackprtnodes');
         $stackprtnode = new backup_nested_element('stackprtnode', ['id'],
                 [
-                    'nodename', 'answertest', 'sans', 'tans', 'testoptions', 'quiet',
+                    'nodename', 'description', 'answertest', 'sans', 'tans', 'testoptions', 'quiet',
                     'truescoremode', 'truescore', 'truepenalty', 'truenextnode',
                     'trueanswernote', 'truefeedback', 'truefeedbackformat',
                     'falsescoremode', 'falsescore', 'falsepenalty', 'falsenextnode',

--- a/backup/moodle2/restore_qtype_stack_plugin.class.php
+++ b/backup/moodle2/restore_qtype_stack_plugin.class.php
@@ -156,11 +156,8 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
         }
 
         $questiondata->options->deployedseeds = [];
-        if (isset($backupdata["plugin_qtype_stack_question"]['deployedseeds'])) {
-            $questiondata->options->deployedseeds = (object) array_merge(
-                (array) $questiondata->options->deployedseeds,
-                $backupdata["plugin_qtype_stack_question"]['deployedseeds'][0],
-            );
+        foreach ($backupdata["plugin_qtype_stack_question"]['stackdeployedseeds']['stackdeployedseed'] ?? [] as $seed) {
+            $questiondata->options->deployedseeds[] = $seed['seed'];
         }
 
         return $questiondata;

--- a/backup/moodle2/restore_qtype_stack_plugin.class.php
+++ b/backup/moodle2/restore_qtype_stack_plugin.class.php
@@ -69,6 +69,114 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
     }
 
     /**
+     * Creates the data to be hashed in restore_questions_parser_processor::generate_question_identity_hash().
+     * Resulting hash must match that obtained using output from qtype_stack->get_question_options() in
+     * order to detect duplicate questions.
+     * @param array $backupdata
+     * @return stdClass
+     */
+    public static function convert_backup_to_questiondata(array $backupdata): stdClass {
+        $questiondata = parent::convert_backup_to_questiondata($backupdata);
+        if (isset($backupdata["plugin_qtype_stack_question"]['stackoptions'])) {
+            $questiondata->options = (object) array_merge(
+                (array) $questiondata->options,
+                $backupdata["plugin_qtype_stack_question"]['stackoptions'][0],
+            );
+        }
+        if (!property_exists($questiondata->options, 'stackversion')) {
+            $questiondata->options->stackversion = '';
+        }
+
+        if (!property_exists($questiondata->options, 'inversetrig')) {
+            $questiondata->options->inversetrig = 'cos-1';
+        }
+
+        if (!property_exists($questiondata->options, 'logicsymbol')) {
+            $questiondata->options->logicsymbol = 'lang';
+        }
+
+        if (!property_exists($questiondata->options, 'matrixparens')) {
+            $questiondata->options->matrixparens = '[';
+        }
+
+        if (!property_exists($questiondata->options, 'questiondescription')) {
+            $questiondata->options->questiondescription = '';
+        }
+
+        $questiondata->options->inputs = [];
+        foreach ($backupdata["plugin_qtype_stack_question"]['stackinputs']['stackinput'] ?? [] as $input) {
+            $questiondata->options->inputs[$input['name']] = (object) $input;
+        }
+
+        foreach ($questiondata->options->inputs as $input) {
+            if (!property_exists($input, 'options')) {
+                $input->options = '';
+            }
+            unset($input->id);
+        }
+
+        $questiondata->options->prts = [];
+        foreach ($backupdata["plugin_qtype_stack_question"]['stackprts']['stackprt'] ?? [] as $prt) {
+            $nodes = [];
+            unset($prt['id']);
+            foreach ($prt['stackprtnodes']['stackprtnode'] as $node) {
+                $node['prtname'] = $prt['name'];
+                unset($node['id']);
+                unset($node['questionid']);
+                $nodes[] = $node;
+            }
+            unset($prt['stackprtnodes']);
+            if (!isset($prt['firstnodename'])) {
+                $graph = new stack_abstract_graph();
+                foreach ($nodes as $node) {
+                    if ($node['truenextnode'] == -1) {
+                        $left = null;
+                    } else {
+                        $left = (int) $node['truenextnode'] + 1;
+                    }
+                    if ($node['falsenextnode'] == -1) {
+                        $right = null;
+                    } else {
+                        $right = (int) $node['falsenextnode'] + 1;
+                    }
+                    $graph->add_node((int) $node['nodename'] + 1, $node['description'], $left, $right);
+                }
+                try {
+                    $graph->layout();
+                } catch (Exception $e) {
+                    $prt['firstnodename'] = -1;
+                }
+
+                $roots = $graph->get_roots();
+                reset($roots);
+                $prt['firstnodename'] = key($roots) - 1;
+            }
+            $prt['nodes'] = $nodes;
+            $questiondata->options->prts[$prt['name']] = (object) $prt;
+        }
+
+        $questiondata->options->deployedseeds = [];
+        if (isset($backupdata["plugin_qtype_stack_question"]['deployedseeds'])) {
+            $questiondata->options->deployedseeds = (object) array_merge(
+                (array) $questiondata->options->deployedseeds,
+                $backupdata["plugin_qtype_stack_question"]['deployedseeds'][0],
+            );
+        }
+
+        return $questiondata;
+    }
+
+    /**
+     * Fields to exclude from hash to detect duplicate questions.
+     * @return string[]
+     */
+    protected function define_excluded_identity_hash_fields(): array {
+        return [
+            '/options/compiledcache',
+        ];
+    }
+
+    /**
      * Process the STACK options.
      * @param array/object $data the data from the backup file.
      */

--- a/backup/moodle2/restore_qtype_stack_plugin.class.php
+++ b/backup/moodle2/restore_qtype_stack_plugin.class.php
@@ -170,6 +170,12 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
     protected function define_excluded_identity_hash_fields(): array {
         return [
             '/options/compiledcache',
+            '/prts/questionid',
+            '/prts/id',
+            '/prts/nodes/questionid',
+            '/prts/nodes/id',
+            '/inputs/questionid',
+            '/inputs/id',
         ];
     }
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -416,15 +416,17 @@ class qtype_stack extends question_type {
         $question->options = $DB->get_record('qtype_stack_options',
                 ['questionid' => $question->id], '*', MUST_EXIST);
 
+        // ISS1422 - Remove id and questionids as dependent on question instance and
+        // causing restore hash not to match.
         $question->inputs = $DB->get_records('qtype_stack_inputs',
                 ['questionid' => $question->id], 'name',
-                'name, id, questionid, type, tans, boxsize, strictsyntax, insertstars, ' .
+                'name, type, tans, boxsize, strictsyntax, insertstars, ' .
                 'syntaxhint, syntaxattribute, forbidwords, allowwords, forbidfloat, requirelowestterms, ' .
                 'checkanswertype, mustverify, showvalidation, options');
 
         $question->prts = $DB->get_records('qtype_stack_prts',
                 ['questionid' => $question->id], 'name',
-                'name, id, questionid, value, autosimplify, feedbackstyle, feedbackvariables, firstnodename');
+                'name, value, autosimplify, feedbackstyle, feedbackvariables, firstnodename');
 
         $noders = $DB->get_recordset('qtype_stack_prt_nodes',
                 ['questionid' => $question->id],
@@ -434,6 +436,8 @@ class qtype_stack extends question_type {
                 $question->prts[$node->prtname]->nodes = [];
             }
             $question->prts[$node->prtname]->nodes[$node->nodename] = $node;
+            unset($question->prts[$node->prtname]->nodes[$node->nodename]->id);
+            unset($question->prts[$node->prtname]->nodes[$node->nodename]->questionid);
         }
         $noders->close();
 

--- a/questiontype.php
+++ b/questiontype.php
@@ -416,17 +416,15 @@ class qtype_stack extends question_type {
         $question->options = $DB->get_record('qtype_stack_options',
                 ['questionid' => $question->id], '*', MUST_EXIST);
 
-        // ISS1422 - Remove id and questionids as dependent on question instance and
-        // causing restore hash not to match.
         $question->inputs = $DB->get_records('qtype_stack_inputs',
                 ['questionid' => $question->id], 'name',
-                'name, type, tans, boxsize, strictsyntax, insertstars, ' .
+                'name, id, questionid, type, tans, boxsize, strictsyntax, insertstars, ' .
                 'syntaxhint, syntaxattribute, forbidwords, allowwords, forbidfloat, requirelowestterms, ' .
                 'checkanswertype, mustverify, showvalidation, options');
 
         $question->prts = $DB->get_records('qtype_stack_prts',
                 ['questionid' => $question->id], 'name',
-                'name, value, autosimplify, feedbackstyle, feedbackvariables, firstnodename');
+                'name, id, questionid, value, autosimplify, feedbackstyle, feedbackvariables, firstnodename');
 
         $noders = $DB->get_recordset('qtype_stack_prt_nodes',
                 ['questionid' => $question->id],
@@ -436,8 +434,6 @@ class qtype_stack extends question_type {
                 $question->prts[$node->prtname]->nodes = [];
             }
             $question->prts[$node->prtname]->nodes[$node->nodename] = $node;
-            unset($question->prts[$node->prtname]->nodes[$node->nodename]->id);
-            unset($question->prts[$node->prtname]->nodes[$node->nodename]->questionid);
         }
         $noders->close();
 

--- a/tests/restore_test.php
+++ b/tests/restore_test.php
@@ -1,0 +1,147 @@
+<?php
+// This file is part of Stack - http://stack.maths.ed.ac.uk/
+//
+// Stack is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Stack is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Stack.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace qtype_stack;
+
+use advanced_testcase;
+use backup_controller;
+use restore_controller;
+use backup;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+require_once($CFG->dirroot . '/question/engine/lib.php');
+require_once($CFG->dirroot . '/mod/quiz/locallib.php');
+require_once($CFG->dirroot . '/course/lib.php');
+require_once($CFG->dirroot . '/mod/quiz/tests/quiz_question_helper_test_trait.php');
+/**
+ * Unit tests for restore.
+ *
+ * @package    qtype_stack
+ * @copyright  2012 The Open University.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
+ * @group qtype_stack
+ */
+final class restore_test extends advanced_testcase {
+
+    /**
+     * Restore a quiz with duplicate questions (same stamp and questions) into the same course.
+     *
+     */
+    public function test_restore_quiz_with_duplicate_questions(): void {
+        global $DB, $USER;
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Create a course and a user with editing teacher capabilities.
+        $generator = $this->getDataGenerator();
+        $course1 = $generator->create_course();
+        $teacher = $USER;
+        $generator->enrol_user($teacher->id, $course1->id, 'editingteacher');
+        $coursecontext = \context_course::instance($course1->id);
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+
+        // Create a question category.
+        $cat = $questiongenerator->create_question_category(['contextid' => $coursecontext->id]);
+
+        // Create a quiz with 2 identical but separate questions.
+        $quiz1 = $this->create_test_quiz($course1);
+        $question1 = $questiongenerator->create_question('stack', 'test1', ['category' => $cat->id]);
+        \quiz_add_quiz_question($question1->id, $quiz1, 0);
+        $question2 = $questiongenerator->create_question('stack', 'test1', ['category' => $cat->id]);
+        \quiz_add_quiz_question($question2->id, $quiz1, 0);
+        $question3 = $questiongenerator->create_question('stack', 'test1', ['category' => $cat->id]);
+        $qtype = new \qtype_stack();
+        $qtype->deploy_variant($question3->id, 1234);
+        $qtype->deploy_variant($question3->id, 27);
+        \quiz_add_quiz_question($question3->id, $quiz1, 0);
+        $question4 = $questiongenerator->create_question('stack', 'test1', ['category' => $cat->id]);
+        \quiz_add_quiz_question($question4->id, $quiz1, 0);
+        $qtype->deploy_variant($question4->id, 1234);
+        $qtype->deploy_variant($question4->id, 27);
+        $question5 = $questiongenerator->create_question('stack', 'test3', ['category' => $cat->id]);
+        \quiz_add_quiz_question($question5->id, $quiz1, 0);
+        $question6 = $questiongenerator->create_question('stack', 'test3', ['category' => $cat->id]);
+        \quiz_add_quiz_question($question6->id, $quiz1, 0);
+
+        // Update question2 to have the same times and stamp as question1.
+        $DB->update_record('question', [
+            'id' => $question2->id,
+            'stamp' => $question1->stamp,
+            'timecreated' => $question1->timecreated,
+            'timemodified' => $question1->timemodified,
+        ]);
+
+        $DB->update_record('question', [
+            'id' => $question4->id,
+            'stamp' => $question3->stamp,
+            'timecreated' => $question3->timecreated,
+            'timemodified' => $question3->timemodified,
+        ]);
+
+        $DB->update_record('question', [
+            'id' => $question6->id,
+            'stamp' => $question5->stamp,
+            'timecreated' => $question5->timecreated,
+            'timemodified' => $question5->timemodified,
+        ]);
+
+        // Backup quiz.
+        $bc = new backup_controller(backup::TYPE_1ACTIVITY, $quiz1->cmid, backup::FORMAT_MOODLE,
+            backup::INTERACTIVE_NO, backup::MODE_IMPORT, $teacher->id);
+        $backupid = $bc->get_backupid();
+        $bc->execute_plan();
+        $bc->destroy();
+
+        // Restore the backup into the same course.
+        $rc = new restore_controller($backupid, $course1->id, backup::INTERACTIVE_NO, backup::MODE_IMPORT,
+            $teacher->id, backup::TARGET_CURRENT_ADDING);
+        $rc->execute_precheck();
+        $rc->execute_plan();
+        $rc->destroy();
+
+        // Expect that the restored quiz will have the second question in both its slots
+        // by virtue of identical stamp, version, and hash of question answer texts.
+        $modules = \get_fast_modinfo($course1->id)->get_instances_of('quiz');
+        $this->assertCount(2, $modules);
+        $quiz2 = end($modules);
+        $quiz2structure = \mod_quiz\question\bank\qbank_helper::get_question_structure($quiz2->instance, $quiz2->context);
+        $this->assertEquals($quiz2structure[1]->questionid, $quiz2structure[2]->questionid);
+        $this->assertEquals($quiz2structure[3]->questionid, $quiz2structure[4]->questionid);
+        $this->assertEquals($quiz2structure[5]->questionid, $quiz2structure[6]->questionid);
+    }
+
+    /**
+     * Create a test quiz for the specified course.
+     *
+     * @param \stdClass $course
+     * @return  \stdClass
+     */
+    protected function create_test_quiz(\stdClass $course): \stdClass {
+        /** @var mod_quiz_generator $quizgenerator */
+        $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
+
+        return $quizgenerator->create_instance([
+            'course' => $course->id,
+            'questionsperpage' => 0,
+            'grade' => 100.0,
+            'sumgrades' => 2,
+        ]);
+    }
+}

--- a/tests/restore_test.php
+++ b/tests/restore_test.php
@@ -37,6 +37,7 @@ require_once($CFG->dirroot . '/mod/quiz/tests/quiz_question_helper_test_trait.ph
  * @copyright  2012 The Open University.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later.
  * @group qtype_stack
+ * @covers \qtype_stack
  */
 final class restore_test extends advanced_testcase {
 

--- a/tests/restore_test.php
+++ b/tests/restore_test.php
@@ -45,7 +45,10 @@ final class restore_test extends advanced_testcase {
      *
      */
     public function test_restore_quiz_with_duplicate_questions(): void {
-        global $DB, $USER;
+        global $DB, $USER, $CFG;
+        if ($CFG->version < 2024100703) {
+            return;
+        }
         $this->resetAfterTest();
         $this->setAdminUser();
 


### PR DESCRIPTION
#1422 

- Changes also fix apparent issues with backing up of node descriptions and prt firstnodename.
- I've created our own version of the test to make sure it works with some more complex questions.
- I figured out the proper way to avoid making changes to questiontype->get_question_options() in the end.
- Worth checking hard there's no way the new convert_backup_to_questiondata() method can throw an error because a restore failing would be much worse than some duplicate questions.