### PR TITLE
Add in better error messages when an editor changes html elements. #1721

### DIFF
--- a/cli/stack_maxima_compiler.php
+++ b/cli/stack_maxima_compiler.php
@@ -421,7 +421,7 @@ foreach ($scripts as $filename) {
             $ast = $parser->parse($po->get_lexer($content));
         } catch (stack_maxima_parser_exception $e) {
             cli_error("PARSING FAIL: in $sname.");
-             $ei = new stack_parser_error_interpreter($po);
+            $ei = new stack_parser_error_interpreter($po);
             $result['exception'] = $e;
             $errors = [];
             $notes = [];

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -884,6 +884,7 @@ $string['stackCas_unknownFunction']         = 'Unknown function: {$a->forbid} in
 $string['stackCas_noFunction']              = 'The use of the function {$a->forbid} in the term {$a->term} is not permitted in this context.';
 $string['stackCas_forbiddenFunction']       = 'Forbidden function: {$a->forbid}.';
 $string['stackCas_spuriousop']              = 'Unknown operator: {$a->cmd}.';
+$string['stackCas_badhtmlelement']          = 'Maxima received <code>{$a->val}</code> instead of {$a->key} which is a sign your text editor might be quietly changing your content.  We recommend CASText source is edited as a plain text document.';
 $string['stackCas_forbiddenOperator']       = 'Forbidden operator: {$a->forbid}.';
 $string['stackCas_forbiddenVariable']       = 'Forbidden variable or constant: {$a->forbid}.';
 $string['stackCas_operatorAsVariable']      = 'Operator {$a->op} interpreted as variable, check syntax.';

--- a/stack/maximaparser/error.interpreter.class.php
+++ b/stack/maximaparser/error.interpreter.class.php
@@ -64,6 +64,16 @@ class stack_parser_error_interpreter {
     public function interprete(stack_maxima_parser_exception $exception, array &$errors = [], array &$answernote = []): string {
         $groupped = $this->group_expectations($exception->expected);
 
+        /**
+         * @var Common patterns which are a sign of using HTML elements.
+         */
+        static $htmlelementpairs  = [
+            '>' => '&gt;',
+            '<' => '&lt;',
+            '&' => '&amp;',
+            '"' => '&quot;',
+        ];
+
         // Lexer errors.
         if ($exception->received !== null && $exception->received->type === StackMaximaTokenType::Error) {
             switch ($exception->received->value) {
@@ -89,6 +99,17 @@ class stack_parser_error_interpreter {
                             $answernote[] = 'illegalcaschars';
                             break;
                         case '&':
+                            // This could be a sign of HTML element contamination in the castext.
+                            $string = $exception->original;
+                            foreach ($htmlelementpairs as $key => $val) {
+                                if (str_contains($string, $val)) {
+                                    $errors[] = stack_string(
+                                        'stackCas_badhtmlelement',
+                                        ['val' => htmlspecialchars($val), 'key' => stack_maxima_format_casstring($key)]
+                                        );
+                                    $answernote[] = 'badhtmlelement';
+                                }
+                            }
                             $a = ['cmd' => stack_maxima_format_casstring('&')];
                             $errors[] = stack_string('stackCas_spuriousop', $a);
                             $answernote[] = 'spuriousop';

--- a/stack/maximaparser/lexer.base.class.php
+++ b/stack/maximaparser/lexer.base.class.php
@@ -602,7 +602,7 @@ class stack_maxima_lexer_base {
 
 
     /**
-     * Continues eating starting from '/*'
+     * Continues eating starting from '/*'.
      */
     public function eat_comment(stack_maxima_lexer_token $token): stack_maxima_lexer_token {
         $token->type = StackMaximaTokenType::Comment;

--- a/stack/maximaparser/preparser.class.php
+++ b/stack/maximaparser/preparser.class.php
@@ -173,8 +173,6 @@ class stack_maxima_student_preparser {
         return $string;
     }
 
-
-
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public static function strings_replace($stringles, $original) {
         $strings = stack_utils::all_substring_strings($original);

--- a/tests/castext_test.php
+++ b/tests/castext_test.php
@@ -3330,4 +3330,20 @@ final class castext_test extends qtype_stack_testcase {
         $cs2->instantiate();
         $this->assertEquals($exp, $at1->get_rendered());
     }
+
+    /**
+     * Add error message for &gt; and other editor-generated problems: issue #1721.
+     * @covers \qtype_stack\stack_cas_castext2_latex
+     * @covers \qtype_stack\stack_cas_keyval
+     */
+    public function test_stack_cas_if_editor_err(): void {
+        $raw = '{@if ta1&gt;3 then a else b@}';
+        $at1 = castext2_evaluatable::make_from_source($raw, 'test-case');
+        $this->assertFalse($at1->get_valid());
+        $errmsg = 'Maxima received <code>&amp;gt;</code> instead of <span class="stacksyntaxexample">></span> ' .
+                  'which is a sign your text editor might be quietly changing your content.  We recommend ' .
+                  'CASText source is edited as a plain text document., Unknown operator: ' .
+                  '<span class="stacksyntaxexample">&</span>.';
+        $this->assertEquals($errmsg, $at1->get_errors());
+    }
 }


### PR DESCRIPTION
Add in better error messages when an editor changes html elements. Fixes #1721.