### PR TITLE
Fix bug in JS code of STACK API rendering

### DIFF
--- a/api/public/stackshared.php
+++ b/api/public/stackshared.php
@@ -368,7 +368,7 @@ require_login();
     // Replace feedback tags in some text with an approproately named HTML div.
     function replaceFeedbackTags(text) {
         let result = text;
-        const feedbackTags = text.match(/\[\[feedback:.*\]\]/g);
+        const feedbackTags = text.match(/\[\[feedback:.*?\]\]/g);
         if (feedbackTags) {
             for (const tag of feedbackTags) {
                 // Part name is between '[[feedback:' and ']]'.


### PR DESCRIPTION
The regular expression for feedback tag capturing sometimes fails, for example for the question below:

[Proof-by-contraposition.zip](https://github.com/user-attachments/files/21770956/Proof-by-contraposition.zip)
Paste the content of the file into the XML field in `stack.php`, and display the question.

The question renders like this:
<img width="768" height="651" alt="image" src="https://github.com/user-attachments/assets/6db96dec-9b69-4a79-b2ef-002e2084a3e4" />

The issue is that the function `replaceFeedbackTags` uses a greedy regex `text.match(/\[\[feedback:.*\]\]/g);` to match feedback tags, yielding the following matches:

```
[​
 "[[feedback:prt1]]",

​ `[[feedback:prt2]] <br />Therefore <input type="text" name="q1_stackapi_input_ans4" id="q1_stackapi_input_ans4" size="8.8" style="width: 7.3em" autocapitalize="none" spellcheck="false" class="algebraic" value="y^? + y*x^?&gt; x^? + ?*y^?" />, <span name='q1_stackapi_val_ans4'></span> <br />so it is <select id="menuq1_stackapi_input_ans5" class="select menuq1_stackapi_input_ans5" name="q1_stackapi_input_ans5"><option value="false">False</option><option value="true">True</option><option selected="selected" value="">(Clear my choice)</option></select> <span name='q1_stackapi_val_ans5'></span>, that \\(y^3 + yx^2 \\leq x^3 + x y^2\\). [[feedback:prt3]] <br />Therefore, \\(\\forall x, y \\in \\mathbb{R} \\). If \\(y^3 + yx^2 \\leq x^3 + xy^2\\), then \\(y \\leq x \\) is <select id="menuq1_stackapi_input_ans10" class="select menuq1_stackapi_input_ans10" name="q1_stackapi_input_ans10"><option value="false">False</option><option value="true">True</option><option selected="selected" value="">(Clear my choice)</option></select> <span name='q1_stackapi_val_ans10'></span> [[feedback:prt8]]`,

​ `[[feedback:prt4]] <br />2. Give the hypothesis used in the proof? <input type="text" name="q1_stackapi_input_ans7" id="q1_stackapi_input_ans7" size="13.2" style="width: 10.9em" autocapitalize="none" spellcheck="false" class="algebraic" value="? &gt; ?" /><span name='q1_stackapi_val_ans7'></span> [[feedback:prt5]] <br />3. Give the obtained conclusion in the proof? <input type="text" name="q1_stackapi_input_ans8" id="q1_stackapi_input_ans8" size="13.2" style="width: 10.9em" autocapitalize="none" spellcheck="false" class="algebraic" value="y^? + ?*x^2 &gt; ?" /> <span name='q1_stackapi_val_ans8'></span> [[feedback:prt6]] <br />4. Give the negation of the conclusion: <input type="text" name="q1_stackapi_input_ans9" id="q1_stackapi_input_ans9" size="13.2" style="width: 10.9em" autocapitalize="none" spellcheck="false" class="algebraic" value="" /> <span name='q1_stackapi_val_ans9'></span> [[feedback:prt7]]`
]
```

Making the `*` in the expression lazy solves the issue.