### PR TITLE
Fix warning message about unused use statement.

### DIFF
--- a/questionlibrary.php
+++ b/questionlibrary.php
@@ -33,8 +33,6 @@ require_once(__DIR__ . '/stack/utils.class.php');
 require_once(__DIR__ . '/stack/questionlibrary.class.php');
 require_once(__DIR__ . '/classes/form/category_form.php');
 
-use category_form;
-
 if ($cmid = optional_param('cmid', 0, PARAM_INT)) {
     $cm = get_coursemodule_from_id(false, $cmid);
     require_login($cm->course, false, $cm);


### PR DESCRIPTION
Hi @sangwinc ,

There is a warning message repeatedly appearing in our error log:

Warning: The use statement with non-compound name 'category_form' has no effect in /var/www/html/public/question/type/stack/questionlibrary.php on line 36

I have removed that line, as it does not appear to be necessary.

Could you please review the PR? It is a minor change.