### PR TITLE
api-solutions - Fix 'can be typed as'. Upgrade Debian version.

### DIFF
--- a/api/controller/RenderController.php
+++ b/api/controller/RenderController.php
@@ -101,7 +101,7 @@ class RenderController {
         foreach ($question->inputs as $name => $input) {
             $apiinput = new StackRenderInput();
 
-            $apiinput->samplesolution = $input->get_api_solution($question->get_ta_for_input($name));
+            $apiinput->samplesolution = $input->get_api_solution($question->get_correct_response()[$name]);
             $apiinput->samplesolutionrender = $input->get_api_solution_render(
                 $question->get_ta_render_for_input($name), $question->get_ta_for_input($name));
 

--- a/api/docker/Dockerfile
+++ b/api/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN composer install
 RUN composer dump-autoload --optimize
 
 #Base Image
-FROM php:8.2-apache-bullseye AS base
+FROM php:8.4.5-apache-bookworm AS base
 
 #Install required php extensions
 RUN apt-get update && \


### PR DESCRIPTION
- Use correct response rather than than ta for sample solution so it is evaluated properly.
- Update the Debian version of the Docker container so CertBot works.

Forgot to update unit tests, sorry. Don't merge this yet...