### PR TITLE
Allow semantic wrappers around matrix TeX

### DIFF
--- a/doc/en/CAS/Matrix.md
+++ b/doc/en/CAS/Matrix.md
@@ -82,6 +82,27 @@ There must be a more elegant way to do this!
 
 ## Display of matrices ## {#matrixparens}
 
+### Semantic TeX wrappers
+
+The optional second argument of `stack_matrix_disp` is a TeX command which wraps the matrix body and its
+configured delimiters.  For example,
+
+    texput(matrix, lambda([m], stack_matrix_disp(m, "\\stackmatrix")));
+
+with square `matrixparens` emits TeX of the form
+
+    \stackmatrix{[}{]}{\begin{array}{cc} ... \end{array}}
+
+The first two arguments are the question's configured left and right delimiters, and the third is the
+delimiter-free array.  Invisible delimiters are represented by `.`.  A TeX definition can therefore use
+the first two arguments as defaults, while another definition may ignore them.  Distinct wrapper commands
+may be used for semantic matrices, column vectors and row vectors.
+
+This option only changes the emitted TeX; it does not install the wrapper command.  The question or the
+surrounding renderer must define it.
+
+Without the optional wrapper, `stack_matrix_disp(m)` retains its existing output.
+
 You can set the type of parentheses used to surround matrices in a number of ways.  Firstly, the admin user should set the site default in the qtype_stack options page.
 
 For an individual question, the teacher can set the variable
@@ -113,4 +134,3 @@ You can control the alignment of the columns of the matrix using the function `s
 To change to right aligned columns, switch `"c"` to `"r"`.  This function takes the whole matrix and therefore potentially gives you full control.
 
 For this function to take effect in the whole question, including validation of students' input, place the redefinition before `%_stack_preamble_end;` in the question variables.
-

--- a/stack/maxima/stackmaxima.mac
+++ b/stack/maxima/stackmaxima.mac
@@ -879,7 +879,7 @@ stack_matrix_pairs:[ ["[", "[", "]"], ["(", "(", ")"], ["\{", "\\{", "\\}"], ["{
 */
 stack_matrix_col(ex):=simplode(maplist(lambda([ex], "c"), first(args(ex))))$
 
-stack_matrix_disp(m):= block([ret, lp, rp, parens],
+stack_matrix_disp(m, [wrapper]):= block([ret, lp, rp, parens],
   if not(matrixp(m)) then error("stack_matrix_disp: argument must be a matrix."),
   if not(stringp(lmxchar)) then error("stack_matrix_disp requires lmxchar to be a string. "),
   parens: sublist(stack_matrix_pairs, lambda([ex], is(first(ex)=lmxchar))),
@@ -891,10 +891,17 @@ stack_matrix_disp(m):= block([ret, lp, rp, parens],
   ret: maplist(lambda([ex], simplode(ex, " & ")), ret),
   ret: simplode(ret, " \\\\ "),
   ret: sconcat("\\begin{array}{", stack_matrix_col(m), "} ", ret, " \\end{array}"),
-  if ""#lp then
-    ret: sconcat("\\left", lp, ret),
-  if ""#rp then
-    ret: sconcat(ret, "\\right", rp),
+  if emptyp(wrapper) then (
+    if ""#lp then
+      ret: sconcat("\\left", lp, ret),
+    if ""#rp then
+      ret: sconcat(ret, "\\right", rp)
+  ) else (
+    if not(length(wrapper)=1) or not(stringp(first(wrapper))) then
+      error("stack_matrix_disp: optional wrapper must be one string."),
+    if ""=lp then (lp:".", rp:"."),
+    ret: sconcat(first(wrapper), "{", lp, "}{", rp, "}{", ret, "}")
+  ),
   ret
 )$
 

--- a/tests/castext2_test.php
+++ b/tests/castext2_test.php
@@ -405,6 +405,42 @@ final class castext2_test extends qtype_stack_testcase {
     }
 
     /**
+     * Test semantic matrix wrappers retain each configured delimiter as a fallback argument.
+     *
+     * @dataProvider matrix_wrapper_provider
+     * @covers \qtype_stack\stack_cas_castext2_latex
+     * @covers \qtype_stack\stack_options
+     *
+     * @param string $matrixparens the configured matrix delimiter.
+     * @param string $left the expected left delimiter argument.
+     * @param string $right the expected right delimiter argument.
+     */
+    public function test_latex_matrix_wrapper(string $matrixparens, string $left, string $right): void {
+
+        $input = '{@matrix([1,0],[0,1])@}';
+        $preamble = ['texput(matrix, lambda([m], stack_matrix_disp(m, "\\\\stackmatrix")))'];
+        $body = '\begin{array}{cc} 1 & 0 \\\\ 0 & 1 \end{array}';
+        $output = '\({\stackmatrix{' . $left . '}{' . $right . '}{' . $body . '}}\)';
+        $options = new stack_options(['matrixparens' => $matrixparens]);
+        $this->assertEquals($output, $this->evaluate($input, $preamble, $options));
+    }
+
+    /**
+     * Matrix delimiters passed to a semantic TeX wrapper.
+     *
+     * @return array[] test cases.
+     */
+    public static function matrix_wrapper_provider(): array {
+        return [
+            'square' => ['[', '[', ']'],
+            'round' => ['(', '(', ')'],
+            'curly' => ['{', '\{', '\}'],
+            'vertical bars' => ['|', '|', '|'],
+            'none' => ['', '.', '.'],
+        ];
+    }
+
+    /**
      * Block-system "define"-block, functional requirements:
      *  1. Allow inline changes to any value.
      *  2. Handle simplification.


### PR DESCRIPTION
### Summary

- Extend `stack_matrix_disp(m)` with an optional TeX wrapper argument.
- With `stack_matrix_disp(m, "\\stackmatrix")`, emit `\stackmatrix{left}{right}{array}`.
- Carry the question's configured delimiters as the first two arguments and use dots for invisible delimiters.
- Preserve the existing one-argument output exactly.

### Motivation

This provides a small platform-neutral hook for late-bound notation. A wrapper can use the first two arguments as the question's configured fallback or ignore them in favour of another presentation. Different wrappers can distinguish semantic matrices, column vectors and row vectors without making STACK inspect Moodle course context or changing compilation, grading or input syntax.

This PR only changes the TeX emitted when an author opts in; it does not install or order wrapper definitions. The ordinary one-argument call remains unchanged.

The corresponding HTML-input distinction remains in #1848. A TeX wrapper cannot restyle STACK's ordinary HTML input grid.

The shared-question use case has also been discussed in [#1327](https://github.com/maths/moodle-qtype_stack/issues/1327) and [MathJax #3603](https://github.com/mathjax/MathJax/issues/3603).

### Verification

- Focused Maxima execution covers square, round, curly, vertical-bar and invisible delimiters and confirms unchanged one-argument output.
- Added data-driven CASText tests for all five delimiter values.
- PHP syntax and `git diff --check` pass.
