### PR TITLE
nrw6 - Return Parsons sample solutions. Fix styles bug.

### DIFF
--- a/api/public/cors.php
+++ b/api/public/cors.php
@@ -39,8 +39,11 @@ if (isset($_GET['question'])) {
 $scriptname = urldecode($_GET['name']);
 $corslocation = dirname($CFG->dirroot) . '/corsscripts/';
 $questionlocation = dirname($CFG->dirroot) . '/samplequestions/';
-
-if (!str_starts_with(realpath($scriptname), $corslocation) && !str_starts_with(realpath($corslocation . $scriptname), $corslocation)) {
+if (
+    !str_starts_with(realpath($scriptname), $corslocation)
+    && !str_starts_with(realpath($corslocation . $scriptname), $corslocation)
+    && $scriptname !== 'styles.css'
+    ) {
     // Give a special exception for sample questions.
     if (!($is_question && str_starts_with(realpath($questionlocation . $scriptname), $questionlocation))) {
         die("No such script here.");

--- a/api/public/stackshared.js
+++ b/api/public/stackshared.js
@@ -105,11 +105,14 @@ function send() {
                             correctAnswers += `\\[{${input.samplesolutionrender}}\\]`;
                         }
                         if (input.samplesolution) {
-                            correctAnswers += `, which can be typed as follows: `;
+                            let answerOutput = "";
                             for (const [name, solution] of Object.entries(input.samplesolution)) {
-                                if (name.indexOf('_val') === -1) {
-                                    correctAnswers += `<span class='correct-answer'>${solution.replace(/\n/g, '<br>')}</span>`;
+                                if (name.indexOf('_val') === -1 && !(typeof solution === 'string' && solution.startsWith('[[{"used":'))) {
+                                    answerOutput += `<span class='correct-answer'>${solution.replace(/\n/g, '<br>')}</span>`;
                                 }
+                            }
+                            if (answerOutput) {
+                                correctAnswers += `, which can be typed as follows: ` + answerOutput;
                             }
                         }
                         correctAnswers += '.</p>';

--- a/stack/input/parsons/parsons.class.php
+++ b/stack/input/parsons/parsons.class.php
@@ -371,9 +371,4 @@ class stack_parsons_input extends stack_json_input {
 
         return $render;
     }
-
-    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
-    public function get_api_solution($value) {
-        return null;
-    }
 }


### PR DESCRIPTION
- API now returns sample solution for Parsons questions.
- Sample JS still only displays the rendered version as 'Can be typed as...' doesn't make sense here.
- Fix bug that was preventing loading of styles.css by the API after recent change to the API version of cors.php.