### PR TITLE
Fix malformed exponent lexes

### DIFF
--- a/stack/maximaparser/lexer.base.class.php
+++ b/stack/maximaparser/lexer.base.class.php
@@ -773,6 +773,14 @@ class stack_maxima_lexer_base {
                 }
                 // Is it a start of an exponent?
                 $c2 = $this->popc();
+                // End of stream after e/E => not an exponent.
+                if ($c2 === null) {
+                    $this->pushc($c1);
+                    if ($last !== null) {
+                        $token->set_end_position($last);
+                    }
+                    break;
+                }
                 if (isset(self::$DIGITS[$c2->c])) {
                     $numbermode = 'exponent';
                     $token->value .= $c1->c . $c2->c;
@@ -780,6 +788,15 @@ class stack_maxima_lexer_base {
                 } else if ($c2->c === '-' || $c2->c === '+') {
                     // Maybe a signed one?
                     $c3 = $this->popc();
+                    // End of stream after sign => not an exponent.
+                    if ($c3 === null) {
+                        $this->pushc($c2);
+                        $this->pushc($c1);
+                        if ($last !== null) {
+                            $token->set_end_position($last);
+                        }
+                        break;
+                    }
                     if (isset(self::$DIGITS[$c3->c])) {
                         $numbermode = 'exponent';
                         $token->value .= $c1->c . $c2->c . $c3->c;

--- a/tests/parser_test.php
+++ b/tests/parser_test.php
@@ -147,4 +147,53 @@ final class parser_test extends qtype_stack_testcase {
 
         $this->assertSame(['-', 2, '*', 'ln', '(', 'c', '(', 2, 'e', '^', '-', 'x', '-', 'x', ')', ')'], $tokens);
     }
+
+    /**
+     * Data provider for malformed exponent expressions.
+     *
+     * @return array[]
+     */
+    public static function malformed_exponent_provider(): array {
+        return [
+            'trailing lowercase e' => [
+                '2e',
+                [2, 'e'],
+            ],
+            'trailing uppercase E' => [
+                '2E',
+                [2, 'E'],
+            ],
+            'incomplete positive exponent' => [
+                '2e+',
+                [2, 'e', '+'],
+            ],
+            'incomplete negative exponent' => [
+                '2e-',
+                [2, 'e', '-'],
+            ],
+        ];
+    }
+
+    /**
+     * Test malformed exponent syntax does not crash the lexer.
+     *
+     * @dataProvider malformed_exponent_provider
+     *
+     * @param string $input
+     * @param array $expectedtokens
+     */
+    public function test_malformed_exponent_lexes_cleanly(
+        string $input,
+        array $expectedtokens
+    ): void {
+        $po = stack_parser_options::get_cas_config();
+        $lexer = $po->get_lexer($input);
+
+        $tokens = [];
+        while (($token = $lexer->get_next_token()) !== null) {
+            $tokens[] = $token->value;
+        }
+
+        $this->assertSame($expectedtokens, $tokens);
+    }
 }


### PR DESCRIPTION
Hi @sangwinc ,

We encountered the following error in the `quiz_statistics\task\recalculate` adhoc task:

> `stack_maxima_lexer_token::set_end_position(): Argument #1 ($lastchar) must be of type stack_maxima_lexer_char, null given`

This issue appears to have already been fixed upstream in STACK PR #1776, so I cherry-picked those changes into our branch.

However, after applying the fix, I found a new problem. When attempting a normal STACK question and entering `2e` as the response, Moodle now throws a different error:

`line 303 of /public/question/type/stack/stack/maximaparser/lexer.base.class.php: TypeError thrown
line 799 of /public/question/type/stack/stack/maximaparser/lexer.base.class.php: call to stack_maxima_lexer_base->pushc()
line 574 of /public/question/type/stack/stack/maximaparser/lexer.base.class.php: call to stack_maxima_lexer_base->eat_number()
line 219 of /public/question/type/stack/stack/maximaparser/autogen/parser-root.php: call to stack_maxima_lexer_base->get_next_token()
line 213 of /public/question/type/stack/stack/cas/ast.container.silent.class.php: call to stack_maxima_parser2_root->parse()
line 1161 of /public/question/type/stack/stack/input/inputbase.class.php: call to stack_ast_container_silent::make_from_student_source()
line 768 of /public/question/type/stack/stack/input/inputbase.class.php: call to stack_input->validate_contents()
line 1026 of /public/question/type/stack/question.php: call to stack_input->validate_student_response()
line 1292 of /public/question/type/stack/question.php: call to qtype_stack_question->get_input_state()
line 1372 of /public/question/type/stack/question.php: call to qtype_stack_question->has_necessary_prt_inputs()
line 1314 of /public/question/type/stack/question.php: call to qtype_stack_question->get_prt_result()
line 1082 of /public/question/type/stack/question.php: call to qtype_stack_question->can_execute_prt()
line 639 of /public/question/behaviour/behaviourbase.php: call to qtype_stack_question->is_complete_response()
line 198 of /public/question/behaviour/interactive/behaviour.php: call to question_behaviour_with_save->is_complete_response()
line 167 of /public/question/behaviour/interactive/behaviour.php: call to qbehaviour_interactive->process_submit()
line 1364 of /public/question/engine/questionattempt.php: call to qbehaviour_interactive->process_action()
line 763 of /public/question/engine/questionusage.php: call to question_attempt->process_action()
line 643 of /public/question/engine/questionusage.php: call to question_usage_by_activity->process_action()
line 1728 of /public/mod/quiz/classes/quiz_attempt.php: call to question_usage_by_activity->process_all_actions()
line 2202 of /public/mod/quiz/classes/quiz_attempt.php: call to mod_quiz\quiz_attempt->process_submitted_actions()
line 96 of /public/mod/quiz/processattempt.php: call to mod_quiz\quiz_attempt->process_attempt()`

This suggests that while PR #1776 resolves the adhoc task failure, it may introduce a regression when handling incomplete scientific notation such as `2e`.

I have fixed the issue and added unit tests to cover the fix.

Could you please help review the changes? If you see anything that could be improved, please let me know and I'll address it as soon as possible, as we'd like to get this issue resolved quickly.
