### PR TITLE
Add an option to the bulk tester to add [[todo]] blocks (in the description) for questions needing attention.

### DIFF
--- a/adminui/bulktest.php
+++ b/adminui/bulktest.php
@@ -41,6 +41,7 @@ $context = context::instance_by_id($contextid);
 $categoryid = optional_param('categoryid', null, PARAM_INT);
 
 $skippreviouspasses = optional_param('skippreviouspasses', false, PARAM_BOOL);
+$addtags = optional_param('addtags', false, PARAM_BOOL);
 $urlparams = ['contextid' => $context->id, 'categoryid' => $categoryid];
 if ($skippreviouspasses) {
     $urlparams['skippreviouspasses'] = 1;
@@ -73,7 +74,7 @@ echo $OUTPUT->heading($title);
 
 // Run the tests.
 list($allpassed, $failing) = $bulktester->run_all_tests_for_context(
-      $context, $categoryid, 'web', false, $skippreviouspasses);
+    $context, $categoryid, 'web', false, $skippreviouspasses, $addtags);
 
 // Display the final summary.
 $bulktester->print_overall_result($allpassed, $failing);

--- a/cli/bulktestall.php
+++ b/cli/bulktestall.php
@@ -38,8 +38,8 @@ require_once(__DIR__ . '/../stack/bulktester.class.php');
 $start = microtime(true);
 
 // Get cli options.
