### PR TITLE
helm_parts styling should only apply to top-level list items

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -988,12 +988,12 @@ ol.HELM_parts {
     float: left;
     width: 100%;
 }
-ol.HELM_parts li {
+ol.HELM_parts > li {
     counter-increment: helm-parts;
     margin-bottom: 1.5rem;
 }
 
-ol.HELM_parts li:before {
+ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";
     margin-left: -2.2rem;
     margin-top: -0.3rem;

--- a/styles.css
+++ b/styles.css
@@ -988,12 +988,12 @@ ol.HELM_parts {
     float: left;
     width: 100%;
 }
-ol.HELM_parts li {
+ol.HELM_parts > li {
     counter-increment: helm-parts;
     margin-bottom: 1.5rem;
 }
 
-ol.HELM_parts li:before {
+ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";
     margin-left: -2.2rem;
     margin-top: -0.3rem;


### PR DESCRIPTION
If you nest a list inside a "helm_parts" list, the styling is applied to the inner list by mistake:
![image](https://github.com/user-attachments/assets/645b2e0b-a496-4018-b517-ec3a136340d6)

This fixes the CSS so that the styling only applies to the list items at the top level:

![image](https://github.com/user-attachments/assets/29ee6e45-fb7e-489b-b216-092a9c464f9c)