### PR TITLE
Drop unused YAML PHP extension as optional dependency

### DIFF
--- a/api/docker/Dockerfile
+++ b/api/docker/Dockerfile
@@ -14,9 +14,7 @@ FROM php:8.4.5-apache-bookworm AS base
 #Install required php extensions
 RUN apt-get update && \
     apt-get -y install libicu-dev libyaml-dev libzip-dev zip && \
-    pecl install yaml && \
     docker-php-ext-configure intl && \
-    docker-php-ext-enable yaml && \
     docker-php-ext-install intl zip && \
     a2enmod rewrite && a2enmod actions
 

--- a/api/docker/DockerfileDemo
+++ b/api/docker/DockerfileDemo
@@ -16,9 +16,7 @@ FROM php:8.4.5-apache-bookworm AS base
 #Install required php extensions
 RUN apt-get update && \
     apt-get -y install libicu-dev libyaml-dev libzip-dev zip && \
-    pecl install yaml && \
     docker-php-ext-configure intl && \
-    docker-php-ext-enable yaml && \
     docker-php-ext-install intl zip && \
     a2enmod rewrite && a2enmod actions
 

--- a/environment.xml
+++ b/environment.xml
@@ -8,11 +8,6 @@
                          <ON_ERROR message="mbstringrequired" plugin="qtype_stack" />
                      </FEEDBACK>
                  </PHP_EXTENSION>
-                 <PHP_EXTENSION name="yaml" level="optional">
-                     <FEEDBACK>
-                         <ON_CHECK message="yamlrecommended" plugin="qtype_stack" />
-                     </FEEDBACK>
-                 </PHP_EXTENSION>
             </PHP_EXTENSIONS>
          </PHP>
      </PLUGIN>

--- a/environment.xml
+++ b/environment.xml
@@ -2,17 +2,18 @@
 <COMPATIBILITY_MATRIX>
      <PLUGIN name="qtype_stack">
         <PHP version="8.1.0" level="required">
-        <PHP_EXTENSIONS>
-             <PHP_EXTENSION name="mbstring" level="required">
-                 <FEEDBACK>
-                     <ON_ERROR message="mbstringrequired" plugin="qtype_stack" />
-                 </FEEDBACK>
-             </PHP_EXTENSION>
-             <PHP_EXTENSION name="yaml" level="optional">
-                 <FEEDBACK>
-                     <ON_CHECK message="yamlrecommended" plugin="qtype_stack" />
-                 </FEEDBACK>
-             </PHP_EXTENSION>
+            <PHP_EXTENSIONS>
+                 <PHP_EXTENSION name="mbstring" level="required">
+                     <FEEDBACK>
+                         <ON_ERROR message="mbstringrequired" plugin="qtype_stack" />
+                     </FEEDBACK>
+                 </PHP_EXTENSION>
+                 <PHP_EXTENSION name="yaml" level="optional">
+                     <FEEDBACK>
+                         <ON_CHECK message="yamlrecommended" plugin="qtype_stack" />
+                     </FEEDBACK>
+                 </PHP_EXTENSION>
+            </PHP_EXTENSIONS>
          </PHP>
      </PLUGIN>
 </COMPATIBILITY_MATRIX>

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -34,7 +34,6 @@ $string['cachedef_parsercache'] = 'STACK parsed Maxima expressions';
 $string['cachedef_librarycache'] = 'STACK question library renders and file structure';
 
 $string['mbstringrequired'] = 'Installing the MBSTRING library is required for STACK.';
-$string['yamlrecommended']  = 'Installing the YAML library is recommended for STACK.';
 
 // General strings.
 $string['errors']            = 'Errors';


### PR DESCRIPTION
### Description

We are currently switching from the deprecated [PECL](https://pecl.php.net/) over to [PIE](https://github.com/php/pie). During this process we found that the STACK question type still has an optional dependency on the [yaml PHP extension](https://pecl.php.net/package/yaml).

The yaml extension was introduced in 2020 as per a57f18f6d0e68730383012349f8c1af3fa09f420 as a side-effect of requiring the mbstring PHP extension (probably an import from earlier?). 

The commit 3ceabf48264fdc1947fda5c59ed62dae04b87797 introduced the alternative implementation [symfony/yaml](https://packagist.org/packages/symfony/yaml) and 940bb616aecf07591819282b2f40a73871c36268 finally removed the last use of any yaml PHP extension function. Threfore I propose dropping the old yaml PECL extension from the list of optional dependencies.

---
### Changes

This PR:

1. Removes the PHP extension [yaml](https://pecl.php.net/package/yaml) from the list of optional PHP extensions as per abaf1a1e89750e65a076c3ecb44b69c10ddab966
2. Fixes the `environment.xml` by adding a missing `</PHP_EXTENSIONS>` closing tag as per fd30d7df5a3f6fd52e2b6036cdbb14661e18d254