### PR TITLE
Matrix inputs: support curly HTML brackets

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -107,7 +107,7 @@ The following keys can be contained inside the input configuration options. The 
 - `syntaxHint`: The configured Syntax hint of the input.
 - `syntaxHintType`: If the Syntax hint should be displayed as a placeholder, or as initial value. Supported for the types `algebraic, numerical, string, units`
 - `options`: Key-Value Object containing the options for choice like input types. Supportet for the types `checkbox, dropdown, radio`
-- `matrixbrackets`: The desired matrix bracket style. One of `matrixroundbrackets`, `matrixsquarebrackets`, `matrixbarbrackets`, `matrixnobrackets`. Supported for the types `matrix` and  `varmatrix`
+- `matrixbrackets`: The desired matrix bracket style. One of `matrixroundbrackets`, `matrixsquarebrackets`, `matrixcurlybrackets`, `matrixbarbrackets`, `matrixnobrackets`. Supported for the types `matrix` and  `varmatrix`
 - `width`: Width of the input matrix. Supported for the `matrix` type.
 - `height` Height of the input matrix. Supported for the `matrix` type.
 

--- a/doc/en/Authoring/Inputs/Matrix_input.md
+++ b/doc/en/Authoring/Inputs/Matrix_input.md
@@ -16,7 +16,7 @@ We cannot use the `EMPTYANSWER` tag for the teacher's answer with the matrix inp
 
     ta:transpose(matrix([null,null,null]));
 
-The shape of the parentheses surrounding the brackets is taken from the question level options, except matrix inputs cannot display curly brackets `{`.  (If you can create CSS to do this, please contact the developers!)
+The brackets around the HTML input grid are taken from the question-level `matrixparens` option.
 
 ## Matrix of variable size input ###
 

--- a/mobile.css
+++ b/mobile.css
@@ -155,6 +155,8 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
     --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
     position: relative;
     display: inline-block;
+    /*rtl:ignore*/
+    direction: ltr;
     border: 0;
     padding: 0.5em;
 }

--- a/mobile.css
+++ b/mobile.css
@@ -151,6 +151,35 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
     padding: 0.5em;
 }
 
