### PR TITLE
Aug improvement

### DIFF
--- a/doc/en/Topics/Linear_algebra/Matrix_library.md
+++ b/doc/en/Topics/Linear_algebra/Matrix_library.md
@@ -83,11 +83,15 @@ The last three predicates above will all accept an optional argument, `sp`, that
 
 It is sometimes convenient to be able to display an augmented matrix. `matrix.mac` adds some limited support for this. 
 
-Perhaps you have a question in which students are asked to solve the matrix equation \(A\underline{\mathbf{x}} = \underline{\mathbf{b}}\) using Gaussian elimination and you wanted to display this problem as an augmented matrix. Then, with matrix `A` and right hand side vector (really a matrix) `b` already defined, you could use `aug(addcol(A,b))` to display
+Perhaps you have a question in which students are asked to solve the matrix equation \(A\underline{\mathbf{x}} = \underline{\mathbf{b}}\) using Gaussian elimination and you wanted to display this problem as an augmented matrix. Then, with matrix `A` and right hand side vector (really a matrix) `b` already defined, you could use `aug(A,b)` to display
 
-\[{\left[\begin{array}{cc} 1 & 2 \\ 4 & 5 \end{array}\right|\left.\begin{array}{c} 3 \\ 6 \end{array}\right]}\]
+\[\left[\begin{array}{cc} 1 & 2 \\ 4 & 5 \end{array}\right|\left.\begin{array}{c} 3 \\ 6 \end{array}\right]\]
 
-Really what is happening here is that `aug` is converting a matrix with concatenated columns `A` and `b` to an `aug_matrix`, which then displays as a matrix with its final column separated by a vertical bar. `aug_matrix` is an inert function that exists only in this library for display purposes. You can save this to a variable, perhaps `Ab`, but Maxima doesn't know that this is a matrix at all and so matrix operations won't work on it. To turn it back into a matrix, you can use `de_aug(Ab)`. 
+Really what is happening here is that `aug` is converting a matrix with concatenated columns `A` and `b` to an `aug_matrix`, which then displays as a matrix with its final column separated by a vertical bar. `aug_matrix` is an inert function that exists only in this library for display purposes. You can save this to a variable, perhaps `Ab`, but Maxima doesn't know that this is a matrix at all and so matrix operations won't work on it. To turn it back into a matrix, you can use `de_aug(Ab)`. `de_aug` concatenates the input matrices instead of returning a list, so if you need more control you may prefer to programme your row operations separately and display `aug(A1,b1)`, `aug(A2,b2)` etc. manually.  
+
+This can generalise to as many inputs as needed. For instance, `aug(matrix([1,2,3],[4,5,6],[7,8,9]), matrix([1],[1],[1]), ident(3))` will display as
+
+\[\left[\begin{array}{ccc} 1 & 2 & 3 \\ 4 & 5 & 6 \\ 7 & 8 & 9 \end{array}\left|\begin{array}{c} 1 \\ 1 \\ 1 \end{array}\right.\left|\begin{array}{ccc} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{array}\right.\right]\]
 
 ### Systems of equations
 

--- a/stack/maxima/contrib/matrix.mac
+++ b/stack/maxima/contrib/matrix.mac
@@ -28,39 +28,43 @@ stack_linear_algebra_declare(true)$
 /*******************************************************************************/
 /* A convenience function for displaying a matrix as an augmented matrix       */
 /*******************************************************************************/
-texput(aug_matrix, lambda([ex], block([M,ll,rr,m,n,A,b,simp],
-  simp:true,
-  M: apply(matrix,args(ex)),
-  ll: lmxchar,
-  if is(ll="[") then rr: "]"
-  else if is(ll="(") then rr: ")"
-  else if is(ll="") then (ll: ".", rr: ".")
-  else if is(ll="{") then (ll: "\\{", rr: "\\}")
-  else if is(ll="|") then rr: "|",
-  [m, n]: matrix_size(M),
-  A: submatrix(M,n),
-  b: col(M,n),
-  sconcat("\\left",ll,block([lmxchar],lmxchar:"",tex1(A)),"\\right|\\left.",block([lmxchar],lmxchar:"",tex1(b)),"\\right",rr)
-)));
+texput(aug_matrix, lambda([ex],
+  block([exl:args(ex),ii,ss,ll:lmxchar,rr,lmxchar],
+    if is(ll="[") then rr: "]"
+    else if is(ll="(") then rr: ")"
+    else if is(ll="") then (ll: ".", rr: ".")
+    else if is(ll="{") then (ll: "\\{", rr: "\\}")
+    else if is(ll="|") then rr: "|",
+    lmxchar: "",
+    ss: ["\\left",ll,tex1(exl[1])],
+    for ii: 2 thru length(exl) do block(
+      ii: ev(ii,simp),
+      ss: append(ss, ["\\left|",tex1(exl[ii]),"\\right."])
+    ),
+    ss: append(ss, ["\\right",rr]),
+    return(simplode(ss))
+  )
+));
 
 /**
  * Converts a matrix to an aug_matrix
  * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
  * To convert back, use de_aug 
  *
- * @param[matrix] M The matrix you would like to display as an augmented matrix
+ * @param[matrix] M The matrix or matrices you would like to display as an augmented matrix
  * @return[aug_matrix] An augmented matrix
  */
