### PR TITLE
Fix to issue #1462: minor bug in message for empty string inputs.

### DIFF
--- a/stack/input/string/string.class.php
+++ b/stack/input/string/string.class.php
@@ -126,7 +126,9 @@ class stack_string_input extends stack_algebraic_input {
         if ($this->extraoptions['hideanswer']) {
             return '';
         }
-
+        if ($this->extraoptions['allowempty'] && trim($value) === '""') {
+            return stack_string('teacheranswerempty');
+        }
         $display = stack_utils::maxima_string_strip_mbox($display);
         return stack_string('teacheranswershow_disp', ['display' => $display]);
     }

--- a/tests/cassession2_test.php
+++ b/tests/cassession2_test.php
@@ -1352,7 +1352,7 @@ final class cassession2_test extends qtype_stack_testcase {
         $at1 = new stack_cas_session2($s1, $options, 0);
         $this->assertTrue($at1->get_valid());
         $at1->instantiate();
-        
+
         foreach ($tests as $key => $test) {
             $cs = $at1->get_by_key('p'.$key);
             if ($tests[$key][3] === '') {

--- a/tests/fixtures/numbersfixtures.class.php
+++ b/tests/fixtures/numbersfixtures.class.php
@@ -15,12 +15,14 @@
 // along with Stack.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * This class provides fixture test cases for the numerical rounding tests.
+ *
  * @package    qtype_stack
  * @copyright  2016 University of Edinburgh
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-/*
+/**
  * This class provides fixture test cases for the numerical rounding tests.
  */
 class stack_numbers_test_data {

--- a/tests/input_string_test.php
+++ b/tests/input_string_test.php
@@ -190,6 +190,8 @@ final class input_string_test extends qtype_stack_testcase {
         // Note here the student has used string quotes which are respected.
         $this->assertEquals('"\"\""', $state->contentsmodified);
         $this->assertEquals('\[ \text{&quot;&quot;} \]', $state->contentsdisplayed);
+        $this->assertEquals('This input can be left blank.',
+            $el->get_teacher_answer_display('""', '""'));
     }
 
     public function test_validate_string_string_allowempty(): void {


### PR DESCRIPTION
Fix to issue #1462: minor bug in message for string inputs with empty… answers.