### PR TITLE
Continue XML import of rest of file if a question has validation errors.

### DIFF
--- a/questiontype.php
+++ b/questiontype.php
@@ -122,7 +122,7 @@ class qtype_stack extends question_type {
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function save_question_options($fromform) {
-        global $DB, $PAGE;
+        global $DB, $PAGE, $OUTPUT;
         $throwexceptions = true;
         switch ($PAGE->pagetype) {
             case 'question-bank-importquestions-import':
@@ -135,6 +135,10 @@ class qtype_stack extends question_type {
                         $dashboardlink,
                         $fromform->name
                     ) . '<br>' . $result->notice;
+                    // If we send the notice back to Moodle the question import process will stop
+                    // without importing any later questions in the file.
+                    echo $OUTPUT->notification($result->notice);
+                    unset($result->notice);
                 }
                 break;
             case 'question-bank-importasversion-import':


### PR DESCRIPTION
The new parser code has highlighted a behaviour change I've created with our XML import I hadn't previously spotted. Now when an XML question is imported we pass back errors and notices. Errors are a major problem that prevent the question being imported, notices are validation issues and the question gets imported but marked as broken. 

Turns out that if you're importing a file with multiple questions and a question creates notices, the question will be imported but the import process stops. This is in the Moodle code:

https://github.com/moodle/moodle/blob/e5f1a3226997bfc1e0f7ecbeee50afa70dcddaa6/public/question/format.php#L539

(The return happens in the middle of looping through questions rather than at the end.)

For errors, the question isn't imported and the process also stops.

Previously, a serious error would throw an exception so behaviour is fundamentally the same as before. The need for a transaction rollback via Moodle means we're stuck with errors ending the whole import process. This change works around the notice issue on the question bank import page, so we can both display the notices and keep importing. (Previously a mildly borked question would just get imported and the user would be none the wiser.)