### PR TITLE
Core compatibility with ILIAS: Use null as default value in lang param

### DIFF
--- a/stack/input/equiv/equiv.class.php
+++ b/stack/input/equiv/equiv.class.php
@@ -585,7 +585,7 @@ class stack_equiv_input extends stack_input {
      * @param string $lang language of the question.
      * @return string HTML for the validation results for this input.
      */
-    public function render_validation(stack_input_state $state, $fieldname, $lang) {
+    public function render_validation(stack_input_state $state, $fieldname, $lang = null) {
         if ($lang !== null && $lang !== '') {
             $prevlang = force_current_language($lang);
         }

--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -1598,7 +1598,7 @@ abstract class stack_input {
      * @param string $lang language of the question.
      * @return string HTML for the validation results for this input.
      */
-    public function render_validation(stack_input_state $state, $fieldname, $lang) {
+    public function render_validation(stack_input_state $state, $fieldname, $lang = null) {
         if ($lang !== null && $lang !== '') {
             $prevlang = force_current_language($lang);
         }

--- a/stack/input/notes/notes.class.php
+++ b/stack/input/notes/notes.class.php
@@ -193,7 +193,7 @@ class stack_notes_input extends stack_input {
      * @param string $lang language of the question.
      * @return string HTML for the validation results for this input.
      */
-    public function render_validation(stack_input_state $state, $fieldname, $lang) {
+    public function render_validation(stack_input_state $state, $fieldname, $lang = null) {
         if ($lang !== null && $lang !== '') {
             $prevlang = force_current_language($lang);
         }


### PR DESCRIPTION
Hi all,

During our meeting with @sangwinc on January 30, 2025, in Dos Hermanas, Spain, we discussed how certain core changes in STACK could be applied to STACK for Moodle without causing issues, while simplifying future updates.

**This PR sets default values of certain language parameters to null, this value is considered one of the possible values, so we can deduce that, by default, it is null, so that it will not be necessary to call it null in all the places where it is used.**

Regards,
Saúl from SURLABS.