### PR TITLE
Stack: Deprecated errors found in Stack bulk check

### DIFF
--- a/question.php
+++ b/question.php
@@ -1798,7 +1798,7 @@ class qtype_stack_question extends question_graded_automatically_with_countback
             if ($this->{$fieldinstantiated} !== null) {
                 $text = trim($this->{$fieldinstantiated}->get_rendered());
             } else {
-                $text = trim($this->{$field});
+                $text = trim($this->{$field} ?? '');
             }
             if ($text !== '') {
                 $tocheck[stack_string($field)] = $text;


### PR DESCRIPTION
Deprecated errors found in Stack bulk check in many of the modules 

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/moodle/question/type/stack/question.php on line 1769

<img width="1139" height="895" alt="image" src="https://github.com/user-attachments/assets/35f568dc-22e3-4e4f-ac97-f8182a3d2ba0" />
