### PR TITLE
iss1752 - Search for garbled nolinks when restoring placeholders #1752

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -97,20 +97,31 @@ class qtype_stack_renderer extends qtype_renderer {
         );
         // Restore inputnames.
         foreach ($question->inputs as $name => $input) {
+            // ISS1752 - The Mathjax filter is mangling the nolink spans if they're between
+            // curly braces so we have to do an extra search.
             $questiontext = str_replace(
-                "<span class=\"nolink\">[[InMNEYMWDx:{$name}]]</span>",
+                [
+                    "<span class=\"nolink\">[[InMNEYMWDx:{$name}]]</span>",
+                    "&lt;span class=\"nolink\"&gt;[[InMNEYMWDx:{$name}]]&lt;/span&gt;"
+                ],
                 "[[input:{$name}]]",
                 $questiontext
             );
             $questiontext = str_replace(
-                "<span class=\"nolink\">[[VnMNEYMWDx:{$name}]]</span>",
+                [
+                    "<span class=\"nolink\">[[VnMNEYMWDx:{$name}]]</span>",
+                    "&lt;span class=\"nolink\"&gt;[[VnMNEYMWDx:{$name}]]&lt;/span&gt;"
+                ],
                 "[[validation:{$name}]]",
                 $questiontext
             );
         }
         foreach ($question->prts as $index => $prt) {
             $questiontext = str_replace(
-                "<span class=\"nolink\">[[GDBBdLBJLg:{$index}]]</span>",
+                [
+                    "<span class=\"nolink\">[[GDBBdLBJLg:{$index}]]</span>",
+                    "&lt;span class=\"nolink\"&gt;[[GDBBdLBJLg:{$index}]]&lt;/span&gt;"
+                ],
                 "[[feedback:{$index}]]",
                 $questiontext
             );


### PR DESCRIPTION
We can either not bother with the nolinks or search for the garbled versions like this (bearing in mind that in this curly brace enclosing the placeholder situation, the nolink will not function for filters which come after MathJax).
#1752