### PR TITLE
CI update

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -67,7 +67,7 @@ jobs:
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'
             maxima: 'GCL'
-            moodle-app: false
+            moodle-app: null
 
     steps:
       - name: Install Maxima (${{ matrix.maxima }})

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -32,7 +32,7 @@ jobs:
       matrix: # I don't know why, but mariadb is much slower, so mostly use pgsql.
         # We use a mix of SBCL and GCL.
         include:
-          - php: '8.2'
+          - php: '8.4'
             moodle-branch: 'main'
             database: 'pgsql'
             maxima: 'GCL'
@@ -67,7 +67,7 @@ jobs:
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'
             maxima: 'GCL'
-            moodle-app: true
+            moodle-app: false
 
     steps:
       - name: Install Maxima (${{ matrix.maxima }})

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -47,28 +47,27 @@ jobs:
             database: 'pgsql'
             maxima: 'GCL'
             moodle-app: true
+          # Edinburgh is planning to run the setup below for 2025-26.
           - php: '8.2'
             moodle-branch: 'MOODLE_405_STABLE'
-            database: 'pgsql'
-            maxima: 'SBCL'
+            database: 'mariadb'
+            maxima: 'GCL'
             moodle-app: true
           - php: '8.2'
             moodle-branch: 'MOODLE_404_STABLE'
             database: 'pgsql'
             maxima: 'SBCL'
             moodle-app: true
-          # Edinburgh is planning to run the setup below for 2024-25.
           - php: '7.4'
             moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
+            database: 'pgsql'
             maxima: 'GCL'
-          # App CI currently broken for PHP 7.4 - Issue MOBILE-4694.
-            moodle-app: null
+            moodle-app: true
           - php: '7.4'
             moodle-branch: 'MOODLE_400_STABLE'
             database: 'pgsql'
             maxima: 'GCL'
-            moodle-app: null
+            moodle-app: true
 
     steps:
       - name: Install Maxima (${{ matrix.maxima }})


### PR DESCRIPTION
- Update `main` to run with PHP 8.4.
- Set Moodle 4.5 to run with same infrastructure as Edinburgh 25/26.
- Reinstate app behat tests for Moodle 4.1 now  MOBILE-4694 is fixed.