### PR TITLE
Add static flag to API question render response

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -75,6 +75,7 @@ The response is again a JSON document, with the following fields:
 - an int field `questionseed` indicating the seed used for this response
 - an int array `questionvariants` containing all variant seeds of the question
 - an array of arrays `iframes` of arguments to create iframes to hold JS panels e.g. JSXGraph, GeoGebra
+- a boolean field `isinteractive`, indicating if the question contains elements preventing a static representation. If true, a printed version of the question would make no sense
 
 The input configuration consists of the following fields:
 

--- a/api/controller/RenderController.php
+++ b/api/controller/RenderController.php
@@ -135,6 +135,7 @@ class RenderController {
         $renderresponse->questionseed = $question->seed;
         $renderresponse->questionvariants = $question->deployedseeds;
         $renderresponse->iframes = StackIframeHolder::$iframes;
+        $renderresponse->isinteractive = $question->is_interactive();
 
         $response->getBody()->write(json_encode($renderresponse));
         return $response->withHeader('Content-Type', 'application/json');

--- a/api/dtos/StackRenderResponse.php
+++ b/api/dtos/StackRenderResponse.php
@@ -41,6 +41,8 @@ class StackRenderResponse {
     public $questionvariants;
     /** @var array */
     public $iframes;
+    /** @var bool */
+    public $isinteractive;
 }
 
 // phpcs:ignore moodle.Commenting.MissingDocblock.Class

--- a/question.php
+++ b/question.php
@@ -2006,6 +2006,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         $units = false;
         $forbiddenkeys = [];
         $sec = new stack_cas_security();
+        \stack_cas_castext2_block::$isinteractive = false;
 
         // Some counter resets to ensure that the result is the same even if
         // we for some reason would compile twice in a session.

--- a/question.php
+++ b/question.php
@@ -2254,7 +2254,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
 
         // Remember to collect the extracted strings once all has been done.
         $cc['static-castext-strings'] = $map->get_map();
-
+        $cc['is-interactive'] = \stack_cas_castext2_block::$isinteractive;
         return $cc;
     }
 
@@ -2288,5 +2288,13 @@ class qtype_stack_question extends question_graded_automatically_with_countback
         $formatoptions->allowid = true;
         $text = $qa->rewrite_pluginfile_urls($text, $component, $filearea, $itemid);
         return format_text($text, $format, $formatoptions);
+    }
+
+    /**
+     * Is the question interactive?
+     * @return bool
+     */
+    public function is_interactive() {
+        return $this->get_cached('is-interactive');
     }
 }

