### PR TITLE
iss1436 - Question library fixes

### DIFF
--- a/stack/cas/castext2/blocks/textdownload.block.php
+++ b/stack/cas/castext2/blocks/textdownload.block.php
@@ -95,6 +95,9 @@ class stack_cas_castext2_textdownload extends stack_cas_castext2_block {
         castext2_placeholder_holder $holder): string {
         if (get_config('qtype_stack', 'stackapi')) {
             return "javascript:download('{$params[1]}', {$params[2]});";
+        } else if (!isset($processor->qa) || !function_exists($processor->qa->get_database_id)) {
+            // ISS1436 - Basic fix for STACK library where there is no question attempt.
+            return "#";
         } else {
             // Note different systems serve out through different logic.
             if (count($params) > 3 && $params[3] === 'stateful') {

--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -1422,7 +1422,9 @@ abstract class stack_input {
      * @param string student's current answer to insert into the xhtml.
      * @param string $fieldname the field name to use in the HTML for this input.
      * @param bool $readonly whether the control should be displayed read-only.
-     * @param array $tavalue the value of the teacher's answer for this input.
+     * ISS1436 - As far as I can tell, only equiv input is using $tavalue
+     * and that's expecting a string not an array.
+     * @param string $tavalue the value of the teacher's answer for this input.
      * @return string HTML for this input.
      */
     abstract public function render(stack_input_state $state, $fieldname, $readonly, $tavalue);

--- a/stack/questionlibrary.class.php
+++ b/stack/questionlibrary.class.php
@@ -90,7 +90,9 @@ class stack_question_library {
             $tavalue = $question->get_ta_for_input($name);
             $fieldname = 'stack_temp_' . $name;
             $state = $question->get_input_state($name, []);
-            $render = $input->render($state, $fieldname, false, [$tavalue]);
+            // ISS1436 - As far as I can tell, only equiv input is using $tavalue
+            // and that's expecting a string not an array.
+            $render = $input->render($state, $fieldname, false, $tavalue);
             StackPlotReplacer::replace_plots($plots, $render, "answer-".$name, $storeprefix);
             $questiontext = str_replace("[[input:{$name}]]",
                 $render,


### PR DESCRIPTION
#1436

- Add dummy link for textdownload blocks when rendering in STACK library (i.e. when there's no question attempt).
- Correct type of tavalue for inputs from array to string.