### PR TITLE
MDL-83541: Fix loading of backup data into questiondata object in restore_qtype_stack_plugin::convert_backup_to_questiondata()

### DIFF
--- a/backup/moodle2/restore_qtype_stack_plugin.class.php
+++ b/backup/moodle2/restore_qtype_stack_plugin.class.php
@@ -103,19 +103,19 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
             $questiondata->options->questiondescription = '';
         }
 
-        $questiondata->options->inputs = [];
+        $questiondata->inputs = [];
         foreach ($backupdata["plugin_qtype_stack_question"]['stackinputs']['stackinput'] ?? [] as $input) {
-            $questiondata->options->inputs[$input['name']] = (object) $input;
+            $questiondata->inputs[$input['name']] = (object) $input;
         }
 
-        foreach ($questiondata->options->inputs as $input) {
+        foreach ($questiondata->inputs as $input) {
             if (!property_exists($input, 'options')) {
                 $input->options = '';
             }
             unset($input->id);
         }
 
-        $questiondata->options->prts = [];
+        $questiondata->prts = [];
         foreach ($backupdata["plugin_qtype_stack_question"]['stackprts']['stackprt'] ?? [] as $prt) {
             $prt['name'] = (isset($prt['name'])) ? $prt['name'] : '';
             $nodes = [];
@@ -162,12 +162,12 @@ class restore_qtype_stack_plugin extends restore_qtype_plugin {
                 $prt['firstnodename'] = key($roots) - 1;
             }
             $prt['nodes'] = $nodes;
-            $questiondata->options->prts[$prt['name']] = (object) $prt;
+            $questiondata->prts[$prt['name']] = (object) $prt;
         }
 
-        $questiondata->options->deployedseeds = [];
+        $questiondata->deployedseeds = [];
         foreach ($backupdata["plugin_qtype_stack_question"]['stackdeployedseeds']['stackdeployedseed'] ?? [] as $seed) {
-            $questiondata->options->deployedseeds[] = $seed['seed'];
+            $questiondata->deployedseeds[] = $seed['seed'];
         }
 
         return $questiondata;


### PR DESCRIPTION
This PR addresses #1431 / [MDL-83541](https://tracker.moodle.org/browse/MDL-83541). For developer information see here: https://moodledev.io/docs/5.0/apis/plugintypes/qtype/restore

This PR fixes `restore_qtype_stack_plugin::convert_backup_to_questiondata()`. Before this PR, additional question data (`inputs`, `prts`, and `deployedseeds`) were falsely loaded as sub-objects of `$questiondata->options` instead of loading them into `$questiondata` directly. The latter is correct as indicated by [qtype_stack::get_question_options()](https://github.com/maths/moodle-qtype_stack/blob/d4a97adc408edab6acb485f94f597f3e8d073fd4/questiontype.php#L411) and many other occurrences. This resulted in identical questions not being identified as such during a restore operation, causing identical questions to be duplicated falsely.

The proposed change prevents identical questions from falesly being duplicated during restore and makes `mod/quiz/tests/backup/repeated_restore_test.php` pass.