### PR TITLE
Core compatibility with ILIAS: Create new public functions

### DIFF
--- a/stack/prt.class.php
+++ b/stack/prt.class.php
@@ -948,4 +948,22 @@ class stack_potentialresponse_tree_lite {
     public function get_trace() {
         return $this->trace;
     }
+
+    public function is_simplify(): bool {
+        return $this->simplify;
+    }
+
+    public function get_nodes() {
+        return $this->nodes;
+    }
+
+    public function set_nodes($nodes): void
+    {
+        $this->nodes = $nodes;
+    }
+
+    public function get_first_node(): string
+    {
+        return $this->firstnode;
+    }
 }

--- a/stack/prt.evaluatable.class.php
+++ b/stack/prt.evaluatable.class.php
@@ -340,4 +340,9 @@ class prt_evaluatable implements cas_raw_value_extractor {
         }
         return $this->holder->replace($filtered);
     }
+
+    public function get_weight(): float
+    {
+        return $this->weight;
+    }
 }


### PR DESCRIPTION
Hi all,

During our meeting with @sangwinc on January 30, 2025, in Dos Hermanas, Spain, we discussed how certain core changes in STACK could be applied to STACK for Moodle without causing issues, while simplifying future updates.

**This PR adds new public getter and setter functions, such as `is_simplify()` or `set_nodes($nodes)`, giving external modules safe access to internal state.**

Regards,
Saúl from SURLABS.