-list($options, $unrecognized) = cli_get_params(['help' => false, 'id' => false, 'remote' => false],
-    ['h' => 'help']);
+list($options, $unrecognized) = cli_get_params(['help' => false, 'id' => false, 'remote' => false,
+    'addtags' => false], ['h' => 'help']);
 
 if ($unrecognized) {
     $unrecognized = implode("\n  ", $unrecognized);
@@ -47,13 +47,14 @@ if ($unrecognized) {
 }
 
 if ($options['help']) {
-    echo "This script runs all the quesion tests for all deployed versions of all
+    echo "STACK CLI bulk test.\n
+This script runs all the quesion tests for all deployed versions of all
 questions in all contexts in the Moodle site. This is intended for regression
 testing, before you release a new version of STACK to your site.\n
-Use with --id=n to start generation from question id is n.\n";
+Use with --id=n to start generation from question id is n.\n
+Use with --addtags to add [[todo]] tags to questions needing attention.\n";
     exit(0);
 }
-
 if ($options['remote']) {
     if (!$DB = moodle_database::get_driver_instance($CFG->dbtype, $CFG->dblibrary)) {
         throw new dml_exception('dbdriverproblem', "Unknown driver $CFG->dblibrary/$CFG->dbtype");
@@ -105,9 +106,11 @@ foreach ($contexts as $contextid => $numstackquestions) {
     echo "\n\n# " . $contextid . ": " . stack_string('bulktesttitle', $testcontext->get_context_name());
 
     if ($partialcontext === $contextid) {
-        list($passed, $failing) = $bulktester->run_all_tests_for_context($testcontext, null, 'cli', (int) $options['id']);
+        list($passed, $failing) = $bulktester->run_all_tests_for_context($testcontext,
+            null, 'cli', (int) $options['id'], false, (bool) $options['addtags']);
     } else {
-        list($passed, $failing) = $bulktester->run_all_tests_for_context($testcontext, null, 'cli', false);
+        list($passed, $failing) = $bulktester->run_all_tests_for_context($testcontext,
+            null, 'cli', false, false, (bool) $options['addtags']);
     }
 
     $allpassed = $allpassed && $passed;

--- a/doc/en/Developer/Development_track.md
+++ b/doc/en/Developer/Development_track.md
@@ -11,6 +11,7 @@ Done:
 
 1. Add in a `style` attribute to the JSXGraph block to load local CSS styles.
 2. Add in the `json` input type.  This better supports JSON for JSXGraph, and better debugging in the existing GeoGebra and Parsons blocks.
+3. Allow the bulk tester to add `[[todo]]` blocks to the question descriptions with the `addtags` option.
 
 Issues with [github milestone 4.10.0](https://github.com/maths/moodle-qtype_stack/issues?q=is%3Aissue+milestone%3A4.10.0) include
 

--- a/doc/en/Installation/API.md
+++ b/doc/en/Installation/API.md
@@ -17,7 +17,7 @@ To use the API look at `http://localhost:3080/stack.php` (or perhaps `http://172
 
 To stop the docker container try `docker compose -f docker-compose.yml down`
 
-The API alos provides a bulk test option `http://localhost:3080/bulktest.php`
+The API also provides a bulk test option `http://localhost:3080/bulktest.php`
 
 ## Building the image locally
 

--- a/doc/en/STACK_question_admin/Authoring_workflow.md
+++ b/doc/en/STACK_question_admin/Authoring_workflow.md
@@ -97,6 +97,7 @@ Tags are a comma separated list of strings.  Whitespace will be trimmed from the
 * Tags can represent a user (e.g. using their name, username) to alert an issue is for them to resolve.
 * Tags can represent a stage in an agreed workflow, e.g. "draft", "for review", "stage 2".
 * Tags can represent an issue, e.g. "iss1231" to remind authors to update the question when a fix to a bug/issue finally goes live on a production server.
+* Tags can be added automatically to the question description by the [bulk test script](Bulk_testing.md) where a question requires attention.
 
 It is entirely up to individual users to decide on what and how to use tags.
 
@@ -110,8 +111,8 @@ Any logged-in user can navigate to the URL
     
 on the moodle site.  This page will list
 
-1. Any courses in which they are teacher.
-2. Any questions in that course which contain STACK questions with `[[todo]]` blocks.
+1. Any contexts for which they have moodle capability `moodle/question:editall`.
+2. Any questions in that context which contain STACK questions with `[[todo]]` blocks.
 3. Questions which contain `[[todo]]` blocks are arranged into groups by tag, and additionally there is a list of questions with `[[todo]]` blocks without any tags.
 
 Notice that, by design, any teachers on the course can see all tags. The purpose of the `[[todo]]` block is _not_ to provide a private list of tickets for an individual user to address.  Rather, it is a public list of tags.  In this way, if users choose to use tags to flag issues for users, every teacher can see outstanding tags including those intended for them and those raised by them for someone else.

--- a/doc/en/STACK_question_admin/Bulk_testing.md
+++ b/doc/en/STACK_question_admin/Bulk_testing.md
@@ -1,0 +1,54 @@
+# Bulk testing STACK questions on your site
+
+You can bulk test all question tests on all variants of all STACK questions by using the bulk-test script.  Access this functionality from STACK's "adminui" page (or the plugin setting page)
+
+    [...]/question/type/stack/adminui/index.php
+
+To make use of the bulk test users require the capability `qtype/stack:usediagnostictools` via Moodle's capability system.
+
+The bulktest index page lists all Moodle contexts which contain STACK questions.  You can bulk-test by context.
+
+Bulk testing does the following.
+
+1. Validate the STACK question against it's `stackversion` number.  STACK questions store the version of the STACK plug-in _last used_ to edit the question.  The bulk tester checks for changes with the current STACK plug-in version.
+2. Runs all question tests on all variants of each STACK question.
+3. Catch any run-time errors generated in the above.
+4. List questions with deficiencies:
+  * No question tests
+  * No deployed variants
+  * Missing general feedback (worked solution)
+
+A report is genereated with links to the question dashboard for each question.
+
+## Bulk test all STACK questions
+
+Moodle site-admins can bulk test all STACK questions on a site. This is typically slow, and so is not available to general users.  Indeed, we recommend this is done using the command line.
+
+    [...]/question/type/stack/cli/bulkrestall.php
+
+On linux consider using "screen" to run this bulk test in the background.  Typically this process is done as part of upgrade acceptance testing.
+
+Site admins will find a link "Run all the question tests for all the questions in the system (slow, admin only)" at the bottom of the bulk-test web index page.  However, running all the tests on a large site is typically too slow.
+
+## Adding `[[todo]]` blocks
+
+Running question tests is slow, and not all users have the capability `qtype/stack:usediagnostictools`.  For this reason, it is useful to be able to "tag" questions requiring attention with [`[[todo]]` blocks](../Authoring/Question_blocks/Static_blocks.md).
+
+You can add in `[[todo]]` blocks to the question description listing problems as a one-off process.
+
+* For the web page run the bulk-test on the chosen context, then run the page again with the option `&addtags=true` in the URL.  There is no web-form interface for this (advanced) option.
+* For the CLI use the flag `--addtags`.
+
+The purpose of adding `[[todo]]` blocks is (1) to find questions more easily without running the whole bulk test again, (2) enabling people without the capability `qtype/stack:usediagnostictools` to find questions which we know need work.
+
+The `[[todo]]` blocks are added for broken questions, problems with upgrade, runtime errors, missing seeds, missing tests and failing question tests.  The `[[todo]]` blocks are _not_ added for empty worked solutions.
+
+These `[[todo]]` blocks are only added once, but it does change the DB entry for each question.  Use with care.
+
+Any teacher with moodle capability `moodle/question:editall` for a given context can find all questions with any `[[todo]]` blocks from STACK's "adminui" page. 
+
+    [...]/question/type/stack/adminui/index.php
+
+## Bulk test materials on other sites
+
+It is possible to [bulk test materials on other sites](Testing_questions_on_other_sites.md).

--- a/doc/en/STACK_question_admin/index.md
+++ b/doc/en/STACK_question_admin/index.md
@@ -1,13 +1,13 @@
 # Testing, using and maintaining questions
 
-This section assumes you have working questions, and it provides information on testing, using and maintaining questions.
+This section of the documentation provides information on testing questions and maintaining question banks for the long term.  This section assumes you have working questions, and it provides information on testing, using and maintaining questions.
 
 * [Creating question tests](Testing.md),
 * [Deploying variants](Deploying.md),
 * [Reporting](Reporting.md),
 * [Ensuring questions work in the future](Future_proof.md).
 
-This section of the documentation provides information on testing questions and maintaining question banks for the long term.  Access to functions related to testing STACK questions and maintaining question banks for the long term is through the "adminui" page
+Access to functions related to testing STACK questions and maintaining question banks for the long term is through the "adminui" page
 
     [...]/question/type/stack/adminui/index.php
 
@@ -42,6 +42,17 @@ You can bulk test all question tests on all variants of all question by using th
 STACK questions store the version of the STACK plug-in _last used_ to edit the question.  The bulk tester runs all question tests, and also checks for changes with the current STACK plug-in version.
 
 It is possible to [bulk test materials on other sites](Testing_questions_on_other_sites.md).  (Site admins will have the option to bulk test all materials, and there is also a command line bulk test option.)
+
+You can add in ``[[todo]]` blocks to the question description listing problems as a one-off process.
+
+* For the web page run the bulk-test on the chosen context, then run the page again with the option `&addtags=true` in the URL.  There is no web-form interface for this (advanced) option.
+* For the CLI use the flag `--addtags`.
+
+The purpose of adding ``[[todo]]` blocks is (1) to find questions more easily without running the whole bulk test again, (2) enabling people without the capability `qtype/stack:usediagnostictools` to find questions which we know need work.
+
+The ``[[todo]]` blocks are added for broken questions, problems with upgrade or other errors.  Missing seeds, missing tests and failing question tests.  Blocks are _not_ added for empty worked solutions.
+
+These ``[[todo]]` blocks are only added once, but it does change the DB entry for each question.  Use with care.
 
 ## Identifying STACK questions using particular blocks
 

--- a/doc/en/STACK_question_admin/index.md
+++ b/doc/en/STACK_question_admin/index.md
@@ -6,6 +6,7 @@ This section of the documentation provides information on testing questions and 
 * [Deploying variants](Deploying.md),
 * [Reporting](Reporting.md),
 * [Ensuring questions work in the future](Future_proof.md).
+* [Bulk testing](Bulk_testing.md) and [Bulk testing on other sites](Testing_questions_on_other_sites.md).
 
 Access to functions related to testing STACK questions and maintaining question banks for the long term is through the "adminui" page
 
@@ -32,27 +33,6 @@ The foundation of long-term maintenance is testing.  ___We strongly recommend al
 Encourage question authors to [future proof](../STACK_question_admin/Future_proof.md) their materials.
 
 We have separate advice on [fixing broken questions](Fixing_broken_questions.md) in a live quiz, or on upgrade.
-
-## Bulk testing STACK questions on your site
-
-You can bulk test all question tests on all variants of all question by using the bulk-test script.  This is available from the question setting page or from the "adminui" page
-
-    [...]/question/type/stack/adminui/index.php
-
-STACK questions store the version of the STACK plug-in _last used_ to edit the question.  The bulk tester runs all question tests, and also checks for changes with the current STACK plug-in version.
-
-It is possible to [bulk test materials on other sites](Testing_questions_on_other_sites.md).  (Site admins will have the option to bulk test all materials, and there is also a command line bulk test option.)
-
-You can add in ``[[todo]]` blocks to the question description listing problems as a one-off process.
-
-* For the web page run the bulk-test on the chosen context, then run the page again with the option `&addtags=true` in the URL.  There is no web-form interface for this (advanced) option.
-* For the CLI use the flag `--addtags`.
-
-The purpose of adding ``[[todo]]` blocks is (1) to find questions more easily without running the whole bulk test again, (2) enabling people without the capability `qtype/stack:usediagnostictools` to find questions which we know need work.
-
-The ``[[todo]]` blocks are added for broken questions, problems with upgrade or other errors.  Missing seeds, missing tests and failing question tests.  Blocks are _not_ added for empty worked solutions.
-
-These ``[[todo]]` blocks are only added once, but it does change the DB entry for each question.  Use with care.
 
 ## Identifying STACK questions using particular blocks
 

--- a/doc/meta_en.json
+++ b/doc/meta_en.json
@@ -704,6 +704,11 @@
         "description":"Information on maintaining questions and question banks for the longer term."
         },
         {
+        "file":"Bulk_testing.md",
+        "title":"Bulk testing STACK questions on your site - STACK Documentation",
+        "description":"Information about bulk testing STACK questions on your site."
+        },
+        {
         "file":"Deploying.md",
         "title":"Deploying - STACK Documentation",
         "description":"Information about deploying random variants in the STACK online assessment system."

--- a/questiontestrun.php
+++ b/questiontestrun.php
@@ -632,6 +632,11 @@ echo html_writer::tag('div', html_writer::tag('div', $rendergeneralfeedback,
 echo $OUTPUT->heading(stack_string('questiondescription'), 3);
 echo html_writer::tag('div', html_writer::tag('div', $renderquestiondescription,
     ['class' => 'outcome generalfeedback']), ['class' => 'que']);
+// The description might consit only of [[todo]] blocks, which won't show up.  Show the raw form.
+if (trim($question->questiondescription) !== '') {
+    echo html_writer::tag('div', html_writer::tag('pre', $question->questiondescription,
+        ['class' => 'outcome generalfeedback']), ['class' => 'que']);
+}
 
 echo "\n";
 if ($question->stackversion == null) {


### PR DESCRIPTION
Add an option to the bulk tester to add [[todo]] blocks (in the description) for questions needing attention.  Fixes #1498.