--- a/stack/cas/castext2/block.interface.php
+++ b/stack/cas/castext2/block.interface.php
@@ -51,6 +51,10 @@ abstract class stack_cas_castext2_block {
     // Store any errors.
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     public $err = [];
+    /**
+     * Keeps track of whether the current question has interactove elements.
+     * @var bool
+     */
     public static $isinteractive = false;
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function

--- a/stack/cas/castext2/block.interface.php
+++ b/stack/cas/castext2/block.interface.php
@@ -51,6 +51,7 @@ abstract class stack_cas_castext2_block {
     // Store any errors.
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     public $err = [];
+    public static $isinteractive = false;
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function __construct(
@@ -92,6 +93,15 @@ abstract class stack_cas_castext2_block {
      */
     public function is_flat(): bool {
         return true;
+    }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return false;
     }
 
     /**

--- a/stack/cas/castext2/blocks/adapt.block.php
+++ b/stack/cas/castext2/blocks/adapt.block.php
@@ -82,4 +82,13 @@ class stack_cas_castext2_adapt extends stack_cas_castext2_block {
         }
         return true;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/adaptauto.block.php
+++ b/stack/cas/castext2/blocks/adaptauto.block.php
@@ -105,4 +105,13 @@ class stack_cas_castext2_adaptauto extends stack_cas_castext2_block {
     public function validate_extract_attributes(): array {
         return [];
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/adaptbutton.block.php
+++ b/stack/cas/castext2/blocks/adaptbutton.block.php
@@ -148,4 +148,13 @@ class stack_cas_castext2_adaptbutton extends stack_cas_castext2_block {
         }
         return true;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/body.block.php
+++ b/stack/cas/castext2/blocks/body.block.php
@@ -82,4 +82,13 @@ class stack_cas_castext2_body extends stack_cas_castext2_block {
 
         return $content;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/cors.block.php
+++ b/stack/cas/castext2/blocks/cors.block.php
@@ -60,4 +60,13 @@ class stack_cas_castext2_cors extends stack_cas_castext2_block {
         }
         return true;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/geogebra.block.php
+++ b/stack/cas/castext2/blocks/geogebra.block.php
@@ -648,4 +648,13 @@ class stack_cas_castext2_geogebra extends stack_cas_castext2_block {
 
         return $valid;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/hint.block.php
+++ b/stack/cas/castext2/blocks/hint.block.php
@@ -73,4 +73,13 @@ class stack_cas_castext2_hint extends stack_cas_castext2_block {
 
         return true;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/iframe.block.php
+++ b/stack/cas/castext2/blocks/iframe.block.php
@@ -300,4 +300,13 @@ class stack_cas_castext2_iframe extends stack_cas_castext2_block {
 
         return $valid;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/javascript.block.php
+++ b/stack/cas/castext2/blocks/javascript.block.php
@@ -156,4 +156,13 @@ class stack_cas_castext2_javascript extends stack_cas_castext2_block {
 
         return $valid;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/jsxgraph.block.php
+++ b/stack/cas/castext2/blocks/jsxgraph.block.php
@@ -345,4 +345,13 @@ class stack_cas_castext2_jsxgraph extends stack_cas_castext2_block {
 
         return $valid;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/parsons.block.php
+++ b/stack/cas/castext2/blocks/parsons.block.php
@@ -568,4 +568,13 @@ class stack_cas_castext2_parsons extends stack_cas_castext2_block {
 
         return $valid;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/reveal.block.php
+++ b/stack/cas/castext2/blocks/reveal.block.php
@@ -114,4 +114,13 @@ class stack_cas_castext2_reveal extends stack_cas_castext2_block {
     public function validate_extract_attributes(): array {
         return [];
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/root.specialblock.php
+++ b/stack/cas/castext2/blocks/root.specialblock.php
@@ -49,6 +49,11 @@ class stack_cas_castext2_special_root extends stack_cas_castext2_block {
             $r = new MP_List([new MP_String('%root')]);
         }
 
+        $interactive = $this->is_interactive();
+        if ($interactive) {
+            stack_cas_castext2_block::$isinteractive = true;
+        }
+
         foreach ($this->children as $item) {
             $c = $item->compile($format, $options);
             if ($c !== null) {
@@ -133,6 +138,20 @@ class stack_cas_castext2_special_root extends stack_cas_castext2_block {
         }
 
         return $flat;
+    }
+
+    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
+    public function is_interactive(): bool {
+        $interactive = false;
+
+        foreach ($this->children as $child) {
+            if ($child->is_interactive()) {
+                $interactive = true;
+                break;
+            };
+        }
+
+        return $interactive;
     }
 
     /**

--- a/stack/cas/castext2/blocks/script.block.php
+++ b/stack/cas/castext2/blocks/script.block.php
@@ -107,4 +107,13 @@ class stack_cas_castext2_script extends stack_cas_castext2_block {
 
         return html_writer::tag('script', $content, $attributes);
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/stack/cas/castext2/blocks/textdownload.block.php
+++ b/stack/cas/castext2/blocks/textdownload.block.php
@@ -128,4 +128,13 @@ class stack_cas_castext2_textdownload extends stack_cas_castext2_block {
 
         return true;
     }
+
+    /**
+     * Is this an interactive block?
+     * If true, we can't generate a static version.
+     * @return bool
+     */
+    public function is_interactive(): bool {
+        return true;
+    }
 }

--- a/tests/api_controller_test.php
+++ b/tests/api_controller_test.php
@@ -168,7 +168,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertContains(1167893775, $this->output->questionvariants);
         $this->assertEquals(3, count($this->output->questionvariants));
         $this->assertEquals(0, count($this->output->iframes));
-        $this->assertEquals(false, count($this->output->isinteractive));
+        $this->assertEquals(false, $this->output->isinteractive);
     }
 
     public function test_render_specified_seed(): void {
@@ -191,7 +191,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-2-0.svg'}));
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-3-0.svg'}));
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-4-0.svg'}));
-        $this->assertEquals(false, count($this->output->isinteractive));
+        $this->assertEquals(false, $this->output->isinteractive);
     }
 
     public function test_render_iframes(): void {
@@ -200,7 +200,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $rc = new RenderController();
         $rc->__invoke($this->request, $this->response, []);
         $this->assertEquals(1, count($this->output->iframes));
-        $this->assertEquals(true, count($this->output->isinteractive));
+        $this->assertEquals(true, $this->output->isinteractive);
     }
 
     public function test_render_download(): void {
@@ -209,7 +209,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $rc = new RenderController();
         $rc->__invoke($this->request, $this->response, []);
         $this->assertMatchesRegularExpression('/javascript\:download\(\'data.csv\'\, 1\)/s', $this->output->questionrender);
-        $this->assertEquals(true, count($this->output->isinteractive));
+        $this->assertEquals(true, $this->output->isinteractive);
     }
 
     public function test_validation(): void {
@@ -251,6 +251,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $rc = new RenderController();
         $rc->__invoke($this->request, $this->response, []);
         $this->assertEquals('<p>Default question</p><p>[[input:ans1]] [[validation:ans1]]</p>', $this->output->questionrender);
+        $this->assertEquals(false, $this->output->isinteractive);
         $vc = new ValidationController();
         $vc->__invoke($this->request, $this->response, []);
         $this->assertStringContainsString('Your last answer was interpreted as follows:', $this->output->validation);
@@ -265,7 +266,6 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(1, $this->output->scoreweights->total);
         $this->assertEquals('[[feedback:prt1]]', $this->output->specificfeedback);
         $this->assertStringContainsString('correct', $this->output->prts->prt1);
-        $this->assertEquals(false, count($this->output->isinteractive));
     }
 
     public function test_grade_scores(): void {

--- a/tests/api_controller_test.php
+++ b/tests/api_controller_test.php
@@ -168,6 +168,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertContains(1167893775, $this->output->questionvariants);
         $this->assertEquals(3, count($this->output->questionvariants));
         $this->assertEquals(0, count($this->output->iframes));
+        $this->assertEquals(false, count($this->output->isinteractive));
     }
 
     public function test_render_specified_seed(): void {
@@ -190,6 +191,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-2-0.svg'}));
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-3-0.svg'}));
         $this->assertEquals(true, isset($this->output->questionassets->{'input-ans1-4-0.svg'}));
+        $this->assertEquals(false, count($this->output->isinteractive));
     }
 
     public function test_render_iframes(): void {
@@ -198,6 +200,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $rc = new RenderController();
         $rc->__invoke($this->request, $this->response, []);
         $this->assertEquals(1, count($this->output->iframes));
+        $this->assertEquals(true, count($this->output->isinteractive));
     }
 
     public function test_render_download(): void {
@@ -206,6 +209,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $rc = new RenderController();
         $rc->__invoke($this->request, $this->response, []);
         $this->assertMatchesRegularExpression('/javascript\:download\(\'data.csv\'\, 1\)/s', $this->output->questionrender);
+        $this->assertEquals(true, count($this->output->isinteractive));
     }
 
     public function test_validation(): void {
@@ -261,6 +265,7 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(1, $this->output->scoreweights->total);
         $this->assertEquals('[[feedback:prt1]]', $this->output->specificfeedback);
         $this->assertStringContainsString('correct', $this->output->prts->prt1);
+        $this->assertEquals(false, count($this->output->isinteractive));
     }
 
     public function test_grade_scores(): void {


### PR DESCRIPTION
https://github.com/IDEMSInternational/pretext/issues/3

Indicate if a question has interactive elements that make a printed version make no sense.

- Add `isinteractive` static variable to stack_cas_castext2_block.
- Updated on question compile if any blocks are interactive.
- Add flag to compiledcache.
- Pass flag as part of render response from API.

~~TODO - classification of body, escape, iframe blocks.~~

@geoo89 @sangwinc 