### PR TITLE
replacebug - Check for null

### DIFF
--- a/stack/maximaparser/decimal.comma.lexer.class.php
+++ b/stack/maximaparser/decimal.comma.lexer.class.php
@@ -264,12 +264,7 @@ class stack_maxima_lexer_decimal_comma extends stack_maxima_lexer_base {
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function eat_number(stack_maxima_lexer_token $token): stack_maxima_lexer_token {
         $numbermode = 'pre-dot';
-        $last = new stack_maxima_lexer_char(
-            mb_substr((string)$token->value, -1),
-            $token->endline,
-            $token->endcolumn,
-            $token->endchar - 1
-        );
+        $last = null;
         if ($token->value === ',') {
             $numbermode = 'post-dot';
         }
@@ -287,7 +282,9 @@ class stack_maxima_lexer_decimal_comma extends stack_maxima_lexer_base {
             } else if ($c1->c === ',') {
                 if ($numbermode !== 'pre-dot') {
                     // No second dot nor dots in exponent.
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     $this->pushc($c1);
                     break;
                 } else {
@@ -298,7 +295,9 @@ class stack_maxima_lexer_decimal_comma extends stack_maxima_lexer_base {
             } else if ($c1->c === 'e' || $c1->c === 'E') {
                 if ($numbermode === 'exponent') {
                     // Not an exponent in exponent.
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     $this->pushc($c1);
                     break;
                 }
@@ -320,14 +319,18 @@ class stack_maxima_lexer_decimal_comma extends stack_maxima_lexer_base {
                         $this->pushc($c3);
                         $this->pushc($c2);
                         $this->pushc($c1);
-                        $token->set_end_position($last);
+                        if ($last !== null) {
+                            $token->set_end_position($last);
+                        }
                         break;
                     }
                 } else {
                     // Was not an exponent.
                     $this->pushc($c2);
                     $this->pushc($c1);
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     break;
                 }
             } else if (isset(self::$DIGITS[$c1->c])) {

--- a/stack/maximaparser/decimal.comma.lexer.class.php
+++ b/stack/maximaparser/decimal.comma.lexer.class.php
@@ -264,7 +264,12 @@ class stack_maxima_lexer_decimal_comma extends stack_maxima_lexer_base {
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function eat_number(stack_maxima_lexer_token $token): stack_maxima_lexer_token {
         $numbermode = 'pre-dot';
-        $last = null;
+        $last = new stack_maxima_lexer_char(
+            mb_substr((string)$token->value, -1),
+            $token->endline,
+            $token->endcolumn,
+            $token->endchar - 1
+        );
         if ($token->value === ',') {
             $numbermode = 'post-dot';
         }

--- a/stack/maximaparser/lexer.base.class.php
+++ b/stack/maximaparser/lexer.base.class.php
@@ -716,12 +716,7 @@ class stack_maxima_lexer_base {
      */
     public function eat_number(stack_maxima_lexer_token $token): stack_maxima_lexer_token {
         $numbermode = 'pre-dot';
-        $last = new stack_maxima_lexer_char(
-            mb_substr((string)$token->value, -1),
-            $token->endline,
-            $token->endcolumn,
-            $token->endchar - 1
-        );
+        $last = null;
         if ($token->value === '.') {
             $numbermode = 'post-dot';
 
@@ -757,7 +752,9 @@ class stack_maxima_lexer_base {
             } else if ($c1->c === '.') {
                 if ($numbermode !== 'pre-dot') {
                     // No second dot nor dots in exponent.
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     $this->pushc($c1);
                     break;
                 } else {
@@ -768,7 +765,9 @@ class stack_maxima_lexer_base {
             } else if ($c1->c === 'e' || $c1->c === 'E') {
                 if ($numbermode === 'exponent') {
                     // Not an exponent in exponent.
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     $this->pushc($c1);
                     break;
                 }
@@ -790,14 +789,18 @@ class stack_maxima_lexer_base {
                         $this->pushc($c3);
                         $this->pushc($c2);
                         $this->pushc($c1);
-                        $token->set_end_position($last);
+                        if ($last !== null) {
+                            $token->set_end_position($last);
+                        }
                         break;
                     }
                 } else {
                     // Was not an exponent.
                     $this->pushc($c2);
                     $this->pushc($c1);
-                    $token->set_end_position($last);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
                     break;
                 }
             } else if (isset(self::$DIGITS[$c1->c])) {

--- a/stack/maximaparser/lexer.base.class.php
+++ b/stack/maximaparser/lexer.base.class.php
@@ -716,7 +716,12 @@ class stack_maxima_lexer_base {
      */
     public function eat_number(stack_maxima_lexer_token $token): stack_maxima_lexer_token {
         $numbermode = 'pre-dot';
-        $last = null;
+        $last = new stack_maxima_lexer_char(
+            mb_substr((string)$token->value, -1),
+            $token->endline,
+            $token->endcolumn,
+            $token->endchar - 1
+        );
         if ($token->value === '.') {
             $numbermode = 'post-dot';
 

--- a/tests/parser_test.php
+++ b/tests/parser_test.php
@@ -37,7 +37,7 @@ require_once(__DIR__ . '/../stack/maximaparser/parser.options.class.php');
  * Defines behaviour for parsing of certain special cases.
  * @group qtype_stack
  */
-final class parser_tests extends qtype_stack_testcase {
+final class parser_test extends qtype_stack_testcase {
     /**
      * Add description here.
      * @covers \qtype_stack\stack_parser_options
@@ -130,5 +130,21 @@ final class parser_tests extends qtype_stack_testcase {
         $this->assertEquals(count($parsed2->items[0]->internalcomments), 1);
         $this->assertTrue($parsed2->items[0]->internalcomments[0] instanceof MP_Comment);
         $this->assertEquals($parsed2->items[0]->internalcomments[0]->value, ' was 1 ');
+    }
+
+    /**
+     * Add description here.
+     * @covers \qtype_stack\stack_parser_options
+     */
+    public function test_non_exponent_e_after_integer_lexes_cleanly(): void {
+        $po = stack_parser_options::get_cas_config();
+        $lexer = $po->get_lexer('-2*ln(c(2e^-x-x))');
+
+        $tokens = [];
+        while (($token = $lexer->get_next_token()) !== null) {
+            $tokens[] = $token->value;
+        }
+
+        $this->assertSame(['-', 2, '*', 'ln', '(', 'c', '(', 2, 'e', '^', '-', 'x', '-', 'x', ')', ')'], $tokens);
     }
 }


### PR DESCRIPTION
Entering e.g. `-2*ln(c(2e^-x-x))` for an input with insertstars 
```
    <input>
      <name>ans1</name>
      <type>algebraic</type>
      <tans>ans</tans>
      <boxsize>30</boxsize>
      <strictsyntax>1</strictsyntax>
      <insertstars>2</insertstars>
      <syntaxhint></syntaxhint>
      <syntaxattribute>0</syntaxattribute>
      <forbidwords>F,f,[,],{,}, In, IN, ln), log), log*, ln*, sin), cos), tan), sec),  csc), cot) ,sin*,cos*,tan*,sec*, csc*,cot*,[[BASIC-ALGEBRA]],[[BASIC-CALCULUS]</forbidwords>
      <allowwords></allowwords>
      <forbidfloat>1</forbidfloat>
      <requirelowestterms>0</requirelowestterms>
      <checkanswertype>1</checkanswertype>
      <mustverify>1</mustverify>
      <showvalidation>1</showvalidation>
      <options></options>
    </input>
```
was throwing:
`Exception - stack_maxima_lexer_token::set_end_position(): Argument #1 ($lastchar) must be of type stack_maxima_lexer_char, null given, called in [dirroot]/question/type/stack/stack/maximaparser/lexer.base.class.php on line 795`

I've initialized $last. Not sure if this is the correct approach or even if the initialization itself is correct, though. Should we be guarding against null where $last is used instead?