### PR TITLE
iss1601 - Make select in-line

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -98,6 +98,9 @@ textarea[name=maximavars] {
     max-width: 100%;
     padding: 2px !important;
 }
+.que.stack select.form-select {
+    display: inline-block;
+}
 .que.stack .geogebra-right,
 .que.stack .numerical-right,
 .que.stack .algebraic-right,

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,9 @@ textarea[name=maximavars] {
 .que.stack input[type=text] {
     max-width: 100%;
 }
+.que.stack select.form-select {
+    display: inline-block;
+}
 .que.stack .geogebra-right,
 .que.stack .numerical-right,
 .que.stack .algebraic-right,


### PR DESCRIPTION
#1601 
Looks like a combo of Bootstrap and Moodle changes have made select tags `display: block'. This update to our CSS hopefully overrides without affecting anything else. Is there any likely question set up that is worth checking in addition to the question supplied?

(CI failure is just the language pack not loading for Behat on main again.)