### PR TITLE
Matrix inputs: expose delimiter shapes to assistive technology

### DIFF
--- a/doc/en/Authoring/Inputs/Matrix_input.md
+++ b/doc/en/Authoring/Inputs/Matrix_input.md
@@ -18,7 +18,8 @@ We cannot use the `EMPTYANSWER` tag for the teacher's answer with the matrix inp
 
     ta:transpose(matrix([null,null,null]));
 
-The brackets around the HTML input grid are taken from the question-level `matrixparens` option.
+The brackets around the HTML inputs are taken from the question-level `matrixparens` option. The left and right
+delimiters are also exposed as labelled mathematical elements for assistive technologies.
 
 With `stack_linear_algebra_declare(true)`, the TeX display of `c(...)` and `r(...)` also follows `matrixparens` through `stack_matrix_disp(...)`. This gives matrix and vector inputs and their resulting expressions one common delimiter choice. Independent matrix and vector delimiter settings are discussed in [#1848](https://github.com/maths/moodle-qtype_stack/issues/1848).
 

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -121,9 +121,17 @@ $string['logicsymbol_help'] = 'Controls how logical symbols should be displayed 
 $string['logicsymbol_link'] = '%%WWWROOT%%/question/type/stack/doc/doc.php/Authoring/Question_options.md#logicsymbol';
 $string['logicsymbollang'] = 'Language';
 $string['logicsymbolsymbol'] = 'Symbolic';
+$string['matrixleftcurlybracket'] = 'Left curly bracket';
+$string['matrixleftparenthesis'] = 'Left parenthesis';
+$string['matrixleftsquarebracket'] = 'Left square bracket';
+$string['matrixleftverticalbar'] = 'Left vertical bar';
 $string['matrixparens'] = 'Default shape of matrix parentheses';
 $string['matrixparens_help'] = 'Controls the default shape of matrix parentheses when displayed in CAS output.';
 $string['matrixparens_link'] = '%%WWWROOT%%/question/type/stack/doc/doc.php/CAS/Matrix.md#matrixparens';
+$string['matrixrightcurlybracket'] = 'Right curly bracket';
+$string['matrixrightparenthesis'] = 'Right parenthesis';
+$string['matrixrightsquarebracket'] = 'Right square bracket';
+$string['matrixrightverticalbar'] = 'Right vertical bar';
 $string['falsebranch'] = 'False branch';
 $string['falsebranch_help'] = 'These fields control what happens when the answer test does not pass
 <h3> Mod and score </h3>

--- a/stack/input/inputbase.class.php
+++ b/stack/input/inputbase.class.php
@@ -1559,6 +1559,36 @@ abstract class stack_input {
     }
 
     /**
+     * Return accessible elements for matrix delimiters.
+     *
+     * Shared by the fixed and variable-size matrix inputs.
+     *
+     * @param string $matrixparens the configured matrix delimiter.
+     * @return string[] the left and right accessible elements.
+     */
+    protected function render_matrix_bracket_accessibility($matrixparens) {
+        $labelkeys = [
+            '[' => ['matrixleftsquarebracket', 'matrixrightsquarebracket'],
+            '(' => ['matrixleftparenthesis', 'matrixrightparenthesis'],
+            '{' => ['matrixleftcurlybracket', 'matrixrightcurlybracket'],
+            '|' => ['matrixleftverticalbar', 'matrixrightverticalbar'],
+        ];
+        if (!array_key_exists($matrixparens, $labelkeys)) {
+            return ['', ''];
+        }
+
+        $attributes = ['class' => 'matrixbracketaccessibility', 'role' => 'math'];
+        return [
+            html_writer::tag('span', '', $attributes + [
+                'aria-label' => stack_string($labelkeys[$matrixparens][0]),
+            ]),
+            html_writer::tag('span', '', $attributes + [
+                'aria-label' => stack_string($labelkeys[$matrixparens][1]),
+            ]),
+        ];
+    }
+
+    /**
      * Returns the XHTML for embedding this input in a page.
      *
      * @param string student's current answer to insert into the xhtml.

--- a/stack/input/matrix/matrix.class.php
+++ b/stack/input/matrix/matrix.class.php
@@ -352,10 +352,11 @@ class stack_matrix_input extends stack_input {
         } else if ($matrixparens == '') {
             $matrixbrackets = 'matrixnobrackets';
         }
+        [$leftbracket, $rightbracket] = $this->render_matrix_bracket_accessibility($matrixparens);
         // Build the html table to contain these values.
         $valueattr = $this->valuetype === 'matrix' ? '' : ' data-stack-input-value-type="' . $this->valuetype . '"';
         $xhtml = '<div class="' . $matrixbrackets . '"' . $valueattr .
-                '><table class="matrixtable" id="' . $fieldname .
+                '>' . $leftbracket . '<table class="matrixtable" id="' . $fieldname .
                 '_container" style="display:inline; vertical-align: middle;" ' .
                 'cellpadding="1" cellspacing="0"><tbody>';
         for ($i = 0; $i < $this->height; $i++) {
@@ -397,7 +398,7 @@ class stack_matrix_input extends stack_input {
             }
             $xhtml .= '</tr>';
         }
-        $xhtml .= '</tbody></table></div>';
+        $xhtml .= '</tbody></table>' . $rightbracket . '</div>';
 
         return $xhtml;
     }

--- a/stack/input/varmatrix/varmatrix.class.php
+++ b/stack/input/varmatrix/varmatrix.class.php
@@ -150,6 +150,7 @@ class stack_varmatrix_input extends stack_input {
 
         // Read matrix bracket style from options.
         // The default brackets for matrices are square in options.
+        $matrixparens = '[';
         $matrixbrackets = 'matrixsquarebrackets';
         if ($this->options) {
             $matrixparens = $this->options->get_option('matrixparens');
@@ -174,11 +175,16 @@ class stack_varmatrix_input extends stack_input {
             $attributes['data-stack-input-list-separator'] = ',';
         }
 
+        [$leftbracket, $rightbracket] = $this->render_matrix_bracket_accessibility($matrixparens);
         $wrapperattributes = ['class' => $matrixbrackets];
         if ($this->valuetype !== 'matrix') {
             $wrapperattributes['data-stack-input-value-type'] = $this->valuetype;
         }
-        $xhtml = html_writer::tag('textarea', htmlspecialchars($current, ENT_COMPAT), $attributes);
+        $xhtml = $leftbracket . html_writer::tag(
+            'textarea',
+            htmlspecialchars($current, ENT_COMPAT),
+            $attributes
+        ) . $rightbracket;
         return html_writer::tag('div', $xhtml, $wrapperattributes);
     }
 

--- a/tests/api_controller_test.php
+++ b/tests/api_controller_test.php
@@ -162,7 +162,8 @@ final class api_controller_test extends qtype_stack_testcase {
         $this->assertEquals(86, $this->output->questionseed);
         $this->assertEquals('matrix([35,30],[28,24])', $this->output->questioninputs->ans1->samplesolution->_val);
         $this->assertMatchesRegularExpression(
-            '/^<div class="matrixsquarebrackets"><table class="matrixtable"/',
+            '/^<div class="matrixsquarebrackets"><span class="matrixbracketaccessibility"[^>]*><\/span>' .
+                '<table class="matrixtable"/',
             $this->output->questioninputs->ans1->render
         );
         $this->assertMatchesRegularExpression('/^<p>To multiply matrices/', $this->output->questionsamplesolutiontext);

--- a/tests/input_matrix_test.php
+++ b/tests/input_matrix_test.php
@@ -39,13 +39,66 @@ require_once(__DIR__ . '/../stack/input/factory.class.php');
  * @covers \stack_matrix_input
  */
 final class input_matrix_test extends qtype_stack_testcase {
+    /**
+     * Matrix delimiters and their accessible names.
+     *
+     * @return array of test cases.
+     */
+    public static function bracket_accessibility_provider(): array {
+        return [
+            'square' => ['[', 'Left square bracket', 'Right square bracket'],
+            'round' => ['(', 'Left parenthesis', 'Right parenthesis'],
+            'curly' => ['{', 'Left curly bracket', 'Right curly bracket'],
+            'vertical bars' => ['|', 'Left vertical bar', 'Right vertical bar'],
+            'none' => ['', null, null],
+        ];
+    }
+
+    /**
+     * Test that matrix delimiters have accessible names.
+     *
+     * @dataProvider bracket_accessibility_provider
+     *
+     * @param string $matrixparens the configured matrix delimiter.
+     * @param string|null $leftlabel the expected left label, or null for no delimiter.
+     * @param string|null $rightlabel the expected right label, or null for no delimiter.
+     */
+    public function test_render_bracket_accessibility(
+        string $matrixparens,
+        ?string $leftlabel,
+        ?string $rightlabel
+    ): void {
+        $options = new stack_options();
+        $options->set_option('matrixparens', $matrixparens);
+        $el = stack_input_factory::make('matrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer('matrix([1])');
+        $html = $el->render(
+            new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
+            'ans1',
+            false,
+            null
+        );
+
+        if ($leftlabel === null) {
+            $this->assertStringNotContainsString('matrixbracketaccessibility', $html);
+            return;
+        }
+
+        $left = '<span class="matrixbracketaccessibility" role="math" aria-label="' . $leftlabel . '"></span>';
+        $right = '<span class="matrixbracketaccessibility" role="math" aria-label="' . $rightlabel . '"></span>';
+        $this->assertStringContainsString($left . '<table', $html);
+        $this->assertStringContainsString('</table>' . $right, $html);
+    }
+
     public function test_render_blank(): void {
 
         $options = new stack_options();
         $el = stack_input_factory::make('matrix', 'ans1', 'M', $options);
         $el->adapt_to_model_answer('matrix([1,2,3],[3,4,5])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody>' .
                 '<tr><td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="" size="5" ' .
@@ -67,7 +120,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_2" name="ans1_sub_1_2" value="" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -122,7 +176,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $el->adapt_to_model_answer('matrix([1,0],[0,1])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
                 '<td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="a" size="5" ' .
@@ -138,7 +194,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="d" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -155,7 +212,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'matrix([a,b], [?,d])');
         $el->adapt_to_model_answer('matrix([1,0],[0,1])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+            '<table class="matrixtable" id="ans1_container" ' .
             'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
             '<td style="padding-top: 0.5em">&nbsp;</td>' .
             '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="a" size="5" ' .
@@ -171,7 +230,8 @@ final class input_matrix_test extends qtype_stack_testcase {
             '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="d" size="5" ' .
                 'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                 'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-            '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+            '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -189,7 +249,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $el->adapt_to_model_answer('matrix([1,0],[0,1])');
         $this->assertEquals(
-            '<div class="matrixroundbrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixroundbrackets">' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Left parenthesis"></span>' .
+            '<table class="matrixtable" id="ans1_container" ' .
             'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
             '<td style="padding-top: 0.5em">&nbsp;</td>' .
             '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="a" size="5" ' .
@@ -205,7 +267,8 @@ final class input_matrix_test extends qtype_stack_testcase {
             '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="d" size="5" ' .
                 'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                 'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-            '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+            '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Right parenthesis"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -223,7 +286,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxAttribute', '1');
         $el->adapt_to_model_answer('matrix([1,0],[0,1])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
                 '<td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" placeholder="a" size="5" ' .
@@ -239,7 +304,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" placeholder="d" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -255,7 +321,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('matrix', 'ans1', 'M', $options);
         $el->adapt_to_model_answer('matrix([null,null],[null,null])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
                 '<td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="" size="5" ' .
@@ -271,7 +339,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -452,7 +521,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         );
         $this->assertEquals('', $state->lvars);
         $this->assertEquals(
-            '<div class="matrixroundbrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixroundbrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left parenthesis"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
                 '<td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="1" size="5" ' .
@@ -468,7 +539,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="5" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right parenthesis"></span></div>',
             $el->render($state, 'ans1', false, null)
         );
     }
@@ -495,7 +567,9 @@ final class input_matrix_test extends qtype_stack_testcase {
         );
         $this->assertEquals('', $state->lvars);
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody><tr>' .
                 '<td style="padding-top: 0.5em">&nbsp;</td>' .
                 '<td><input type="text" id="ans1_sub_0_0" name="ans1_sub_0_0" value="1" size="5" ' .
@@ -511,7 +585,8 @@ final class input_matrix_test extends qtype_stack_testcase {
                 '<td><input type="text" id="ans1_sub_1_1" name="ans1_sub_1_1" value="5" size="5" ' .
                     'autocapitalize="none" spellcheck="false" data-stack-input-type="matrix" ' .
                     'data-stack-input-decimal-separator="." data-stack-input-list-separator="," /></td>' .
-                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table></div>',
+                '<td style="padding-bottom: 0.5em">&nbsp;</td></tr></tbody></table>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render($state, 'ans1', false, null)
         );
     }
@@ -696,9 +771,12 @@ final class input_matrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('matrix', 'ans1', 'x^2', $options);
         $el->set_parameter('options', 'allowempty');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><table class="matrixtable" id="stack1__ans1_container" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<table class="matrixtable" id="stack1__ans1_container" ' .
                 'style="display:inline; vertical-align: middle;" cellpadding="1" cellspacing="0"><tbody></tbody>' .
-                '</table></div>',
+                '</table><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'stack1__ans1',

--- a/tests/input_varmatrix_test.php
+++ b/tests/input_varmatrix_test.php
@@ -38,14 +38,67 @@ require_once(__DIR__ . '/../stack/input/factory.class.php');
  * @covers \stack_varmatrix_input
  */
 final class input_varmatrix_test extends qtype_stack_testcase {
+    /**
+     * Matrix delimiters and their accessible names.
+     *
+     * @return array of test cases.
+     */
+    public static function bracket_accessibility_provider(): array {
+        return [
+            'square' => ['[', 'Left square bracket', 'Right square bracket'],
+            'round' => ['(', 'Left parenthesis', 'Right parenthesis'],
+            'curly' => ['{', 'Left curly bracket', 'Right curly bracket'],
+            'vertical bars' => ['|', 'Left vertical bar', 'Right vertical bar'],
+            'none' => ['', null, null],
+        ];
+    }
+
+    /**
+     * Test that matrix delimiters have accessible names.
+     *
+     * @dataProvider bracket_accessibility_provider
+     *
+     * @param string $matrixparens the configured matrix delimiter.
+     * @param string|null $leftlabel the expected left label, or null for no delimiter.
+     * @param string|null $rightlabel the expected right label, or null for no delimiter.
+     */
+    public function test_render_bracket_accessibility(
+        string $matrixparens,
+        ?string $leftlabel,
+        ?string $rightlabel
+    ): void {
+        $options = new stack_options();
+        $options->set_option('matrixparens', $matrixparens);
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
+        $html = $el->render(
+            new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
+            'ans1',
+            false,
+            null
+        );
+
+        if ($leftlabel === null) {
+            $this->assertStringNotContainsString('matrixbracketaccessibility', $html);
+            return;
+        }
+
+        $left = '<span class="matrixbracketaccessibility" role="math" aria-label="' . $leftlabel . '"></span>';
+        $right = '<span class="matrixbracketaccessibility" role="math" aria-label="' . $rightlabel . '"></span>';
+        $this->assertStringContainsString($left . '<textarea', $html);
+        $this->assertStringContainsString('</textarea>' . $right, $html);
+    }
+
     public function test_render_blank(): void {
 
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" rows="5" cols="5" ' .
                 'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." data-stack-input-list-separator=",">' .
-                '</textarea></div>',
+                '</textarea><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -61,10 +114,13 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');
 
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" rows="5" cols="5" ' .
                 'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." data-stack-input-list-separator=",">' .
-                '</textarea></div>',
+                '</textarea><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -79,11 +135,14 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" rows="5" cols="10" ' .
                 'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." ' .
                 'data-stack-input-list-separator=",">a b' . "\n" .
-                '? d</textarea></div>',
+                '? d</textarea><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -99,10 +158,13 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $el->set_parameter('syntaxAttribute', '1');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" placeholder="a b' .
                 "\n" . '? d" rows="5" cols="10" data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." ' .
-                'data-stack-input-list-separator=","></textarea></div>',
+                'data-stack-input-list-separator=","></textarea>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -119,11 +181,14 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
         $el->set_parameter('syntaxHint', 'matrix([a,b],[?,d])');
         $this->assertEquals(
-            '<div class="matrixroundbrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixroundbrackets">' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Left parenthesis"></span>' .
+            '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
             'spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" rows="5" cols="10" ' .
             'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." ' .
             'data-stack-input-list-separator=",">a b' . "\n" .
-            '? d</textarea></div>',
+            '? d</textarea>' .
+            '<span class="matrixbracketaccessibility" role="math" aria-label="Right parenthesis"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'ans1',
@@ -155,10 +220,13 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');
         $el->set_parameter('options', 'monospace:true');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput input-monospace" size="5.5" style="width: 4.6em" rows="5" cols="5" ' .
                 'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." data-stack-input-list-separator=",">' .
-                '</textarea></div>',
+                '</textarea><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -173,10 +241,13 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         set_config('inputmonospace', '3', 'qtype_stack');
         $el = stack_input_factory::make('varmatrix', 'ans1', 'M');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="ans1" id="ans1" autocapitalize="none" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="ans1" id="ans1" autocapitalize="none" ' .
                 'spellcheck="false" class="varmatrixinput input-monospace" size="5.5" style="width: 4.6em" rows="5" cols="5" ' .
                 'data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." data-stack-input-list-separator=",">' .
-                '</textarea></div>',
+                '</textarea><span class="matrixbracketaccessibility" role="math" ' .
+                'aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
                 'ans1',
@@ -427,10 +498,13 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         $el = stack_input_factory::make('varmatrix', 'ans1', 'x^2');
         $el->set_parameter('options', 'allowempty');
         $this->assertEquals(
-            '<div class="matrixsquarebrackets"><textarea name="stack1__ans1" id="stack1__ans1" ' .
+            '<div class="matrixsquarebrackets">' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Left square bracket"></span>' .
+                '<textarea name="stack1__ans1" id="stack1__ans1" ' .
                 'autocapitalize="none" spellcheck="false" class="varmatrixinput" size="5.5" style="width: 4.6em" ' .
                 'rows="5" cols="5" data-stack-input-type="varmatrix" data-stack-input-decimal-separator="." ' .
-                'data-stack-input-list-separator=","></textarea></div>',
+                'data-stack-input-list-separator=","></textarea>' .
+                '<span class="matrixbracketaccessibility" role="math" aria-label="Right square bracket"></span></div>',
             $el->render(
                 new stack_input_state(stack_input::VALID, [], '', '', '', '', ''),
                 'stack1__ans1',


### PR DESCRIPTION
### Summary

Following the accessibility discussion in #1849, this exposes the visual delimiters around fixed and variable-size matrix inputs to assistive technology.

Each visible left and right delimiter has a corresponding empty `span` with `role="math"` and a localized `aria-label`. This covers square brackets, parentheses, curly brackets and vertical bars. The no-brackets setting emits no accessibility elements.

The existing visual CSS and input API metadata are unchanged.

### Verification

- Added data-driven renderer tests covering all five `matrixparens` values for both matrix input types.
- Updated existing exact-HTML renderer tests for the additional elements.
- Rendered fixed and variable-size inputs through the standalone STACK API.
- Verified in a browser accessibility snapshot that the order is left delimiter, input, right delimiter.
- Verified that the empty elements have zero width and do not change the variable-input dimensions.
- Rebasing onto the current `iss1848` branch produced no conflicts, and PHP syntax checks pass for all modified PHP files.
