### PR TITLE
iss1519 - Add sticky footer

### DIFF
--- a/edit_stack_form.php
+++ b/edit_stack_form.php
@@ -186,7 +186,9 @@ class qtype_stack_edit_form extends question_edit_form {
     protected function definition() {
         parent::definition();
         $mform = $this->_form;
-
+        if (method_exists('MoodleQuickForm', 'set_sticky_footer')) {
+            $mform->set_sticky_footer('updatebuttonar');
+        }
         $fixdollars = $mform->createElement('checkbox', 'fixdollars',
                 stack_string('fixdollars'), stack_string('fixdollarslabel'));
         $mform->insertElementBefore($fixdollars, 'buttonar');


### PR DESCRIPTION
iss1519

Put the 'Save and continue' and 'Preview' buttons in a sticky footer.

(Trying to add the 'Save' and 'Cancel' buttons as well proved tricky - I couldn't do it without copies of all four buttons in their current location as well as in the footer.)