### PR TITLE
iss1474 - Fix inverse trig option

### DIFF
--- a/stack/maxima/stackmaxima.mac
+++ b/stack/maxima/stackmaxima.mac
@@ -326,7 +326,7 @@ make_arccos(OPT_ACOS) := block(
        ?tex\-setup(?cdr([?%acsch, "{\\rm acsch}"])),
        ?tex\-setup(?cdr([?%acoth, "{\\rm acoth}"]))
     ),
-    if OPT_ACOS = "arccos-arcosh" then block(
+    if OPT_ACOS = "arsinh" then block(
        ?tex\-setup(?cdr([?%asin, "\\arcsin "])),
        ?tex\-setup(?cdr([?%acos, "\\arccos "])),
        ?tex\-setup(?cdr([?%atan, "\\arctan "])),

--- a/stack/options.class.php
+++ b/stack/options.class.php
@@ -76,7 +76,7 @@ class stack_options {
                 'type'       => 'list',
                 'value'      => 'cos-1',
                 'strict'     => true,
-                'values'     => ['cos-1', 'acos', 'arccos', 'arccos-arcosh'],
+                'values'     => ['cos-1', 'acos', 'arccos', 'arsinh'],
                 'caskey'     => 'make_arccos',
                 'castype'    => 'fun',
             ],
@@ -333,7 +333,7 @@ class stack_options {
             'cos-1'         => "cos\xe2\x81\xbb\xc2\xb9(x)",
             'acos'          => 'acos(x)',
             'arccos'        => 'arccos(x)',
-            'arccos-arcosh' => 'arccos(x)/arcosh(x)',
+            'arsinh'        => 'arsinh(x)',
         ];
     }
 

--- a/tests/cassession2_test.php
+++ b/tests/cassession2_test.php
@@ -643,7 +643,7 @@ final class cassession2_test extends qtype_stack_testcase {
         }
 
         $options = new stack_options();
-        $options->set_option('inversetrig', 'arccos-arcosh');
+        $options->set_option('inversetrig', 'arsinh');
 
         $at1 = new stack_cas_session2($s1, $options, 0);
         $at1->instantiate();


### PR DESCRIPTION
#1474 

- Change id string for inverse trig option from arccos-arcosh to arsinh so it fits in the DB field.
- Also change option on dropdown to arsinh(x) to match.