### PR TITLE
iss1824 - Fix hideanswer for dropdowns

### DIFF
--- a/stack/input/dropdown/dropdown.class.php
+++ b/stack/input/dropdown/dropdown.class.php
@@ -90,6 +90,12 @@ class stack_dropdown_input extends stack_input {
                     } else {
                         $this->extraoptions[$opt] = $arg;
                     }
+                    // ISS1824 - The extraoptions we're testing against here are just hideanswer and
+                    // allowempty because dropdown does not override base class extraoptions like other
+                    // inputs. This is a bit of a landmine and we should consider a refactor longer term.
+                    // For minimal code change now, continue allows multiple options but doesn't trigger the fall through
+                    // to error in the switch below for hideanswer and allowempty.
+                    continue;
                 }
 
                 switch ($option) {

--- a/tests/input_checkbox_test.php
+++ b/tests/input_checkbox_test.php
@@ -641,4 +641,11 @@ final class input_checkbox_test extends qtype_stack_testcase {
         $this->assertEquals('', $state->errors);
         $this->assertEquals('A correct answer is: This input can be left blank.',
             $el->get_teacher_answer_display($state->contentsmodified, $state->contentsdisplayed));
-    }}
+    }
+
+    public function test_validate_extra_options_hideanswer(): void {
+        $el = stack_input_factory::make('checkbox', 'ans1', $this->make_ta(), null, ['options' => 'hideanswer'], false);
+        $el->validate_extra_options();
+        $this->assertEquals([], $el->get_errors());
+    }
+}

--- a/tests/input_dropdown_test.php
+++ b/tests/input_dropdown_test.php
@@ -293,6 +293,8 @@ final class input_dropdown_test extends qtype_stack_walkthrough_test_base {
     public function test_render_hidenonotanswered(): void {
 
         $el = $this->make_dropdown(['options' => 'hideanswer,nonotanswered']);
+        $el->validate_extra_options();
+        $this->assertEquals([], $el->get_errors());
         $el->adapt_to_model_answer($this->make_ta());
         $expected = '<select data-stack-input-type="dropdown" id="menustack1__ans1" class="select'
             . self::$moodleclass . ' menustack1__ans1" '
@@ -308,6 +310,12 @@ final class input_dropdown_test extends qtype_stack_walkthrough_test_base {
                             '',
                             ''
                         ), 'stack1__ans1', false, null));
+    }
+
+    public function test_validate_extra_options_hideanswer(): void {
+        $el = stack_input_factory::make('dropdown', 'ans1', $this->make_ta(), null, ['options' => 'hideanswer'], false);
+        $el->validate_extra_options();
+        $this->assertEquals([], $el->get_errors());
     }
 
     public function test_render_latex(): void {


### PR DESCRIPTION
- Essentially this is a one line change with tests. Replaces the `break` removed by #1720 with a `continue` . This allows multiple options but prevents `hideanswer` and `allowempty` from hitting the `unknown option` error.

#1824