-aug(M):= apply(aug_matrix,args(M));
+aug([M]):= if is(length(M)=1) then apply(aug_matrix,[submatrix(first(M),second(matrix_size(first(M)))),col(first(M),second(matrix_size(first(M))))]) else apply(aug_matrix,M);
 
 /**
  * Converts an aug_matrix to a matrix
  * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
+ * Note: This always returns a single matrix constructed by concatenating the arguments of the original aug_matrix. 
  *
  * @param[matrix] M The aug_matrix you would like to treat as a regular matrix
  * @return[aug_matrix] A matrix
  */
-de_aug(M):= apply(matrix,args(M));
+de_aug(M):= apply(addcol, args(M));
 
 /*********************************************************************************/
 /* Functions to extract parts of matrices                                        */

--- a/stack/maxima/contrib/matrix_test.mac
+++ b/stack/maxima/contrib/matrix_test.mac
@@ -30,6 +30,15 @@
 
 s_test_case(aug(matrix([1,2,3,1],[4,5,6,1],[7,8,9,1])),aug_matrix([1,2,3,1],[4,5,6,1],[7,8,9,1]));
 s_test_case(de_aug(aug_matrix([1,2,3,1],[4,5,6,1],[7,8,9,1])),matrix([1,2,3,1],[4,5,6,1],[7,8,9,1]));
+s_test_case(de_aug(aug(ident(4),matrix([1],[2],[3],[4]),ident(4))),matrix([1,0,0,0,1,1,0,0,0],[0,1,0,0,2,0,1,0,0],[0,0,1,0,3,0,0,1,0],[0,0,0,1,4,0,0,0,1]));
+
+lmxchar: "[";
+s_test_case(tex1(aug(matrix([1,2,3],[4,5,6],[7,8,9]),matrix([1],[1],[1]))),"\\left[\\begin{array}{ccc} 1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\ 7 & 8 & 9 \\end{array}\\left|\\begin{array}{c} 1 \\\\ 1 \\\\ 1 \\end{array}\\right.\\right]");
+s_test_case(tex1(aug(matrix([1,2,3,1],[4,5,6,1],[7,8,9,1]))),"\\left[\\begin{array}{ccc} 1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\ 7 & 8 & 9 \\end{array}\\left|\\begin{array}{c} 1 \\\\ 1 \\\\ 1 \\end{array}\\right.\\right]");
+s_test_case(tex1(aug(matrix([1,2,3],[4,5,6],[7,8,9]),matrix([1],[1],[1]),matrix([3,2,1,0],[6,5,4,3],[9,8,7,6]))),"\\left[\\begin{array}{ccc} 1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\ 7 & 8 & 9 \\end{array}\\left|\\begin{array}{c} 1 \\\\ 1 \\\\ 1 \\end{array}\\right.\\left|\\begin{array}{cccc} 3 & 2 & 1 & 0 \\\\ 6 & 5 & 4 & 3 \\\\ 9 & 8 & 7 & 6 \\end{array}\\right.\\right]");
+lmxchar: "{";
+s_test_case(tex1(aug(matrix([1,2,3],[4,5,6],[7,8,9]),matrix([1],[1],[1]))),"\\left\\{\\begin{array}{ccc} 1 & 2 & 3 \\\\ 4 & 5 & 6 \\\\ 7 & 8 & 9 \\end{array}\\left|\\begin{array}{c} 1 \\\\ 1 \\\\ 1 \\end{array}\\right.\\right\\}");
+lmxchar: "[";
 
 s_test_case(triu(matrix([1,2,3],[4,5,6],[7,8,9])),matrix([1,2,3],[0,5,6],[0,0,9]));
 s_test_case(triu(matrix([1,2,3],[4,5,6],[7,8,9],[10,11,12])),matrix([1,2,3],[0,5,6],[0,0,9],[0,0,0]));


### PR DESCRIPTION
Improvements to `aug` following suggestions from Marc Peterfi. The function behaves as it previously did when given a single matrix (that is, it will insert a vertical bar before the final column), but when given two or more matrices as arguments it will concatenate them with vertical bars between each. 

The original use case is to generate worked solutions for matrix inversion or similar, e.g. aug(A, ident(3)) → aug(rowop(A,2,1,A[2,1]/A[1,1]), rowop(ident(3),2,1,A[2,1]/A[1,1]) but could be used for more. 

aug(addcol(A,b)) and aug(A,b) are identical. 

Existing test cases will fail only because the vertical bar is now generated as a closing bracket instead of an opening one. This looks nicer, so I am treating this as a feature instead of a bug.

My apologies for two separate pull requests in quick succession! 