+.que.stack div.matrixcurlybrackets {
+    --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
+    position: relative;
+    display: inline-block;
+    border: 0;
+    padding: 0.5em;
+}
+
+.que.stack div.matrixcurlybrackets::before,
+.que.stack div.matrixcurlybrackets::after {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    width: 0.55em;
+    background-color: currentColor;
+    -webkit-mask: var(--stack-curly-bracket) center / 100% 100% no-repeat;
+    mask: var(--stack-curly-bracket) center / 100% 100% no-repeat;
+    pointer-events: none;
+}
+
+.que.stack div.matrixcurlybrackets::before {
+    inset-inline-start: 0;
+}
+
+.que.stack div.matrixcurlybrackets::after {
+    inset-inline-end: 0;
+    transform: scaleX(-1);
+}
+
 .que.stack div.matrixnobrackets {
     display: inline-block;
     border: 0;

--- a/mobile.css
+++ b/mobile.css
@@ -152,7 +152,7 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
 }
 
 .que.stack div.matrixcurlybrackets {
-    --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
+    --stack-curly-bracket: url(pix/curlybracket.svg);
     position: relative;
     display: inline-block;
     /*rtl:ignore*/

--- a/pix/curlybracket.svg
+++ b/pix/curlybracket.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 100" preserveAspectRatio="none">
+  <path d="M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99"
+        fill="none" stroke="black" stroke-width="2" vector-effect="non-scaling-stroke"
+        stroke-linecap="square"/>
+</svg>

--- a/stack/input/matrix/matrix.class.php
+++ b/stack/input/matrix/matrix.class.php
@@ -313,6 +313,8 @@ class stack_matrix_input extends stack_input {
         $matrixparens = $this->options->get_option('matrixparens');
         if ($matrixparens == '(') {
             $matrixbrackets = 'matrixroundbrackets';
+        } else if ($matrixparens == '{') {
+            $matrixbrackets = 'matrixcurlybrackets';
         } else if ($matrixparens == '|') {
             $matrixbrackets = 'matrixbarbrackets';
         } else if ($matrixparens == '') {
@@ -387,6 +389,8 @@ class stack_matrix_input extends stack_input {
         $matrixparens = $this->options->get_option('matrixparens');
         if ($matrixparens == '[') {
             $matrixbrackets = 'matrixsquarebrackets';
+        } else if ($matrixparens == '{') {
+            $matrixbrackets = 'matrixcurlybrackets';
         } else if ($matrixparens == '|') {
             $matrixbrackets = 'matrixbarbrackets';
         } else if ($matrixparens == '') {

--- a/stack/input/varmatrix/varmatrix.class.php
+++ b/stack/input/varmatrix/varmatrix.class.php
@@ -119,6 +119,8 @@ class stack_varmatrix_input extends stack_input {
             $matrixparens = $this->options->get_option('matrixparens');
             if ($matrixparens == '(') {
                 $matrixbrackets = 'matrixroundbrackets';
+            } else if ($matrixparens == '{') {
+                $matrixbrackets = 'matrixcurlybrackets';
             } else if ($matrixparens == '|') {
                 $matrixbrackets = 'matrixbarbrackets';
             } else if ($matrixparens == '') {
@@ -157,6 +159,8 @@ class stack_varmatrix_input extends stack_input {
         $matrixparens = $this->options->get_option('matrixparens');
         if ($matrixparens == '[') {
             $matrixbrackets = 'matrixsquarebrackets';
+        } else if ($matrixparens == '{') {
+            $matrixbrackets = 'matrixcurlybrackets';
         } else if ($matrixparens == '|') {
             $matrixbrackets = 'matrixbarbrackets';
         } else if ($matrixparens == '') {

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,35 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
     padding: 0.5em;
 }
 
+.que.stack div.matrixcurlybrackets {
+    --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
+    position: relative;
+    display: inline-block;
+    border: 0;
+    padding: 0.5em;
+}
+
+.que.stack div.matrixcurlybrackets::before,
+.que.stack div.matrixcurlybrackets::after {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    width: 0.55em;
+    background-color: currentColor;
+    -webkit-mask: var(--stack-curly-bracket) center / 100% 100% no-repeat;
+    mask: var(--stack-curly-bracket) center / 100% 100% no-repeat;
+    pointer-events: none;
+}
+
+.que.stack div.matrixcurlybrackets::before {
+    inset-inline-start: 0;
+}
+
+.que.stack div.matrixcurlybrackets::after {
+    inset-inline-end: 0;
+    transform: scaleX(-1);
+}
+
 .que.stack div.matrixnobrackets {
     display: inline-block;
     border: 0;

--- a/styles.css
+++ b/styles.css
@@ -149,7 +149,7 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
 }
 
 .que.stack div.matrixcurlybrackets {
-    --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
+    --stack-curly-bracket: url([[pix:qtype_stack|curlybracket]]);
     position: relative;
     display: inline-block;
     /*rtl:ignore*/

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,8 @@ body.pagelayout-embedded .que.stack .formulation .questiontestslink {
     --stack-curly-bracket: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 100' preserveAspectRatio='none'%3E%3Cpath d='M11 1C5 1 5 8 5 15V38C5 45 3 49 1 50C3 51 5 55 5 62V85C5 92 5 99 11 99' fill='none' stroke='black' stroke-width='2' vector-effect='non-scaling-stroke' stroke-linecap='square'/%3E%3C/svg%3E");
     position: relative;
     display: inline-block;
+    /*rtl:ignore*/
+    direction: ltr;
     border: 0;
     padding: 0.5em;
 }

--- a/tests/input_matrix_test.php
+++ b/tests/input_matrix_test.php
@@ -427,6 +427,32 @@ final class input_matrix_test extends qtype_stack_testcase {
         );
     }
 
+    public function test_validate_student_response_valid_curly(): void {
+
+        $options = new stack_options();
+        $options->set_option('matrixparens', '{');
+        $el = stack_input_factory::make('matrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer('matrix([1,2],[3,4])');
+        $inputvals = [
+            'ans1_sub_0_0' => '1',
+            'ans1_sub_0_1' => '2',
+            'ans1_sub_1_0' => '4',
+            'ans1_sub_1_1' => '5',
+        ];
+        $state = $el->validate_student_response($inputvals, $options, 'matrix([1,2],[3,4])', new stack_cas_security());
+
+        $this->assertEquals(stack_input::VALID, $state->status);
+        $this->assertEquals(
+            '\[ \left\{\begin{array}{cc} 1 & 2 \\\\ 4 & 5 \end{array}\right\} \]',
+            $state->contentsdisplayed
+        );
+        $this->assertStringStartsWith(
+            '<div class="matrixcurlybrackets">',
+            $el->render($state, 'ans1', false, null)
+        );
+        $this->assertEquals('matrixcurlybrackets', $el->render_api_data('matrix([1,2],[4,5])')['matrixbrackets']);
+    }
+
     public function test_validate_student_response_invalid_one_blank(): void {
 
         $options = new stack_options();

--- a/tests/input_varmatrix_test.php
+++ b/tests/input_varmatrix_test.php
@@ -133,6 +133,23 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         );
     }
 
+    public function test_render_syntax_hint_curly(): void {
+
+        $options = new stack_options();
+        $options->set_option('matrixparens', '{');
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
+        $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
+        $html = $el->render(
+            new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
+            'ans1',
+            false,
+            null
+        );
+
+        $this->assertStringStartsWith('<div class="matrixcurlybrackets">', $html);
+        $this->assertEquals('matrixcurlybrackets', $el->render_api_data('matrix([1,2],[3,4])')['matrixbrackets']);
+    }
+
     public function test_render_monospace(): void {
 
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');


### PR DESCRIPTION
### Summary

The question-level `matrixparens` option already accepts `{`, and STACK's TeX output renders matrices with curly braces. The fixed and variable-size HTML matrix inputs currently fall back to square brackets for that value.

This adds a `matrixcurlybrackets` style and selects it for both input types and their API metadata. The brace is stored as a small STACK plugin SVG and used as a CSS mask, so it scales to the input height while keeping a stable stroke width and inheriting the surrounding text colour. The same rule is included in `styles.css` and `mobile.css`.

There is no new question option or migration. Existing square, round, bar and no-bracket rendering is unchanged.

### Screenshots

Fixed 2 × 2, fixed 4 × 1 and variable-size inputs rendered by a local patched STACK instance:

![Curly brackets scaling across STACK matrix input types](https://raw.githubusercontent.com/adamant-pwn/moodle-qtype_stack/027987a187ec05b24df1f12561b03766b1f644ee/.github/pr-assets/curly-input-scaling.png)

The existing square and round choices alongside the new curly rendering:

![Square, round and curly STACK matrix input brackets](https://raw.githubusercontent.com/adamant-pwn/moodle-qtype_stack/027987a187ec05b24df1f12561b03766b1f644ee/.github/pr-assets/bracket-comparison.png)

These were captured from the local STACK API image `2025102100` with the patch applied; each widget was produced by the API renderer rather than reconstructed as static HTML.

### Verification

- Added focused rendering/API tests for fixed and variable-size inputs with `matrixparens: '{'`.
- PHP syntax checks pass for both renderer classes and their test files.
- Rendered locally through the standalone STACK API with fixed 2 × 2, fixed 4 × 1 and variable-size inputs.
- Compared square, round and curly settings side by side; the existing styles remain unchanged.
- Verified left-to-right and right-to-left placement in a browser.
- Verified in a browser accessibility snapshot that the empty CSS pseudo-elements and mask add no accessible node or text; the matrix table, cells and inputs remain exposed normally.
