### PR TITLE
Tests fix

### DIFF
--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,7 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
-        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
+        $moduleinfo->duedate = null; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,6 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
+        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,7 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
-        $moduleinfo->duedate = null; // Prevent "Undefined property" warning in Moodle 5.3+.
+        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,27 +386,4 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
-
-    /**
-     * Conditionally press collapseElement-2 on Moodle 4.2 and 5.0 only.
-     * This is needed because the PRT section collapse behavior differs across Moodle versions.
-     *
-     * @When /^I press collapseElement-2 if on Moodle 4.2 or 5.0$/
-     */
-    public function i_press_collapse_element_if_on_moodle_42_or_50() {
-        global $CFG;
-        require_once($CFG->libdir . '/environmentlib.php');
-
-        $currentversion = normalize_version(get_config('', 'release'));
-
-        // Check if running on Moodle 4.2.x or 5.0.x
-        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
-        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
-
-        if ($is42 || $is50) {
-            $context = behat_context_helper::get('behat_general');
-            $context->i_press("collapseElement-2");
-        }
-        // On other versions, do nothing - the PRT section is already expanded
-    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,4 +386,27 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
+
+    /**
+     * Conditionally press collapseElement-2 on Moodle 4.2 and 5.0 only.
+     * This is needed because the PRT section collapse behavior differs across Moodle versions.
+     *
+     * @When /^I press collapseElement-2 if on Moodle 4.2 or 5.0$/
+     */
+    public function i_press_collapse_element_if_on_moodle_42_or_50() {
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
+
+        // Check if running on Moodle 4.2.x or 5.0.x
+        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
+        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
+
+        if ($is42 || $is50) {
+            $context = behat_context_helper::get('behat_general');
+            $context->i_press("collapseElement-2");
+        }
+        // On other versions, do nothing - the PRT section is already expanded
+    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,4 +386,28 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
+
+    /**
+     * Conditionally press element on Moodle 4.2 and 5.0 only.
+     * This is needed because section collapse behavior differs across Moodle versions.
+     *
+     * @param string $element id to press
+     * @When /^I press "(?P<element>[^"]*)" if on Moodle 4.2 or 5.0$/
+     */
+    public function i_press_collapse_element_if_on_moodle_42_or_50($element) {
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
+
+        // Check if running on Moodle 4.2.x or 5.0.x
+        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
+        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
+
+        if ($is42 || $is50) {
+            $context = behat_context_helper::get('behat_general');
+            $context->i_press($element);
+        }
+        // On other versions, do nothing - the PRT section is already expanded
+    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -406,7 +406,7 @@ class behat_qtype_stack extends behat_base {
 
         if ($is42 || $is50) {
             $context = behat_context_helper::get('behat_general');
-            $context->i_press($element);
+            $context->i_click_on('#' . $element, 'css');
         }
         // On other versions, do nothing - the PRT section is already expanded
     }

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -80,6 +80,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
+    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -71,7 +71,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I press "collapseElement-2"
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +80,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -20,6 +20,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
   Scenario: Create, preview, test, tidy and edit STACK questions in Moodle ≥ 4.0
     Given the site is running Moodle version 4.0 or higher
     When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
+    And I pause
     # Create a new question.
     And I add a "STACK" question filling the form with:
       | Question name        | Test STACK question                                                           |
@@ -32,7 +33,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then I should see "Test STACK question"
 
     When I am on the "Test STACK question" "core_question > edit" page
-    And I pause
     Then the following fields match these values:
       | Question name        | Test STACK question                                                           |
       | Question variables   | p : (x-1)^3;                                                                  |
@@ -68,10 +68,10 @@ Feature: Create, edit STACK questions adding in PRT and saving.
       | Model answer         | diff(p,x)                                                                     |
       | SAns                 | ans1                                                                          |
       | TAns                 | diff(p,x)                                                                     |
-    And I press "collapseElement-2"
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
+    And I press collapseElement-2 if on Moodle 4.2 or 5.0
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +81,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press "collapseElement-2"
+    And I press collapseElement-2
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -70,8 +70,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I wait "2" seconds
-    And I press "collapseElement-2"
+    And I press "collapseElement-2" if on Moodle 4.2 or 5.0
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -20,7 +20,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
   Scenario: Create, preview, test, tidy and edit STACK questions in Moodle ≥ 4.0
     Given the site is running Moodle version 4.0 or higher
     When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
-    And I pause
     # Create a new question.
     And I add a "STACK" question filling the form with:
       | Question name        | Test STACK question                                                           |
@@ -71,7 +70,8 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I press collapseElement-2 if on Moodle 4.2 or 5.0
+    And I wait "2" seconds
+    And I press "collapseElement-2"
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +81,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press collapseElement-2
+    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -32,6 +32,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then I should see "Test STACK question"
 
     When I am on the "Test STACK question" "core_question > edit" page
+    And I pause
     Then the following fields match these values:
       | Question name        | Test STACK question                                                           |
       | Question variables   | p : (x-1)^3;                                                                  |
@@ -67,7 +68,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
       | Model answer         | diff(p,x)                                                                     |
       | SAns                 | ans1                                                                          |
       | TAns                 | diff(p,x)                                                                     |
-
+    And I press "collapseElement-2"
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"


### PR DESCRIPTION
- Set a default the absence of which was throwing a PHPUnit warning in Moodle 5.3+.
- Deal in Behat tests with an added PRT now being open by default in some (but not all!) versions of Moodle.