### PR TITLE
STACK: prevent ob_clean exception when no output buffer exists

### DIFF
--- a/questionxmledit.php
+++ b/questionxmledit.php
@@ -88,7 +88,9 @@ if ($mform->is_cancelled()) {
         $errors = $e->getMessage();
     }
     // The import process spits out the question description somewhere. Clean output to remove.
-    ob_clean();
+    if (ob_get_level() > 0) {
+        ob_clean();
+    }
     // Refresh data with newly saved question.
     [$qversion, $questionid] = get_latest_question_version($questionid);
     $question = question_bank::load_question($questionid);


### PR DESCRIPTION
Hi @sangwinc ,

We recently encountered an intermittent Behat failure on our specific CI server environment. The test fails with the following PHP notice/exception:

Notice: ob_clean(): Failed to delete buffer. No buffer to delete

After investigating, we found that this occurs because ob_clean() is called when no active output buffer exists (ob_get_level() === 0). This is environment-dependent (e.g., when the CI server runs with output_buffering = Off in php.ini or uses a built-in CLI webserver) and we are unable to reproduce it in other setups.
To prevent this across different server configurations, we would like to propose adding a defensive check before cleaning the buffer: