### PR TITLE
Bug in poly_equate_coeffsp() with simp=false

### DIFF
--- a/stack/maxima/assessment.mac
+++ b/stack/maxima/assessment.mac
@@ -104,7 +104,7 @@ poly_equate_coeffsp(p1, p2) := block([lov1, lov2, poly1, andex1, andex2, numvard
     numvardiff:ev(length(lov1)-length(lov2), simp),
     /* The difference in the number of variables has to be exactly one. */
     if not(is(ev(abs(numvardiff=1),simp))) then return(false),
-    if is(length(lov1)-length(lov2)=1) then block(
+    if equal(length(lov1)-length(lov2),1) then block(
         poly1:lhs(p1)-rhs(p1),
         andex2:p2,
         vardiff:first(args(setdifference(lov1,lov2))),


### PR DESCRIPTION
With simp=false this condition in poly_equate_coeffsp() is always false.