### PR TITLE
behat-fix - Sticky footer fix

### DIFF
--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -146,6 +146,39 @@ class behat_qtype_stack extends behat_base {
     }
 
     /**
+     * Set a checkbox without clicking it.
+     *
+     * @param string $fieldname the visible label of the checkbox.
+     * @param string $value 1 to check the box, 0 to uncheck it.
+     *
+     * @When /^I set the checkbox "(?P<fieldname>[^"]*)" to "(?P<value>[01])"$/
+     */
+    public function i_set_the_checkbox_to(string $fieldname, string $value): void {
+        $field = $this->getSession()->getPage()->findField($fieldname);
+        if ($field === null) {
+            throw new \Exception("Field '$fieldname' not found.");
+        }
+
+        $checked = $value === '1';
+
+        $xpath = json_encode(str_replace(["\r\n", "\r", "\n"], ' ', $field->getXpath()));
+        $checkedjs = $checked ? 'true' : 'false';
+        $js = <<<EOF
+            (function() {
+                const field = document.evaluate({$xpath}, document, null,
+                        XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+                if (!field) {
+                    return;
+                }
+                field.checked = {$checkedjs};
+                field.dispatchEvent(new Event('input', {bubbles: true}));
+                field.dispatchEvent(new Event('change', {bubbles: true}));
+            })();
+        EOF;
+        $this->execute_script($js);
+    }
+
+    /**
      * Check an iframe element value
      *
      * @param string $id id of element

--- a/tests/behat/create_preview_edit.feature
+++ b/tests/behat/create_preview_edit.feature
@@ -402,8 +402,7 @@ Feature: Create, preview, test, tidy and edit STACK questions
       | Model answer         |                       |
     And I press "id_submitbutton"
     Then I should not see "Broken question"
-    And I set the following fields to these values:
-      | Save as broken        | 1 |
+    And I set the checkbox "Save as broken" to "1"
     And I press "id_submitbutton"
     Then I should see "Broken question"
 
@@ -455,6 +454,6 @@ Feature: Create, preview, test, tidy and edit STACK questions
     And I set the following fields to these values:
       | Question name        | Fixed question  |
       | Model answer         | diff(p,x)       |
-      | Save as broken       | 0               |
+    And I set the checkbox "Save as broken" to "0"
     And I press "id_submitbutton"
     Then I should see "Fixed question"


### PR DESCRIPTION
- For some reason the sticky footer has got in the way of clicking the checkbox on main. It's not a real issue - I updated Moodle to check.
- Have worked round the problem in the test, setting the box without clicking.