### PR TITLE
Iss1509 - HELM list item CSS fix

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -993,6 +993,9 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
+ol.HELM_parts > li > p:first-child{
+    display: inline-block;
+}
 
 ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";

--- a/mobile.css
+++ b/mobile.css
@@ -993,7 +993,7 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
-ol.HELM_parts > li > :first-child{
+ol.HELM_parts > li > :first-child {
     display: inline-block;
 }
 

--- a/mobile.css
+++ b/mobile.css
@@ -993,14 +993,14 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
-ol.HELM_parts > li > p:first-child{
+ol.HELM_parts > li > :first-child{
     display: inline-block;
 }
 
 ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";
     margin-left: -2.2rem;
-    margin-top: -0.3rem;
+    margin-top: -0.2rem;
     margin-right: 0.4rem;
     background: #1e92cc;
     border-radius: 0.2rem;
@@ -1010,6 +1010,7 @@ ol.HELM_parts > li:before {
     text-align: center;
     display: inline-block;
     box-sizing: border-box;
+    vertical-align: top;
 }
 
 ol.HELM_parts_inline {

--- a/styles.css
+++ b/styles.css
@@ -993,6 +993,9 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
+ol.HELM_parts > li > p:first-child{
+    display: inline-block;
+}
 
 ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";

--- a/styles.css
+++ b/styles.css
@@ -993,7 +993,7 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
-ol.HELM_parts > li > :first-child{
+ol.HELM_parts > li > :first-child {
     display: inline-block;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -993,14 +993,14 @@ ol.HELM_parts > li {
     margin-bottom: 1.5rem;
     display: block;
 }
-ol.HELM_parts > li > p:first-child{
+ol.HELM_parts > li > :first-child{
     display: inline-block;
 }
 
 ol.HELM_parts > li:before {
     content: "(" counter(helm-parts, lower-alpha) ")";
     margin-left: -2.2rem;
-    margin-top: -0.3rem;
+    margin-top: -0.2rem;
     margin-right: 0.4rem;
     background: #1e92cc;
     border-radius: 0.2rem;
@@ -1010,6 +1010,7 @@ ol.HELM_parts > li:before {
     text-align: center;
     display: inline-block;
     box-sizing: border-box;
+    vertical-align: top;
 }
 
 ol.HELM_parts_inline {


### PR DESCRIPTION
#1509 Make first list item appear on same line as item identifier and vertically align the identifier at the top.

We still potentially end up with an unwanted single space on the first line between the identifier and the item but that's dependent on the layout of the question HTML. The paragraph tag either needs to be on the same line hard against the list item tag or the first item needs to not be in paragraph tags. There's no real way around that with CSS without risking breaking something else.
