### PR TITLE
Fix Behat tests using removed random question type

### DIFF
--- a/tests/behat/analysis.feature
+++ b/tests/behat/analysis.feature
@@ -1,5 +1,5 @@
 @qtype @qtype_stack
-Feature: Test analysis response page
+Feature: Test analysis response page in Moodle < 5.2.
   As a teacher
   In order to analyse student responses
   I need to open the analysis reposnse page

--- a/tests/behat/analysis52.feature
+++ b/tests/behat/analysis52.feature
@@ -1,5 +1,5 @@
 @qtype @qtype_stack
-Feature: Test analysis response page
+Feature: Test analysis response page in Moodle ≥ 5.2.
   As a teacher
   In order to analyse student responses
   I need to open the analysis reposnse page


### PR DESCRIPTION
- Create separate Behat tests for the response analysis page for Moodle 5.2+.
- Remove test for Moodle 4.0 and below as we no longer support.