### PR TITLE
Core compatibility with ILIAS: Removed {} from js imports in blocks

### DIFF
--- a/stack/cas/castext2/blocks/adaptauto.block.php
+++ b/stack/cas/castext2/blocks/adaptauto.block.php
@@ -43,7 +43,7 @@ class stack_cas_castext2_adaptauto extends stack_cas_castext2_block {
         $list[] = new MP_String('script');
         $list[] = new MP_String(json_encode(['type' => 'module']));
 
-        $code = 'import {stack_js} from "' . stack_cors_link('stackjsiframe.min.js') . '";';
+        $code = 'import stack_js from "' . stack_cors_link('stackjsiframe.min.js') . '";';
         $code .= 'document.addEventListener("DOMContentLoaded", function(){';
         $list[] = new MP_String($code);
 

--- a/stack/cas/castext2/blocks/adaptbutton.block.php
+++ b/stack/cas/castext2/blocks/adaptbutton.block.php
@@ -53,7 +53,7 @@ class stack_cas_castext2_adaptbutton extends stack_cas_castext2_block {
         $list[] = new MP_String('script');
         $list[] = new MP_String(json_encode(['type' => 'module']));
 
-        $code = "\nimport {stack_js} from '" . stack_cors_link('stackjsiframe.min.js') . "';\n";
+        $code = "\nimport stack_js from '" . stack_cors_link('stackjsiframe.min.js') . "';\n";
         $code .= "stack_js.request_access_to_input('" . $this->params['save_state'] . "', true).then((id) => {\n";
         $code .= "const input = document.getElementById(id);\n";
         $code .= "if (input.value=='true'){ hide_and_show(); }\n";

--- a/stack/cas/castext2/blocks/geogebra.block.php
+++ b/stack/cas/castext2/blocks/geogebra.block.php
@@ -367,9 +367,9 @@ class stack_cas_castext2_geogebra extends stack_cas_castext2_block {
         $r->items[] = new MP_String('<div style="' . $style .
             '"><div class="geogebrabox" id="geogebrabox" style="width:100%;height:100%;"></div></div><script type="module">');
         // For binding we need to import the binding libraries.
-        $r->items[] = new MP_String("\nimport {stack_js} from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
+        $r->items[] = new MP_String("\nimport stack_js from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
         // TO-DO: minify.
-        $r->items[] = new MP_String("import {stack_geogebra} from '" . stack_cors_link('stackgeogebra.js') . "';\n");
+        $r->items[] = new MP_String("import stack_geogebra from '" . stack_cors_link('stackgeogebra.js') . "';\n");
 
         // Lets define the common bits of code.
         $commonprecode = 'var presetparams = {"id":"applet","appName":"classic","width":800,"height": 600,' .

--- a/stack/cas/castext2/blocks/javascript.block.php
+++ b/stack/cas/castext2/blocks/javascript.block.php
@@ -68,7 +68,7 @@ class stack_cas_castext2_javascript extends stack_cas_castext2_block {
         $r->items[] = new MP_String('&nbsp;<script type="module">');
 
         // For binding and other use we need to import the stack_js library.
-        $r->items[] = new MP_String("\nimport {stack_js} from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
+        $r->items[] = new MP_String("\nimport stack_js from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
 
         // Do we need to bind anything?
         if (count($inputs) > 0) {

--- a/stack/cas/castext2/blocks/jsxgraph.block.php
+++ b/stack/cas/castext2/blocks/jsxgraph.block.php
@@ -180,8 +180,8 @@ class stack_cas_castext2_jsxgraph extends stack_cas_castext2_block {
             '"><div class="jxgbox" id="jxgbox" style="width:100%;height:100%;"></div></div><script type="module">');
 
         // For binding we need to import the binding libraries.
-        $r->items[] = new MP_String("\nimport {stack_js} from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
-        $r->items[] = new MP_String("import {stack_jxg} from '" . stack_cors_link('stackjsxgraph.min.js') . "';\n");
+        $r->items[] = new MP_String("\nimport stack_js from '" . stack_cors_link('stackjsiframe.min.js') . "';\n");
+        $r->items[] = new MP_String("import stack_jxg from '" . stack_cors_link('stackjsxgraph.min.js') . "';\n");
 
         // Do we need to bind anything?
         if (count($inputs) > 0) {

--- a/stack/cas/castext2/blocks/parsons.block.php
+++ b/stack/cas/castext2/blocks/parsons.block.php
@@ -203,8 +203,8 @@ class stack_cas_castext2_parsons extends stack_cas_castext2_block {
         // JS script.
         $r->items[] = new MP_String('<script type="module">');
 
-        $importcode = "\nimport {stack_js} from '" . stack_cors_link('stackjsiframe.min.js') . "';\n";
-        $importcode .= "import {Sortable} from '" . stack_cors_link('sortablecore.min.js') . "';\n";
+        $importcode = "\nimport stack_js from '" . stack_cors_link('stackjsiframe.min.js') . "';\n";
+        $importcode .= "import Sortable from '" . stack_cors_link('sortablecore.min.js') . "';\n";
         $importcode .= "import {preprocess_steps,
                                 stack_sortable,
                                 get_iframe_height,

--- a/stack/cas/castext2/blocks/reveal.block.php
+++ b/stack/cas/castext2/blocks/reveal.block.php
@@ -65,7 +65,7 @@ class stack_cas_castext2_reveal extends stack_cas_castext2_block {
         }
         $body->items[] = new MP_String('</div>');
 
-        $code = 'import {stack_js} from "' . stack_cors_link('stackjsiframe.min.js') . '";';
+        $code = 'import stack_js from "' . stack_cors_link('stackjsiframe.min.js') . '";';
         $code .= 'stack_js.request_access_to_input("' . $this->params['input'] . '", true).then((id) => {';
         // So that should give us access to the input.
         // Once we get the access immediately bind a listener to it.


### PR DESCRIPTION
Hi all,

During our meeting with @sangwinc on January 30, 2025, in Dos Hermanas, Spain, we discussed how certain core changes in STACK could be applied to STACK for Moodle without causing issues, while simplifying future updates.

This PR removes unnecessary braces in JS, this is not a problem since, fortunately, all these modules export the same function that was being imported as the default value.

In this case, this change is important because in ILIAS, something like `{word}` without commas or spaces is taken as a template variable and, if it is not filled in automatically, it is deleted, breaking the functioning of the blocks. In other places where it is necessary to import with arms, fortunately this is not a problem, since, for example, `{one, two, three}` is not detected as a variable.

Regards,
Saúl from SURLABS.