### PR TITLE
Fix to issue #1562: Remove inert numerical wrappers in ATNumRelative and ATNumAbsolute

### DIFF
--- a/doc/en/CAS/Numbers.md
+++ b/doc/en/CAS/Numbers.md
@@ -145,10 +145,10 @@ The following commands generate displayed forms of numbers.  These will not be m
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | `dispdp(x,n)`                   | Truncate \(x\) to \(n\) decimal places and display with trailing digits.  Note, this always prints as a float (or integer), and not in scientific notation.
 | `dispsf(x,n)`                   | Truncate \(x\) to \(n\) significant figures and display with trailing digits.  Note, this always prints as a float, and not in scientific notation.
-| `scientific_notation(x,n)`      | Write \(x\) in the form \(m10^e\).   Only works reliably with `simp:false` (e.g. try 9000).  The optional second argument applies `displaysci(m,n)` to the mantissa to control the display of trailing zeros.
 | `displaydp(x,n)`                | An inert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits.  This function does no rounding.
 | `displaysci(x,n,expo)`          | An inert internal function to record that \(x\) should be displayed to \(n\) decimal places with trailing digits, in scientific notation.  E.g. \(x\times 10^{expo}\).
-
+| `remove_numerical_inert(ex)`   | Removes the above inert forms from an expression `ex`.
+| `scientific_notation(x,n)`      | Write \(x\) in the form \(m10^e\).   Only works reliably with `simp:false` (e.g. try 9000).  The optional second argument applies `displaysci(m,n)` to the mantissa to control the display of trailing zeros.
 
 | Function                  | Predicate
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/stack/maxima/numericaltest.mac
+++ b/stack/maxima/numericaltest.mac
@@ -45,7 +45,7 @@ ATNumerical(SA, SB, SO, numtype) := block([simp:true, RawMark, FeedBack, AnswerN
 
     /* Are we dealing with numbers? */
     if (debug) then print ([SA,SB,tol]),
-    if numberp(SAN) then
+    if numberp(remove_numerical_inert(SAN)) then
       if numberp(SB) then
         if numtype = "ABSOLUTE" then
             return([true, numabsolutep(SA, SB, tol), "", ""])
@@ -60,11 +60,12 @@ ATNumerical(SA, SB, SO, numtype) := block([simp:true, RawMark, FeedBack, AnswerN
     return(ret)
 )$
 
+/* Remove inert functions when establishing precision. */
 /* We have to define our own working precision. */
 STACK_NUM_TOL:10E-10$
-numabsolutep(sa,ta,tol) :=  if ev(abs(float(sa-ta)), simp) < ev(abs(tol)+STACK_NUM_TOL, simp)  then true else false;
+numabsolutep(sa,ta,tol) :=  if ev(abs(float(remove_numerical_inert(sa)-remove_numerical_inert(ta))), simp) < ev(abs(tol)+STACK_NUM_TOL, simp)  then true else false;
 /* The equality sign below is to accommodate the edge case numrelativep(0.0,0.0,0.0?).  Needed for units tests with things like 0m/s. */
-numrelativep(sa,ta,tol) :=  if ev(abs(float(sa-ta)), simp) <= ev(abs(ta*tol*(1+STACK_NUM_TOL)), simp) then true else false;
+numrelativep(sa,ta,tol) :=  if ev(abs(float(remove_numerical_inert(sa)-remove_numerical_inert(ta))), simp) <= ev(abs(remove_numerical_inert(ta)*tol*(1+STACK_NUM_TOL)), simp) then true else false;
 
 ATNumerical_list(SA, SB, numtype, tol) := block([SAl, SBl, cl, res, fb:"", an:""],
     SAl:length(SA),
@@ -72,6 +73,8 @@ ATNumerical_list(SA, SB, numtype, tol) := block([SAl, SBl, cl, res, fb:"", an:""
     if (SAl#SBl) then
         return([true, false, StackAddNote("","ATNumerical_wronglen"), StackAddFeedback("", "ATList_wronglen", stack_disp(SBl, "i"), stack_disp(SAl, "i"))]),
 
+    SA:map(remove_numerical_inert, SA),
+    SB:map(remove_numerical_inert, SB),
     if numtype = "ABSOLUTE" then
        cl:zip_with(lambda([ex1,ex2], numabsolutep(ex1, ex2, tol)), SA, SB)
     else
@@ -95,6 +98,8 @@ ATNumerical_set(SA, SB, numtype, tol) := block([SAl, SBl, cl, res, fbl, fb:"", a
         return([true, false, StackAddNote("","ATNumerical_wronglen"), StackAddFeedback("", "ATSet_wrongsz", stack_disp(SBl, "i"), stack_disp(SAl, "i"))]),
 
     /* Why on earth has listify stopped working...?! */
+    SA:map(remove_numerical_inert, SA),
+    SB:map(remove_numerical_inert, SB),
     SA:sort(float(args(SA))),
     SB:sort(float(args(SB))),
     fbl:num_compare_helper(SA, SB, [], [], tol, numtype),

--- a/tests/fixtures/answertestfixtures.class.php
+++ b/tests/fixtures/answertestfixtures.class.php
@@ -2501,6 +2501,8 @@ class stack_answertest_test_data {
         ['NumAbsolute', '0.1', '{1,1.414,3.1,2}', '{1,2,pi,sqrt(2)}', 1, '', ''],
         ['NumAbsolute', '0.01', '{-1,2,3}', '{-1,2,3}', 1, '', ''],
         ['NumAbsolute', '0.01', '{-1.1,2,3}', '{-1,2,3}', 0, 'ATNumerical_wrongentries: TA/SA=[-1.0], SA/TA=[-1.1].', ''],
+        ['NumAbsolute', '0.02', 'dispdp(409/100,2)', '4.1', 1, '', ''],
+        ['NumAbsolute', '0.02', 'remove_numerical_inert(dispdp(409/100,2))', '4.1', 1, '', ''],
 
         ['NumSigFigs', '', '3.141', '3.1415927', -1, 'STACKERROR_OPTION.', 'Basic tests'],
         ['NumSigFigs', '3', '1/0', '3', -1, 'ATNumSigFigs_STACKERROR_SAns.', ''],

--- a/tests/fixtures/answertestfixtures.class.php
+++ b/tests/fixtures/answertestfixtures.class.php
@@ -2474,6 +2474,7 @@ class stack_answertest_test_data {
         // What happens with floating point complex numbers?
         // This is rejected as not a real number.
         ['NumRelative', '0.1', '0.99*%i', '%i', 0, 'ATNumerical_SA_not_number.', 'Complex numbers'],
+        ['NumRelative', '', 'displaydp(0.95,2)', '1', 1, '', ''],
 
         ['NumAbsolute', '', '1/0', '0', -1, 'ATNumAbsolute_STACKERROR_SAns.', 'Basic tests'],
         ['NumAbsolute', '', '0', '1/0', -1, 'ATNumAbsolute_STACKERROR_TAns.', ''],
@@ -2501,8 +2502,11 @@ class stack_answertest_test_data {
         ['NumAbsolute', '0.1', '{1,1.414,3.1,2}', '{1,2,pi,sqrt(2)}', 1, '', ''],
         ['NumAbsolute', '0.01', '{-1,2,3}', '{-1,2,3}', 1, '', ''],
         ['NumAbsolute', '0.01', '{-1.1,2,3}', '{-1,2,3}', 0, 'ATNumerical_wrongentries: TA/SA=[-1.0], SA/TA=[-1.1].', ''],
-        ['NumAbsolute', '0.02', 'dispdp(409/100,2)', '4.1', 1, '', ''],
+        ['NumAbsolute', '0.02', 'dispdp(4.09,2)', '4.1', 1, '', ''],
+        ['NumAbsolute', '0.02', 'displaydp(4.09,2)', '4.1', 1, '', ''],
         ['NumAbsolute', '0.02', 'remove_numerical_inert(dispdp(409/100,2))', '4.1', 1, '', ''],
+        ['NumAbsolute', '0.01', '[displaydp(-1,0),2,3]', '[-1,2,3]', 1, '', ''],
+        ['NumAbsolute', '0.01', '{displaydp(-1,0),2,3}', '{-1,2,3}', 1, '', ''],
 
         ['NumSigFigs', '', '3.141', '3.1415927', -1, 'STACKERROR_OPTION.', 'Basic tests'],
         ['NumSigFigs', '3', '1/0', '3', -1, 'ATNumSigFigs_STACKERROR_SAns.', ''],


### PR DESCRIPTION
Remove inert numerical wrappers in ATNumRelative and ATNumAbsolute. #1562.