### PR TITLE
Question editing enhancements

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       postgres:

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -41,7 +41,7 @@ jobs:
           - php: '8.2'
             moodle-branch: 'MOODLE_405_STABLE'
             database: 'pgsql'
-            maxima: 'SBCL'
+            maxima: 'GCL'
             moodle-app: true
           - php: '8.2'
             moodle-branch: 'MOODLE_404_STABLE'

--- a/edit_stack_form.php
+++ b/edit_stack_form.php
@@ -218,8 +218,13 @@ class qtype_stack_edit_form extends question_edit_form {
 
         // TO-DO: add in warnings here.  See b764b39675 for deleted materials.
         $warnings = '';
+        if (isset($this->question->id)) {
+            $question = question_bank::load_question($this->question->id);
+            $warnings = implode("<br />", $question->validate_warnings());
+        }
         if (get_class(editors_get_preferred_editor()) !== 'textarea_texteditor') {
-            $warnings = '<i class="icon fa fa-exclamation-circle text-danger fa-fw"></i>' . stack_string('usetextarea');
+            $warnings = ($warnings) ? $warnings . '<br />' : $warnings;
+            $warnings .= '<i class="icon fa fa-exclamation-circle text-danger fa-fw"></i>' . stack_string('usetextarea');
         }
 
         // Note that for the editor elements, we are using $mform->getElement('prtincorrect')->setValue(...); instead

--- a/edit_stack_form.php
+++ b/edit_stack_form.php
@@ -107,10 +107,12 @@ class qtype_stack_edit_form extends question_edit_form {
         // See prepare_text_field() for explanation of swapping formats.
         $editorpreference = get_user_preferences('htmleditor', '', $USER);
         if ($editorpreference === '') {
-            if ($question->questiontextformat == FORMAT_HTML && $this->search_for_scripts($question->questiontext)) {
+            if ((!isset($question->questiontextformat) || $question->questiontextformat == FORMAT_HTML)
+                        && isset($question->questiontext) && $this->search_for_scripts($question->questiontext)) {
                 $question->questiontextformat = FORMAT_PLAIN;
             }
-            if ($question->generalfeedbackformat == FORMAT_HTML && $this->search_for_scripts($question->generalfeedback)) {
+            if ((!isset($question->generalfeedbackformat) || $question->generalfeedbackformat == FORMAT_HTML)
+                        && isset($question->generalfeedback) && $this->search_for_scripts($question->generalfeedback)) {
                 $question->generalfeedbackformat = FORMAT_PLAIN;
             }
         }

--- a/edit_stack_form.php
+++ b/edit_stack_form.php
@@ -992,7 +992,7 @@ class qtype_stack_edit_form extends question_edit_form {
         if (!$text) {
             return false;
         }
-        return preg_match("/<\/jsxgraph>|\[\[jsxgraph|\[\[geogebra|<\/geogebra>|<script/i", $text);
+        return preg_match("/<\/jsxgraph>|\[\[jsxgraph|\[\[geogebra|<\/geogebra>|<script|\[\[javascript|\[\[script|<=|=>/i", $text);
     }
 
 }

--- a/question.php
+++ b/question.php
@@ -1750,17 +1750,18 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         // 2. Check alt-text exists.
         // Reminder: previous approach in Oct 2021 tried to use libxml_use_internal_errors, but this was a dead end.
         $tocheck = [];
-        $text = '';
-        if ($this->questiontextinstantiated !== null) {
-            $text = trim($this->questiontextinstantiated->get_rendered());
-        }
-        if ($text !== '') {
-            $tocheck[stack_string('questiontext')] = $text;
-        }
-        $ct = $this->get_generalfeedback_castext();
-        $text = trim($ct->get_rendered($this->castextprocessor));
-        if ($text !== '') {
-            $tocheck[stack_string('generalfeedback')] = $text;
+        $fields = ['questiontext', 'specificfeedback', 'generalfeedback', 'questiondescription'];
+        foreach ($fields as $field) {
+            $text = '';
+            $fieldinstantiated = $field . 'instantiated';
+            if ($this->{$fieldinstantiated} !== null) {
+                $text = trim($this->{$fieldinstantiated}->get_rendered());
+            } else {
+                $text = trim($this->{$field});
+            }
+            if ($text !== '') {
+                $tocheck[stack_string($field)] = $text;
+            }
         }
         // This is a compromise.  We concatinate all nodes and we don't instantiate this!
         foreach ($this->prts as $prt) {

--- a/tests/editform_test.php
+++ b/tests/editform_test.php
@@ -84,6 +84,7 @@ final class editform_test_class extends \qtype_stack_edit_form {
      * @param mixed $itemid
      * @param mixed $filearea
      * @return array
+     * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
      */
     public function prepare_text_field($field, $text, $format, $itemid, $filearea = '') {
         return parent::prepare_text_field($field, $text, $format, $itemid, $filearea);
@@ -114,7 +115,7 @@ final class editform_test extends \advanced_testcase {
         return new editform_test_class($questiontext, $specificfeedback, $quizmoduleid);
     }
 
-    public function x_test_get_input_names_from_question_text_default(): void {
+    public function test_get_input_names_from_question_text_default(): void {
 
         $form = $this->get_form(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
                 \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK);
@@ -124,7 +125,7 @@ final class editform_test extends \advanced_testcase {
                 $qtype->get_input_names_from_question_text(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT));
     }
 
-    public function x_test_get_prt_names_from_question_default(): void {
+    public function test_get_prt_names_from_question_default(): void {
 
         $form = $this->get_form(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
                 \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK);

--- a/tests/editform_test.php
+++ b/tests/editform_test.php
@@ -76,6 +76,19 @@ final class editform_test_class extends \qtype_stack_edit_form {
         parent::__construct(new \moodle_url('/'), $fakequestion, $category, $contexts);
     }
 
+    /**
+     * Public override of parent function to allow access.
+     * @param mixed $field
+     * @param mixed $text
+     * @param mixed $format
+     * @param mixed $itemid
+     * @param mixed $filearea
+     * @return array
+     */
+    public function prepare_text_field($field, $text, $format, $itemid, $filearea = '') {
+        return parent::prepare_text_field($field, $text, $format, $itemid, $filearea);
+    }
+
 }
 
 /**
@@ -101,7 +114,7 @@ final class editform_test extends \advanced_testcase {
         return new editform_test_class($questiontext, $specificfeedback, $quizmoduleid);
     }
 
-    public function test_get_input_names_from_question_text_default(): void {
+    public function x_test_get_input_names_from_question_text_default(): void {
 
         $form = $this->get_form(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
                 \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK);
@@ -111,7 +124,7 @@ final class editform_test extends \advanced_testcase {
                 $qtype->get_input_names_from_question_text(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT));
     }
 
-    public function test_get_prt_names_from_question_default(): void {
+    public function x_test_get_prt_names_from_question_default(): void {
 
         $form = $this->get_form(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
                 \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK);
@@ -120,5 +133,44 @@ final class editform_test extends \advanced_testcase {
         $this->assertEquals(['prt1' => 1],
                 $qtype->get_prt_names_from_question(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
                 \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK));
+    }
+
+    public function test_text_format(): void {
+        $form = $this->get_form(\qtype_stack_edit_form::DEFAULT_QUESTION_TEXT,
+                \qtype_stack_edit_form::DEFAULT_SPECIFIC_FEEDBACK);
+        // No script. Leave format alone.
+        $data = $form->prepare_text_field('questiontext', 'hello', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_HTML, $data['format']);
+        // Scripts of different types. Set input to plain.
+        $data = $form->prepare_text_field('questiontext', 'hello<script>there</script>', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello[[javascript]]there[[/javascript]]', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello[[geogebra]]there[[/geogebra]]', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello<jsxgraph>there</jsxgraph>', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello[[jsxgraph]]there[[/jsxgraph]]', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello<geogebra>there</geogebra>', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello[[script]]there[[/script]]', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello<=there', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'hello=>there', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_PLAIN, $data['format']);
+        // No script. Leave format alone.
+        $data = $form->prepare_text_field('questiontext', '=hello>', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_HTML, $data['format']);
+        $data = $form->prepare_text_field('questiontext', 'script', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_HTML, $data['format']);
+        // Format already set to something other than HTML. Leave alone.
+        $data = $form->prepare_text_field('questiontext', 'hello<=there', FORMAT_MARKDOWN, 1);
+        $this->assertEquals(FORMAT_MARKDOWN, $data['format']);
+        // User editor preference set. Leave format alone.
+        set_user_preference('htmleditor', 'bob', null);
+        $data = $form->prepare_text_field('questiontext', 'hello<=there', FORMAT_HTML, 1);
+        $this->assertEquals(FORMAT_HTML, $data['format']);
     }
 }


### PR DESCRIPTION
- Add warnings back in. Previously triggered error no longer exists. However, some reworking done to avoid similar issues where fields haven't been instantiated.
- Fixes to the dependencies page with counting of compiled questions and display of todo questions.
- Switch editor to plain text for fields that look like they have scripts but the user has the default editor and the filed is set to HTML.