### PR TITLE
Resolve unit test failure

### DIFF
--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -30,6 +30,9 @@ $string['pluginnameediting'] = 'Editing a STACK question';
 $string['pluginnamesummary'] = 'STACK provides mathematical questions for the Moodle quiz.  These use a computer algebra system to establish the mathematical properties of the student\'s responses.';
 
 $string['privacy:metadata']  = 'The STACK question type plugin does not store any personal data.';
+$string['cachedef_parsercache'] = 'STACK parsed Maxima expressions';
+$string['cachedef_librarycache'] = 'STACK question library renders and file structure';
+
 $string['mbstringrequired'] = 'Installing the MBSTRING library is required for STACK.';
 $string['yamlrecommended']  = 'Installing the YAML library is recommended for STACK.';
 


### PR DESCRIPTION
Resolves #1579 

Reverted the deleted lines.

```
php vendor/bin/phpunit --testsuite core_cache_testsuite --filter test_get_summaries
Moodle 4.5.6+ (Build: 20250912), a403ab4b0bab410ad592d3cf6b61cb6cc98239ee
Php: 8.1.33, pgsql: 17.6 (Debian 17.6-1.pgdg13+1), OS: Linux 6.8.0-79-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.232, Memory: 99.50 MB

OK (1 test, 53 assertions)
```