### PR TITLE
API - Use better 'can be typed as' solution. Update Debian.

### DIFF
--- a/api/controller/RenderController.php
+++ b/api/controller/RenderController.php
@@ -100,8 +100,9 @@ class RenderController {
         $inputs = [];
         foreach ($question->inputs as $name => $input) {
             $apiinput = new StackRenderInput();
-
-            $apiinput->samplesolution = $input->get_api_solution($question->get_correct_response()[$name]);
+            $correctresponse = $question->get_correct_response()[$name];
+            $correctresponse = ($correctresponse) ? $correctresponse : $question->get_ta_for_input($name);
+            $apiinput->samplesolution = $input->get_api_solution($correctresponse);
             $apiinput->samplesolutionrender = $input->get_api_solution_render(
                 $question->get_ta_render_for_input($name), $question->get_ta_for_input($name));
 

--- a/api/controller/RenderController.php
+++ b/api/controller/RenderController.php
@@ -101,7 +101,7 @@ class RenderController {
         foreach ($question->inputs as $name => $input) {
             $apiinput = new StackRenderInput();
 
-            $apiinput->samplesolution = $input->get_api_solution($question->get_ta_for_input($name));
+            $apiinput->samplesolution = $input->get_api_solution($question->get_correct_response()[$name]);
             $apiinput->samplesolutionrender = $input->get_api_solution_render(
                 $question->get_ta_render_for_input($name), $question->get_ta_for_input($name));
 

--- a/api/controller/RenderController.php
+++ b/api/controller/RenderController.php
@@ -100,8 +100,9 @@ class RenderController {
         $inputs = [];
         foreach ($question->inputs as $name => $input) {
             $apiinput = new StackRenderInput();
-            $correctresponse = $question->get_correct_response()[$name];
-            $correctresponse = ($correctresponse) ? $correctresponse : $question->get_ta_for_input($name);
+            $correctresponse = (isset($question->get_correct_response()[$name])) ? $question->get_correct_response()[$name] : null;
+            // Deal with matrix questions.
+            $correctresponse = (isset($correctresponse)) ? $correctresponse : $question->get_ta_for_input($name);
             $apiinput->samplesolution = $input->get_api_solution($correctresponse);
             $apiinput->samplesolutionrender = $input->get_api_solution_render(
                 $question->get_ta_render_for_input($name), $question->get_ta_for_input($name));

--- a/api/docker/Dockerfile
+++ b/api/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN composer install
 RUN composer dump-autoload --optimize
 
 #Base Image
-FROM php:8.2-apache-bullseye AS base
+FROM php:8.4.5-apache-bookworm AS base
 
 #Install required php extensions
 RUN apt-get update && \

--- a/api/public/stackshared.php
+++ b/api/public/stackshared.php
@@ -111,7 +111,7 @@ require_login();
                                 correctAnswers += `, <?php echo stack_string('api_which_typed') ?>: `;
                                 for (const [name, solution] of Object.entries(input.samplesolution)) {
                                     if (name.indexOf('_val') === -1) {
-                                        correctAnswers += `<span class='correct-answer'>${solution}</span>`;
+                                        correctAnswers += `<span class='correct-answer'>${solution.replace(/\n/g, '<br>')}</span>`;
                                     }
                                 }
                             }

--- a/stack/input/equiv/equiv.class.php
+++ b/stack/input/equiv/equiv.class.php
@@ -588,9 +588,4 @@ class stack_equiv_input extends stack_input {
         $in = implode("\n", $in);
         return [$this->name => $in];
     }
-
-    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public function get_api_solution($tavalue) {
-        return ['' => $this->maxima_to_raw_input($tavalue)];
-    }
 }

--- a/stack/input/notes/notes.class.php
+++ b/stack/input/notes/notes.class.php
@@ -230,11 +230,6 @@ class stack_notes_input extends stack_input {
     }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public function get_api_solution($tavalue) {
-        return new stdClass();
-    }
-
-    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function get_api_solution_render($tadisplay, $ta) {
         return '';
     }

--- a/stack/input/textarea/textarea.class.php
+++ b/stack/input/textarea/textarea.class.php
@@ -342,21 +342,4 @@ class stack_textarea_input extends stack_input {
 
         return stack_string('teacheranswershow', ['value' => $value, 'display' => $display]);
     }
-
-    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public function get_api_solution($tavalue) {
-        $values = stack_utils::list_to_array($tavalue, false);
-        foreach ($values as $key => $val) {
-            if (trim($val) !== '' ) {
-                $cs = stack_ast_container::make_from_teacher_source($val);
-                $cs->get_valid();
-                $val = $cs->get_inputform(true, 0, true);
-            }
-            $values[$key] = $val;
-        }
-
-        return ['' => implode("\n", $values)];
-    }
-
-
 }

--- a/stack/input/varmatrix/varmatrix.class.php
+++ b/stack/input/varmatrix/varmatrix.class.php
@@ -457,16 +457,4 @@ class stack_varmatrix_input extends stack_input {
         }
         return $valid;
     }
-
-    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public function get_api_solution($tavalue) {
-        // We clear the name, and then restore its original value,
-        // to not include the prefix in the api solution.
-        $name = $this->name;
-        $this->name = '';
-        $sol = $this->maxima_to_response_array($tavalue);
-        $this->name = $name;
-        return $sol;
-    }
-
 }


### PR DESCRIPTION
 - Use correct response rather than ta for API sample solution so it is evaluated properly e.g. `dispsf(tv,2)*m/s` becomes `(0.50*m)/s` rather than `(displaydp(0.5,2)*m)/s`.
 - Remove `get_api_solution()` for some inputs as no longer needed.
 - Replace line breaks with `<br>` on front end.
 - Update the Debian version of the Docker container so CertBot works.