### PR TITLE
STACK: Fix Question variables field is overlapping with 'Save changes…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1486,8 +1486,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
     color: #44331b;
 }
 
-#page-question-type-stack .stickyfooter,
-#page-question-type-stack .sticky-footer-content {
+[id^="page-question-type-stack"] .stickyfooter {
     z-index: 1050; /* Overrides Ace's z-index 4 & 6 */
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1485,6 +1485,12 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 .que .comment {
     color: #44331b;
 }
+
+#page-question-type-stack .stickyfooter,
+#page-question-type-stack .sticky-footer-content {
+    z-index: 1050; /* Overrides Ace's z-index 4 & 6 */
+}
+
 .stack-ace-wrapper {
     border: 1px solid #ced4da;
     border-radius: 4px;


### PR DESCRIPTION
Hi @sangwinc 
I found a minor UI issue related to the CSS z-index, which was causing the Ace Editor to overlap with the sticky footer.

<img width="1903" height="347" alt="image" src="https://github.com/user-attachments/assets/4ef19273-e540-4e81-9ecc-00e2a0e5579f" />

I've fixed the issue.

Could you please review the changes?