### PR TITLE
Fix AlgEquiv fixture timeout

### DIFF
--- a/tests/fixtures/answertestfixtures.class.php
+++ b/tests/fixtures/answertestfixtures.class.php
@@ -423,7 +423,8 @@ class stack_answertest_test_data {
         ['AlgEquiv', '', '0=-x+y/A+(y-z)/B', '0=x-y/A-(y-z)/B', 1, 'ATEquation_num', ''],
         ['AlgEquiv', '', 'x^6000-x^6001=x^5999', 'x^5999*(1-x+x^2)=0', 1, 'ATEquation_ratio', ''],
         ['AlgEquiv', '', 'x^6000-x^6001=x^5999', 'x^5999*(1-x+x^3)=0', 0, 'ATEquation_default', ''],
-        ['AlgEquiv', '', '258552*x^7*(81*x^8+1)^398', 'x^3*(x^4+1)^399', 0, '', ''],
+        // Factoring the difference of these expressions is expensive enough to hit the CAS timeout on slower runs.
+        ['AlgEquiv', '', '258552*x^7*(81*x^8+1)^398', '(algebraic_equivalence_factorp:false,x^3*(x^4+1)^399)', 0, '', ''],
         ['AlgEquiv', '', 'Ia*(R1+R2+R3)-Ib*R3=0', '-Ia*(R1+R2+R3)+Ib*R3=0', 1, 'ATEquation_num', ''],
         ['AlgEquiv', '', 'a=0 or b=0', 'a*b=0', 1, 'ATEquation_sides', ''],
         ['AlgEquiv', '', 'a*b=0', 'a=0 or b=0', 1, 'ATEquation_sides', ''],


### PR DESCRIPTION
 ## Summary
  This patch fixes a sporadic `answertest_general_fixtures_test` failure in the `AlgEquiv` fixture for  `258552*x^7*(81*x^8+1)^398` vs `x^3*(x^4+1)^399`.

The fixture expects raw mark `0` and an empty answer note, but on slower Maxima runs it can time out while `algebraic_equivalence` tries to factor `SA-SB`. When that timeout happens, STACK reports it as `ATAlgEquiv_STACKERROR_SAns`.

## Fix
Disable the expensive factor step by using `algebraic_equivalence_factorp:false`.

The expected result is unchanged: the expressions are still marked as not equivalent with no answer note.

## Precedent
Other `AlgEquiv` fixtures already disable specific expensive equivalence subroutines for known cases, including `algebraic_equivalence_trigexpandp:false` and an existing `algebraic_equivalence_factorp:false` fixture for large exponential expressions.