### PR TITLE
Preserve augmented values in fixed and variable-size matrix inputs

### DIFF
--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,7 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
-        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
+        $moduleinfo->duedate = null; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,6 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
+        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/classes/library_import.php
+++ b/classes/library_import.php
@@ -346,7 +346,7 @@ class library_import extends \external_api {
         $moduleinfo->navmethod = $quizdata->quiz->navmethod;
         $moduleinfo->timeopen = 0;
         $moduleinfo->timeclose = 0;
-        $moduleinfo->duedate = null; // Prevent "Undefined property" warning in Moodle 5.3+.
+        $moduleinfo->duedate = 0; // Prevent "Undefined property" warning in Moodle 5.3+.
         $moduleinfo->decimalpoints = 2;
         $moduleinfo->questiondecimalpoints = -1;
         $moduleinfo->grademethod = 1;

--- a/doc/en/Authoring/Inputs/Matrix_input.md
+++ b/doc/en/Authoring/Inputs/Matrix_input.md
@@ -18,19 +18,33 @@ We cannot use the `EMPTYANSWER` tag for the teacher's answer with the matrix inp
 
 The shape of the parentheses surrounding the brackets is taken from the question level options, except matrix inputs cannot display curly brackets `{`.  (If you can create CSS to do this, please contact the developers!)
 
-### Augmented matrix grids
+### Augmented matrix inputs
 
-Use the input extra option `columnseparators:3` to draw a vertical separator after column 3,
-for example for a 3-by-4 augmented system. For multiple blocks, use semicolons:
-`columnseparators:2;4` draws separators after columns 2 and 4. Column numbers are one-based,
-must be strictly increasing, and must be smaller than the instantiated matrix width.
+Use an augmented model answer directly:
 
-The teacher answer and student response remain ordinary Maxima matrices. The separators are
-presentation metadata: they do not add fields or change validation, algebra, grading or field names.
-The validation echo still uses ordinary matrix notation; display the augmented form separately in
-question text or feedback where needed. This option does not infer boundaries from `aug(A,b)`.
-API clients receive the optional `columnseparators` array with the same one-based column numbers
-and should draw these boundaries in their own matrix grid.
+    A:matrix([1,2],[3,4]);
+    b:c(5,6);
+    ta:aug(A,b);
+
+Choose the fixed matrix input with model answer `ta`. Its instantiated value is
+`aug_matrix(matrix([1,2],[3,4]),c(5,6))`: the grid automatically has two rows, three columns
+and an internal separator after column two. Multiple blocks such as `aug(A,B,C)` work in the
+same way. Blocks may be matrices or `c(...)`/`r(...)` vectors and must be nonempty with equal
+row counts. No separate boundary option is required.
+
+The student fills one grid. Submission and validation reconstruct the same augmented constructor
+and block types, and the validation echo displays the augmented matrix again. Saved responses,
+model answers and syntax hints are mapped back to the same cells. Ordinary matrix inputs retain
+their current behaviour.
+
+The teacher and student values can be compared as augmented objects. For answer tests which require
+an ordinary matrix, use `de_aug(ans1)` (and `de_aug(ta)` where appropriate). `aug`, its display rules
+and `de_aug` are available in the linear-algebra core; no contributed-library load is required.
+
+API consumers receive `casValueType: "aug_matrix"` and a `blocks` array, for example
+`[{"type":"matrix","columns":2},{"type":"c","columns":1}]`. Use these widths for grid boundaries
+and reconstruct each block with its indicated constructor. Field names and the native Moodle AJAX
+grid format do not change.
 
 ## Matrix of variable size input ###
 

--- a/doc/en/Authoring/Inputs/Matrix_input.md
+++ b/doc/en/Authoring/Inputs/Matrix_input.md
@@ -55,3 +55,28 @@ Students must separate their matrix elements by spaces, and newline characters.
 Input box size is used to determine the starting width of the input.
 
 If you use the `allowempty` option then an empty answer is indicated by the `EMPTYANSWER` tag.  This is a different _type_ than a matrix.  (We could have chosen `matrix()` as the empty matrix, but `EMPTYANSWER` is more in keeping with other inputs.)
+
+### Augmented matrices of variable size
+
+The variable-size matrix textarea also accepts an augmented model answer such as `aug(A,b)`.
+Students separate entries with spaces, rows with newlines, and blocks with `|` on every row:
+
+```text
+1 2 | 5
+3 4 | 6
+```
+
+Rows and matrix-block widths are student-selected; the model does not fix their dimensions. The model
+does fix the number and constructor types of blocks. A `c(...)` block must remain one column and an
+`r(...)` block must remain one row. Matrix blocks can have any positive number of columns. Every row
+must have the same nonempty block widths. Missing or inconsistent separators are validation errors.
+
+Submitted answers preserve `aug_matrix(...)` and the block constructors, and validation renders the
+augmented matrix with the selected outer bracket style. Model answers, syntax hints, saved responses
+and AJAX validation use the same bar-separated textarea representation. Ordinary matrices retain
+their existing space/newline syntax. The row/column-vector behavior previously introduced in #1847
+is preserved.
+
+The textarea wrapper exposes `data-stack-input-value-type="aug_matrix"`. API clients receive
+`casValueType`, `blockTypes` and `blockSeparator` metadata. These are input-surface hooks; a dedicated
+CSS wrapper around augmented MathJax output is not introduced here.

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -2072,5 +2072,4 @@ $string['sbasen_validate_not_basen'] = 'Expected a raw base-N number.';
 $string['sbasen_validate_base_too_big'] = 'The base-N system currently does not support base-{$a->base}, only bases 2-36 are supported.';
 $string['sbasen_validate_invalid_digits'] = 'Some of the digits in base-N number {$a->num} are not suitable for the base ({$a->base}) in use.';
 
-$string['matrixcolumnseparatorsinvalid'] = 'Column separators must be strictly increasing positive column numbers separated by semicolons, for example columnseparators:2;4.';
-$string['matrixcolumnseparatorswidth'] = 'Each column separator must be before the final column of the matrix input.';
+$string['matrixaugmentedshape'] = 'An augmented matrix input requires at least two nonempty blocks with the same number of rows.';

--- a/lang/en/qtype_stack.php
+++ b/lang/en/qtype_stack.php
@@ -2073,3 +2073,5 @@ $string['sbasen_validate_base_too_big'] = 'The base-N system currently does not 
 $string['sbasen_validate_invalid_digits'] = 'Some of the digits in base-N number {$a->num} are not suitable for the base ({$a->base}) in use.';
 
 $string['matrixaugmentedshape'] = 'An augmented matrix input requires at least two nonempty blocks with the same number of rows.';
+
+$string['varmatrixaugmentedstructure'] = 'Separate the augmented blocks with | on every row. Keep the same nonempty block widths on each row; column-vector blocks need one column and row-vector blocks need one row.';

--- a/samplequestions/stacklibrary/Topics/LinearAlgebra/LinearSystems/Linear-system.xml
+++ b/samplequestions/stacklibrary/Topics/LinearAlgebra/LinearSystems/Linear-system.xml
@@ -25,16 +25,16 @@
       <text><![CDATA[<p>The first step in solving this problem, is to write the augmented matrix of
 \[ {@QA@} \mathbf{x} = {@Qb@} \]
 which is
-\[ {@auglast(QAM)@} \]
+\[ {@aug(QAM)@} \]
 Now we perform row operations.</p>
 <p>(a). Clear the first column.
-\[ {@auglast(invert(E3).QAM)@}\quad \mbox{Add } {@-e3@} \times \mbox{ row 1 to row 2.}\]
-\[ {@auglast(invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-k1@} \times \mbox{ row 1 to row 3.}\]
-\[ {@auglast(invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-e1@} \times \mbox{ row 1 to row 4.}\]
+\[ {@aug(invert(E3).QAM)@}\quad \mbox{Add } {@-e3@} \times \mbox{ row 1 to row 2.}\]
+\[ {@aug(invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-k1@} \times \mbox{ row 1 to row 3.}\]
+\[ {@aug(invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-e1@} \times \mbox{ row 1 to row 4.}\]
 </p>
 <p>(b). Clear the second column.
-\[ {@auglast(invert(E2).invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-e2@} \times \mbox{ row 2 to row 3.}\]
-\[ {@auglast(invert(Ek2).invert(E2).invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-k2@} \times \mbox{ row 2 to row 4.}\]
+\[ {@aug(invert(E2).invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-e2@} \times \mbox{ row 2 to row 3.}\]
+\[ {@aug(invert(Ek2).invert(E2).invert(E1).invert(Ek1).invert(E3).QAM)@}\quad \mbox{Add } {@-k2@} \times \mbox{ row 2 to row 4.}\]
 </p>
 <p>This is in upper triangular form, and since we do not need <em>row echelon form</em> to solve the problem, so we stop row operations here.  Indeed, we don't want to divide by either {@k-k1@} or {@k-k2@} since these may turn out to be zero.  ("Division is evil!")</p>
 
@@ -51,7 +51,7 @@ Certainly the value \(k={@k1@}\) is inconsistent. The only value which gives an 
 Certainly with the value \(k={@k2@}\) we have a row of zeros, and hence an infinite number of solutions. The only value which gives an infinite number of solutions is \(k={@k2@}\).
 
 </p>
-<p>Setting \(k={@k2@}\) gives \[ {@auglast(TAM2)@} \]
+<p>Setting \(k={@k2@}\) gives \[ {@aug(TAM2)@} \]
 which has a row of zeros at the bottom, indicating we have infinite solutions.
 Notice also, we can put a parameter, \(t\) say, in the last coordinate
 \[ {@submatrix(TAM2,5) @}\begin{bmatrix} ? \\ ? \\ ? \\ t \end{bmatrix} =  {@submatrix(TAM2,1,2,3,4) @}\]
@@ -71,8 +71,6 @@ Evaluating this at \(k={@k2@}\) gives
     </stackversion>
     <questionvariables>
       <text><![CDATA[/* Based on ideas in Naiman2022. */
-stack_include_contrib("matrix.mac");
-
 k1:3+rand(2);
 k2:k1+1+rand(2);
 M:matrix([1, 0, 1, 0],[0, 1, 0, 1],[k1, 0, k, 0],[0, k2, 0, k]);
@@ -99,9 +97,6 @@ E3:matrix([1, 0, 0, 0],[e3, 1, 0, 0],[0, 0, 1, 0],[0, 0, 0, 1]);
 QAM:E3.E2.E1.MA;
 QA:submatrix(QAM,5);
 Qb:submatrix(QAM,1,2,3,4);
-
-/* Turn a matrix into an augmented matrix. */
-auglast(M):=aug(submatrix(M,5),submatrix(M,1,2,3,4));
 
 /* Answers. */
 TAM1:invert(Ek2).invert(E2).invert(E1).invert(Ek1).invert(E3).QAM;
@@ -136,7 +131,7 @@ taw1: transpose(apply(matrix,[taw1]));]]></text>
 [[feedback:prt4]]</text>
     </specificfeedback>
     <questionnote format="moodle_auto_format">
-      <text>\( {@auglast(QAM)@} \rightarrow {@auglast(TAM1)@} \) Inconsistent: \(k={@k1@}\). Infinite solutions: \(k={@k2@}\). \(\mathbf{x} = {@ta4@} \).</text>
+      <text>\( {@aug(QAM)@} \rightarrow {@aug(TAM1)@} \) Inconsistent: \(k={@k1@}\). Infinite solutions: \(k={@k2@}\). \(\mathbf{x} = {@ta4@} \).</text>
     </questionnote>
     <questiondescription format="moodle_auto_format">
       <text>This question is distributed as part of the STACK source code as an example. This is licenced as Creative Commons Attribution-ShareAlike 4.0 International License.</text>
@@ -156,7 +151,7 @@ taw1: transpose(apply(matrix,[taw1]));]]></text>
     <input>
       <name>ans1</name>
       <type>matrix</type>
-      <tans>TAM1</tans>
+      <tans>aug(TAM1)</tans>
       <boxsize>3</boxsize>
       <strictsyntax>1</strictsyntax>
       <insertstars>0</insertstars>
@@ -169,7 +164,7 @@ taw1: transpose(apply(matrix,[taw1]));]]></text>
       <checkanswertype>0</checkanswertype>
       <mustverify>1</mustverify>
       <showvalidation>3</showvalidation>
-      <options>columnseparators:4</options>
+      <options/>
     </input>
     <input>
       <name>ans2</name>
@@ -231,8 +226,10 @@ taw1: transpose(apply(matrix,[taw1]));]]></text>
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>/* Pick our the entries which need to be zero. */
-sa1:setify(flatten(makelist(makelist(ans1[l1,l2],l2,1,l1-1),l1,2,first(matrix_size(ans1)))));</text>
+        <text>/* Matrix operations use the flattened augmented response. */
+AM1:de_aug(ans1);
+/* Pick our the entries which need to be zero. */
+sa1:setify(flatten(makelist(makelist(AM1[l1,l2],l2,1,l1-1),l1,2,first(matrix_size(AM1)))));</text>
       </feedbackvariables>
       <node>
         <name>0</name>
@@ -263,7 +260,7 @@ sa1:setify(flatten(makelist(makelist(ans1[l1,l2],l2,1,l1-1),l1,2,first(matrix_si
         <name>1</name>
         <description/>
         <answertest>AlgEquiv</answertest>
-        <sans>rref(ans1)</sans>
+        <sans>rref(AM1)</sans>
         <tans>rref(TAM1)</tans>
         <testoptions/>
         <quiet>1</quiet>
@@ -325,7 +322,9 @@ sa1:setify(flatten(makelist(makelist(ans1[l1,l2],l2,1,l1-1),l1,2,first(matrix_si
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>SM2:submatrix(ans1,5);
+        <text>/* Matrix operations use the flattened augmented response. */
+AM1:de_aug(ans1);
+SM2:submatrix(AM1,5);
 sd1:determinant(at(SM2,k=ans3))</text>
       </feedbackvariables>
       <node>
@@ -367,7 +366,7 @@ sd1:determinant(at(SM2,k=ans3))</text>
         <truenextnode>-1</truenextnode>
         <trueanswernote>prt3-2-T</trueanswernote>
         <truefeedback format="html">
-          <text>You probably didn't get part 1. correct, but follow-through marking has been applied and your system {@auglast(ans1)@} does have an infinite number of solutions when \(k={@ans3@}\).</text>
+          <text>You probably didn't get part 1. correct, but follow-through marking has been applied and your system {@ans1@} does have an infinite number of solutions when \(k={@ans3@}\).</text>
         </truefeedback>
         <falsescoremode>-</falsescoremode>
         <falsescore>0</falsescore>
@@ -375,7 +374,7 @@ sd1:determinant(at(SM2,k=ans3))</text>
         <falsenextnode>-1</falsenextnode>
         <falseanswernote>prt3-2-F</falseanswernote>
         <falsefeedback format="html">
-          <text>You claim that the system {@auglast(ans1)@} has an infinite number of solutions when \(k={@ans3@}\).  But, evaluating {@SM2@} at \(k={@ans3@}\) gives {@at(SM2,k=ans3)@}.  This has determinant \({@sd1@}\neq 0\), so the augmented matrix {@auglast(ans1)@} has a unique solution when \(k={@ans3@}\).</text>
+          <text>You claim that the system {@ans1@} has an infinite number of solutions when \(k={@ans3@}\).  But, evaluating {@SM2@} at \(k={@ans3@}\) gives {@at(SM2,k=ans3)@}.  This has determinant \({@sd1@}\neq 0\), so the augmented matrix {@ans1@} has a unique solution when \(k={@ans3@}\).</text>
         </falsefeedback>
       </node>
     </prt>
@@ -385,8 +384,10 @@ sd1:determinant(at(SM2,k=ans3))</text>
       <autosimplify>1</autosimplify>
       <feedbackstyle>1</feedbackstyle>
       <feedbackvariables>
-        <text>v4:listofvars(ans4);
-SM2:submatrix(ans1,5);</text>
+        <text>/* Matrix operations use the flattened augmented response. */
+AM1:de_aug(ans1);
+v4:listofvars(ans4);
+SM2:submatrix(AM1,5);</text>
       </feedbackvariables>
       <node>
         <name>0</name>
@@ -446,7 +447,7 @@ In fact
         <description/>
         <answertest>AlgEquiv</answertest>
         <sans>at(SM2,k=ans3).ans4</sans>
-        <tans>submatrix(ans1,1,2,3,4)</tans>
+        <tans>submatrix(AM1,1,2,3,4)</tans>
         <testoptions/>
         <quiet>1</quiet>
         <truescoremode>+</truescoremode>
@@ -457,7 +458,7 @@ In fact
         <truefeedback format="html">
           <text>You probably didn't get the first part correct.
 In this case we have checked, using your answer in part 1.  When we use \(k={@ans3@}\) in your answer to part 1 we get 
-\[ {@at(SM2,k=ans3)@}{@ans4@} = {@at(SM2,k=ans3).ans4@} = {@submatrix(ans1,1,2,3,4)@} \]
+\[ {@at(SM2,k=ans3)@}{@ans4@} = {@at(SM2,k=ans3).ans4@} = {@submatrix(AM1,1,2,3,4)@} \]
 So, although your row reductions contain a mistake you have correctly solved the system for \(k={@ans3@}\) as you claim!</text>
         </truefeedback>
         <falsescoremode>-</falsescoremode>
@@ -468,7 +469,7 @@ So, although your row reductions contain a mistake you have correctly solved the
         <falsefeedback format="html">
           <text>You probably didn't get the first part correct.
 In this case we have checked, using your answer in part 1.  When we use \(k={@ans3@}\) in your answer to part 1 we get 
-\[ {@at(SM2,k=ans3)@}{@ans4@} = {@at(SM2,k=ans3).ans4@} \neq {@submatrix(ans1,1,2,3,4)@}. \]
+\[ {@at(SM2,k=ans3)@}{@ans4@} = {@at(SM2,k=ans3).ans4@} \neq {@submatrix(AM1,1,2,3,4)@}. \]
 So, no follow-through marking applies here either.</text>
         </falsefeedback>
       </node>
@@ -484,7 +485,7 @@ So, no follow-through marking applies here either.</text>
       <description/>
       <testinput>
         <name>ans1</name>
-        <value>TAM1</value>
+        <value>aug(TAM1)</value>
       </testinput>
       <testinput>
         <name>ans2</name>
@@ -528,7 +529,7 @@ So, no follow-through marking applies here either.</text>
       <description/>
       <testinput>
         <name>ans1</name>
-        <value>WTAM1</value>
+        <value>aug(WTAM1)</value>
       </testinput>
       <testinput>
         <name>ans2</name>
@@ -567,5 +568,49 @@ So, no follow-through marking applies here either.</text>
         <expectedanswernote>prt4-3-T</expectedanswernote>
       </expected>
     </qtest>
-  </question>
+  <qtest>
+      <testcase>3</testcase>
+      <description>The unreduced augmented system is equivalent but is not upper triangular.</description>
+      <testinput>
+        <name>ans1</name>
+        <value>aug(QAM)</value>
+      </testinput>
+      <testinput>
+        <name>ans2</name>
+        <value>ta2</value>
+      </testinput>
+      <testinput>
+        <name>ans3</name>
+        <value>ta3</value>
+      </testinput>
+      <testinput>
+        <name>ans4</name>
+        <value>ta4</value>
+      </testinput>
+      <expected>
+        <name>prt1</name>
+        <expectedscore>0.0000000</expectedscore>
+        <expectedpenalty>0.1000000</expectedpenalty>
+        <expectedanswernote>prt1-1-F</expectedanswernote>
+      </expected>
+      <expected>
+        <name>prt2</name>
+        <expectedscore>1.0000000</expectedscore>
+        <expectedpenalty>0.0000000</expectedpenalty>
+        <expectedanswernote>prt2-1-T</expectedanswernote>
+      </expected>
+      <expected>
+        <name>prt3</name>
+        <expectedscore>1.0000000</expectedscore>
+        <expectedpenalty>0.0000000</expectedpenalty>
+        <expectedanswernote>prt3-1-T</expectedanswernote>
+      </expected>
+      <expected>
+        <name>prt4</name>
+        <expectedscore>1.0000000</expectedscore>
+        <expectedpenalty>0.0000000</expectedpenalty>
+        <expectedanswernote>prt4-2-T</expectedanswernote>
+      </expected>
+    </qtest>
+    </question>
 </quiz>

--- a/stack/input/matrix/matrix.class.php
+++ b/stack/input/matrix/matrix.class.php
@@ -26,6 +26,14 @@ class stack_matrix_input extends stack_input {
     protected $width;
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     protected $height;
+    /** @var string Constructor reconstructed from the grid. */
+    protected $valuetype = 'matrix';
+    /** @var int[] Width of each augmented block. Empty for an ordinary matrix. */
+    protected $blockwidths = [];
+    /** @var string[] Constructor of each augmented block (matrix, c or r). */
+    protected $blocktypes = [];
+    /** @var int[] One-based columns followed by an augmentation separator. */
+    protected $columnseparators = [];
 
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     protected $extraoptions = [
@@ -38,58 +46,55 @@ class stack_matrix_input extends stack_input {
         'validator' => false,
         'feedback' => false,
         'manualgraded' => false,
-        'columnseparators' => false,
     ];
-
-    /** @var int[] One-based columns followed by a visual block separator. */
-    protected $columnseparators = [];
-
-    /** Validate separator syntax independently of the instantiated matrix size. */
-    public function validate_extra_options() {
-        // The base validator handles common options; this input owns separator validation.
-        $value = $this->extraoptions['columnseparators'];
-        unset($this->extraoptions['columnseparators']);
-        parent::validate_extra_options();
-        $this->extraoptions['columnseparators'] = $value;
-        $this->columnseparators = [];
-        if ($value === false) {
-            return;
-        }
-        if (!is_string($value) || !preg_match('/^[1-9][0-9]*(;[1-9][0-9]*)*$/D', $value)) {
-            $this->errors[] = stack_string('matrixcolumnseparatorsinvalid');
-            return;
-        }
-        $columns = array_map('intval', explode(';', $value));
-        $previous = 0;
-        foreach ($columns as $column) {
-            if ($column <= $previous) {
-                $this->errors[] = stack_string('matrixcolumnseparatorsinvalid');
-                return;
-            }
-            $previous = $column;
-        }
-        $this->columnseparators = $columns;
-    }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function adapt_to_model_answer($teacheranswer) {
-
-        // Work out how big the matrix should be from the INSTANTIATED VALUE of the teacher's answer.
-        $cs = stack_ast_container::make_from_teacher_source('matrix_size(' . $teacheranswer . ')');
+        $this->valuetype = 'matrix';
+        $this->blockwidths = [];
+        $this->blocktypes = [];
+        $this->columnseparators = [];
+        // aug(A,b) is instantiated by matrix.mac as aug_matrix(A,b). Infer boundaries from
+        // the value, as with c/r inputs, rather than asking authors to duplicate its shape.
+        $cs = stack_ast_container::make_from_teacher_source(
+            'block([v:' . $teacheranswer . ',blocks,shapes,hh], ' .
+            'if safe_op(v)#"aug_matrix" then append(matrix_size(v),[0]) else (' .
+            'blocks:args(v), ' .
+            'if length(blocks)<2 then [0,0,1] else (' .
+            'shapes:map(lambda([b],if safe_op(b)="c" then [length(args(b)),1,1] ' .
+            'else if safe_op(b)="r" then [1,length(args(b)),2] else append(matrix_size(b),[0])),blocks), ' .
+            'hh:first(first(shapes)), ' .
+            'if hh<1 or member(true,map(lambda([z],is(first(z)#hh or second(z)<1)),shapes)) then [0,0,1] ' .
+            'else append([hh,apply("+",map(second,shapes)),length(blocks)], ' .
+            'apply(append,map(lambda([z],[second(z),third(z)]),shapes))))))'
+        );
         $cs->get_valid();
-        $at1 = new stack_cas_session2([$cs], null, 0);
-        $at1->instantiate();
-
-        if ('' != $at1->get_errors()) {
-            $this->errors[] = $at1->get_errors();
+        $session = new stack_cas_session2([$cs], null, 0);
+        $session->instantiate();
+        if ('' != $session->get_errors()) {
+            $this->errors[] = $session->get_errors();
             return;
         }
-
-        // These are ints...
         $this->height = $cs->get_list_element(0, true)->value;
         $this->width = $cs->get_list_element(1, true)->value;
-        if ($this->columnseparators && end($this->columnseparators) >= $this->width) {
-            $this->errors[] = stack_string('matrixcolumnseparatorswidth');
+        $count = $cs->get_list_element(2, true)->value;
+        if ($count && $this->height === 0) {
+            $this->errors[] = stack_string('matrixaugmentedshape');
+            return;
+        }
+        if ($count) {
+            $this->valuetype = 'aug_matrix';
+            $offset = 0;
+            for ($i = 0; $i < $count; $i++) {
+                $width = $cs->get_list_element(3 + 2 * $i, true)->value;
+                $type = $cs->get_list_element(4 + 2 * $i, true)->value;
+                $this->blockwidths[] = $width;
+                $this->blocktypes[] = ['matrix', 'c', 'r'][$type];
+                $offset += $width;
+                if ($i + 1 < $count) {
+                    $this->columnseparators[] = $offset;
+                }
+            }
         }
     }
 
@@ -176,11 +181,33 @@ class stack_matrix_input extends stack_input {
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     public function contents_to_maxima($contents) {
-        $matrix = [];
-        foreach ($contents as $row) {
-            $matrix[] = '[' . implode(',', $row) . ']';
+        if ($this->valuetype === 'aug_matrix') {
+            $blocks = [];
+            $offset = 0;
+            foreach ($this->blockwidths as $i => $width) {
+                $rows = array_map(function($row) use ($offset, $width) {
+                    return array_slice($row, $offset, $width);
+                }, $contents);
+                $blocks[] = $this->array_to_constructor($rows, $this->blocktypes[$i]);
+                $offset += $width;
+            }
+            return 'aug_matrix(' . implode(',', $blocks) . ')';
         }
-        return 'matrix(' . implode(',', $matrix) . ')';
+        return $this->array_to_constructor($contents, 'matrix');
+    }
+
+    /** Serialize a block without evaluating student expressions. */
+    private function array_to_constructor($contents, $type) {
+        if ($type === 'c') {
+            return 'c(' . implode(',', array_column($contents, 0)) . ')';
+        }
+        if ($type === 'r') {
+            return 'r(' . implode(',', $contents[0]) . ')';
+        }
+        $rows = array_map(function($row) {
+            return '[' . implode(',', $row) . ']';
+        }, $contents);
+        return 'matrix(' . implode(',', $rows) . ')';
     }
 
     /**
@@ -195,6 +222,20 @@ class stack_matrix_input extends stack_input {
 
         // Turn the student's answer, syntax hint, etc., into a PHP array.
         $t = trim($in);
+        if ($this->valuetype === 'aug_matrix' && substr($t, 0, 11) === 'aug_matrix(') {
+            $blocks = $this->modinput_tokenizer(substr($t, 11, -1));
+            $offset = 0;
+            foreach ($this->blockwidths as $block => $width) {
+                $rows = $this->constructor_to_array($blocks[$block] ?? '');
+                for ($i = 0; $i < $this->height; $i++) {
+                    for ($j = 0; $j < $width; $j++) {
+                        $tc[$i][$offset + $j] = $rows[$i][$j] ?? '';
+                    }
+                }
+                $offset += $width;
+            }
+            return $tc;
+        }
         if ('matrix(' == substr($t, 0, 7)) {
             // @codingStandardsIgnoreStart
             // E.g. array("[a,b]","[c,d]").
@@ -207,6 +248,25 @@ class stack_matrix_input extends stack_input {
         }
 
         return $tc;
+    }
+
+    /** Decode an instantiated augmented block for model answers and saved responses. */
+    private function constructor_to_array($value) {
+        $value = trim($value);
+        if (substr($value, 0, 2) === 'c(') {
+            return array_map(function($entry) {
+                return [$entry];
+            }, $this->modinput_tokenizer(substr($value, 2, -1)));
+        }
+        if (substr($value, 0, 2) === 'r(') {
+            return [$this->modinput_tokenizer(substr($value, 2, -1))];
+        }
+        if (substr($value, 0, 7) === 'matrix(') {
+            return array_map(function($row) {
+                return $this->modinput_tokenizer(substr(trim($row), 1, -1));
+            }, $this->modinput_tokenizer(substr($value, 7, -1)));
+        }
+        return [];
     }
 
     /**
@@ -270,18 +330,15 @@ class stack_matrix_input extends stack_input {
         }
         // Construct one final "answer" as a single maxima object.
         // In the case of matrices (where $caslines are empty) create the object directly here.
-        // As this will create a matrix we need to check that 'matrix' is not a forbidden word.
-        // Should it be a forbidden word it gets still applied to the cells.
-        if (isset(stack_cas_security::list_to_map($this->get_parameter('forbidWords', ''))['matrix'])) {
-            $modifiedforbid = str_replace('\,', 'COMMA_TAG', $this->get_parameter('forbidWords', ''));
-            $modifiedforbid = explode(',', $modifiedforbid);
-            array_map('trim', $modifiedforbid);
-            unset($modifiedforbid[array_search('matrix', $modifiedforbid)]);
-            $modifiedforbid = implode(',', $modifiedforbid);
-            $modifiedforbid = str_replace('COMMA_TAG', '\,', $modifiedforbid);
-            $secrules->set_forbiddenwords(trim($modifiedforbid));
-            // Cumbersome, and cannot deal with matrix being within an alias...
-            // But first iteration and so on.
+        // Cell-level forbidden words still apply. Only constructors generated by the grid
+        // are removed from the forbidden list for validation of the assembled object.
+        $constructors = array_unique(array_merge([$this->valuetype], $this->blocktypes));
+        $modifiedforbid = str_replace('\\,', 'COMMA_TAG', $this->get_parameter('forbidWords', ''));
+        $modifiedforbid = array_map('trim', explode(',', $modifiedforbid));
+        $modifiedforbid = array_diff($modifiedforbid, $constructors);
+        $secrules->set_forbiddenwords(str_replace('COMMA_TAG', '\\,', implode(',', $modifiedforbid)));
+        if ($this->valuetype === 'aug_matrix') {
+            $secrules->add_allowedwords(implode(',', $constructors));
         }
         $value = $this->contents_to_maxima($modifiedcontents);
         // Sanitised above.
@@ -352,10 +409,12 @@ class stack_matrix_input extends stack_input {
         } else if ($matrixparens == '') {
             $matrixbrackets = 'matrixnobrackets';
         }
+        // Expose the value type without changing grid field names or AJAX responses.
+        $valueattr = $this->valuetype === 'matrix' ? '' : ' data-stack-input-value-type="aug_matrix"';
         // Build the html table to contain these values.
         $xhtml = '<div class="' . $matrixbrackets . '"><table class="matrixtable" id="' . $fieldname .
                 '_container" style="display:inline; vertical-align: middle;" ' .
-                'cellpadding="1" cellspacing="0"><tbody>';
+                'cellpadding="1" cellspacing="0"' . $valueattr . '><tbody>';
         for ($i = 0; $i < $this->height; $i++) {
             $xhtml .= '<tr>';
             if ($i == 0) {
@@ -435,8 +494,12 @@ class stack_matrix_input extends stack_input {
         $data['boxWidth'] = $this->parameters['boxWidth'];
         $data['width'] = $this->width;
         $data['height'] = $this->height;
-        if ($this->columnseparators) {
-            $data['columnseparators'] = $this->columnseparators;
+        if ($this->valuetype === 'aug_matrix') {
+            $data['casValueType'] = $this->valuetype;
+            $data['blocks'] = [];
+            foreach ($this->blockwidths as $i => $width) {
+                $data['blocks'][] = ['type' => $this->blocktypes[$i], 'columns' => $width];
+            }
         }
 
         return $data;

--- a/stack/input/varmatrix/varmatrix.class.php
+++ b/stack/input/varmatrix/varmatrix.class.php
@@ -23,6 +23,16 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class stack_varmatrix_input extends stack_input {
+    /**
+     * The Maxima constructor generated from the textarea: matrix, c, or r.
+     *
+     * @var string
+     */
+    protected $valuetype = 'matrix';
+
+    /** @var string[] Constructors of augmented blocks; dimensions remain student-selected. */
+    protected $blocktypes = [];
+
     // phpcs:ignore moodle.Commenting.VariableComment.Missing
     protected $extraoptions = [
         'hideanswer' => false,
@@ -35,6 +45,47 @@ class stack_varmatrix_input extends stack_input {
         'monospace' => false,
         'manualgraded' => false,
     ];
+
+    // phpcs:ignore moodle.Commenting.MissingDocblock.Function
+    public function adapt_to_model_answer($teacheranswer) {
+        $this->valuetype = 'matrix';
+        $this->blocktypes = [];
+
+        // Read the value type from the INSTANTIATED VALUE of the teacher's answer.
+        $cs = stack_ast_container::make_from_teacher_source(
+            'block([v:' . $teacheranswer . ', vop], ' .
+            'vop:safe_op(v), ' .
+            'if is(vop="c") then [1] ' .
+            'else if is(vop="r") then [2] ' .
+            'else if is(vop="aug_matrix") then cons(3,map(lambda([b], ' .
+            'if safe_op(b)="c" then 1 else if safe_op(b)="r" then 2 else 0),args(v))) ' .
+            'else [0])'
+        );
+        $cs->get_valid();
+        $at1 = new stack_cas_session2([$cs], null, 0);
+        $at1->instantiate();
+
+        if ('' != $at1->get_errors()) {
+            $this->errors[] = $at1->get_errors();
+            return;
+        }
+
+        $valuetype = $cs->get_list_element(0, true)->value;
+        if ($valuetype === 1) {
+            $this->valuetype = 'c';
+        } else if ($valuetype === 2) {
+            $this->valuetype = 'r';
+        } else if ($valuetype === 3) {
+            $this->valuetype = 'aug_matrix';
+            $types = stack_utils::list_to_array($cs->get_value(), false);
+            foreach (array_slice($types, 1) as $type) {
+                $this->blocktypes[] = ['matrix', 'c', 'r'][(int)$type];
+            }
+            if (count($this->blocktypes) < 2) {
+                $this->errors[] = stack_string('matrixaugmentedshape');
+            }
+        }
+    }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
     protected function is_blank_response($contents) {
@@ -136,8 +187,12 @@ class stack_varmatrix_input extends stack_input {
             $attributes['data-stack-input-list-separator'] = ',';
         }
 
+        $wrapperattributes = ['class' => $matrixbrackets];
+        if ($this->valuetype !== 'matrix') {
+            $wrapperattributes['data-stack-input-value-type'] = $this->valuetype;
+        }
         $xhtml = html_writer::tag('textarea', htmlspecialchars($current, ENT_COMPAT), $attributes);
-        return html_writer::tag('div', $xhtml, ['class' => $matrixbrackets]);
+        return html_writer::tag('div', $xhtml, $wrapperattributes);
     }
 
     // phpcs:ignore moodle.Commenting.MissingDocblock.Function
@@ -149,6 +204,11 @@ class stack_varmatrix_input extends stack_input {
         $data = [];
 
         $data['type'] = 'varmatrix';
+        $data['casValueType'] = $this->valuetype;
+        if ($this->valuetype === 'aug_matrix') {
+            $data['blockTypes'] = $this->blocktypes;
+            $data['blockSeparator'] = '|';
+        }
         $data['boxWidth'] = $this->parameters['boxWidth'];
         $data['syntaxHint'] = $this->maxima_to_raw_input($this->parameters['syntaxHint']);
 
@@ -189,6 +249,19 @@ class stack_varmatrix_input extends stack_input {
             if (trim($sans) === '' && $this->get_extra_option('allowempty')) {
                 return(['EMPTYANSWER']);
             }
+            if (in_array($this->valuetype, ['c', 'r'])) {
+                $entries = preg_split('/\s+/', trim($sans), -1, PREG_SPLIT_NO_EMPTY);
+                if ($this->valuetype === 'c') {
+                    return array_map(function ($entry) {
+                        return [$entry];
+                    }, $entries);
+                }
+                return $entries === [] ? [] : [$entries];
+            }
+            // A bar is a structural separator, never an expression passed to the CAS.
+            if ($this->valuetype === 'aug_matrix') {
+                $sans = str_replace('|', ' | ', $sans);
+            }
             $rowsin = explode("\n", $sans);
             foreach ($rowsin as $key => $row) {
                 $cleanrow = trim($row);
@@ -205,6 +278,9 @@ class stack_varmatrix_input extends stack_input {
             $contents[$key] = $entries;
         }
         foreach ($contents as $key => $row) {
+            if ($this->valuetype === 'aug_matrix') {
+                continue; // Mismatched augmented rows are reported explicitly during validation.
+            }
             // Pad out short rows.
             $padrow = [];
             for ($i = 0; $i < ($maxlen - count($row)); $i++) {
@@ -243,11 +319,77 @@ class stack_varmatrix_input extends stack_input {
         if ($contents == ['EMPTYANSWER']) {
             return 'EMPTYANSWER';
         }
+        if ($this->valuetype === 'c') {
+            return 'c(' . implode(',', array_column($contents, 0)) . ')';
+        }
+        if ($this->valuetype === 'r') {
+            return 'r(' . implode(',', $contents[0] ?? []) . ')';
+        }
+        if ($this->valuetype === 'aug_matrix') {
+            $widths = $this->augmented_widths($contents);
+            if ($widths === null) {
+                return 'matrix([])'; // Invalid structure is reported before CAS validation.
+            }
+            $blocks = [];
+            $offset = 0;
+            foreach ($widths as $i => $width) {
+                $rows = array_map(function ($row) use ($offset, $width) {
+                    return array_slice($row, $offset, $width);
+                }, $contents);
+                if ($this->blocktypes[$i] === 'c') {
+                    $blocks[] = 'c(' . implode(',', array_column($rows, 0)) . ')';
+                } else if ($this->blocktypes[$i] === 'r') {
+                    $blocks[] = 'r(' . implode(',', $rows[0]) . ')';
+                } else {
+                    $blocks[] = 'matrix(' . implode(',', array_map(function ($row) {
+                        return '[' . implode(',', $row) . ']';
+                    }, $rows)) . ')';
+                }
+                $offset += $width + 1;
+            }
+            return 'aug_matrix(' . implode(',', $blocks) . ')';
+        }
         $matrix = [];
         foreach ($contents as $row) {
             $matrix[] = '[' . implode(',', $row) . ']';
         }
         return 'matrix(' . implode(',', $matrix) . ')';
+    }
+
+    /**
+     * Read consistent, nonempty block widths from every row of a student response.
+     *
+     * @param array $contents Tokenised textarea rows, including structural bars.
+     * @return array|null Block widths, or null for malformed or incompatible blocks.
+     */
+    private function augmented_widths($contents) {
+        $widths = null;
+        foreach ($contents as $row) {
+            $current = [0];
+            foreach ($row as $entry) {
+                if ($entry === '|') {
+                    $current[] = 0;
+                } else {
+                    $current[count($current) - 1]++;
+                }
+            }
+            if (in_array(0, $current) || count($current) !== count($this->blocktypes)) {
+                return null;
+            }
+            if ($widths !== null && $widths !== $current) {
+                return null;
+            }
+            $widths = $current;
+        }
+        if ($widths === null) {
+            return null;
+        }
+        foreach ($this->blocktypes as $i => $type) {
+            if (($type === 'c' && $widths[$i] !== 1) || ($type === 'r' && count($contents) !== 1)) {
+                return null;
+            }
+        }
+        return $widths;
     }
 
     /**
@@ -260,6 +402,11 @@ class stack_varmatrix_input extends stack_input {
         $errors = [];
         $notes = [];
         $valid = true;
+        if ($this->valuetype === 'aug_matrix' && $contents !== ['EMPTYANSWER'] &&
+                $this->augmented_widths($contents) === null) {
+            $valid = false;
+            $errors[] = stack_string('varmatrixaugmentedstructure');
+        }
         [$secrules, $filterstoapply] = $this->validate_contents_filters($basesecurity);
         // Separate rules for inert display logic, which wraps floats with certain functions.
         $secrulesd = clone $secrules;
@@ -273,6 +420,10 @@ class stack_varmatrix_input extends stack_input {
             foreach ($contents as $row) {
                 $modifiedrow = [];
                 foreach ($row as $val) {
+                    if ($this->valuetype === 'aug_matrix' && $val === '|') {
+                        $modifiedrow[] = '|';
+                        continue;
+                    }
                     // Any student input which is too long is not even parsed.
                     if (strlen($val) > $this->maxinputlength) {
                         $valid = false;
@@ -324,20 +475,14 @@ class stack_varmatrix_input extends stack_input {
             }
         }
 
-        // Construct one final "answer" as a single maxima object.
-        // In the case of matrices (where $caslines are empty) create the object directly here.
-        // As this will create a matrix we need to check that 'matrix' is not a forbidden word.
-        // Should it be a forbidden word it gets still applied to the cells.
-        if (isset(stack_cas_security::list_to_map($this->get_parameter('forbidWords', ''))['matrix'])) {
-            $modifiedforbid = str_replace('\,', 'COMMA_TAG', $this->get_parameter('forbidWords', ''));
-            $modifiedforbid = explode(',', $modifiedforbid);
-            array_map('trim', $modifiedforbid);
-            unset($modifiedforbid[array_search('matrix', $modifiedforbid)]);
-            $modifiedforbid = implode(',', $modifiedforbid);
-            $modifiedforbid = str_replace('COMMA_TAG', '\,', $modifiedforbid);
-            $secrules->set_forbiddenwords($modifiedforbid);
-            // Cumbersome, and cannot deal with matrix being within an alias...
-            // But first iteration and so on.
+        // Only generated constructors are exempted, after every student cell was checked above.
+        $constructors = array_unique(array_merge([$this->valuetype], $this->blocktypes));
+        $modifiedforbid = str_replace('\,', 'COMMA_TAG', $this->get_parameter('forbidWords', ''));
+        $modifiedforbid = array_map('trim', explode(',', $modifiedforbid));
+        $modifiedforbid = array_diff($modifiedforbid, $constructors);
+        $secrules->set_forbiddenwords(str_replace('COMMA_TAG', '\,', implode(',', $modifiedforbid)));
+        if ($this->valuetype === 'aug_matrix') {
+            $secrules->add_allowedwords(implode(',', $constructors));
         }
         $value = $this->contents_to_maxima($modifiedcontents);
         // Sanitised above.
@@ -385,6 +530,30 @@ class stack_varmatrix_input extends stack_input {
             'decimal' => $decimal,
             'listsep' => $listsep,
         ];
+        $trimmed = trim($in);
+        if (substr($trimmed, 0, 11) === 'aug_matrix(') {
+            $blocks = stack_utils::list_to_array('[' . substr($trimmed, 11, -1) . ']', false);
+            $rows = [];
+            foreach ($blocks as $i => $block) {
+                $blockrows = explode("\n", trim($this->maxima_to_raw_input($block)));
+                foreach ($blockrows as $j => $row) {
+                    $rows[$j] = ($rows[$j] ?? '') . ($i > 0 ? ' | ' : '') . trim($row);
+                }
+            }
+            return implode("\n", $rows);
+        }
+        if (in_array(substr($trimmed, 0, 2), ['c(', 'r('])) {
+            $entries = stack_utils::list_to_array('[' . substr($trimmed, 2, -1) . ']', false);
+            if (substr($trimmed, 0, 2) === 'c(') {
+                $rows = [];
+                foreach ($entries as $entry) {
+                    $rows[] = '[' . $entry . ']';
+                }
+                $in = 'matrix(' . implode(',', $rows) . ')';
+            } else {
+                $in = 'matrix([' . implode(',', $entries) . '])';
+            }
+        }
         $cs = stack_ast_container::make_from_teacher_source($in);
         return $cs->ast_to_string(null, $tostringparams);
     }

--- a/stack/maxima/contrib/matrix.mac
+++ b/stack/maxima/contrib/matrix.mac
@@ -25,46 +25,7 @@ stack_linear_algebra_declare(true)$
 /* Thank you to Georg Osang of IDEMS International    */
 /* for significant contributions to this work in 2024 */
 
-/*******************************************************************************/
-/* A convenience function for displaying a matrix as an augmented matrix       */
-/*******************************************************************************/
-texput(aug_matrix, lambda([ex],
-  block([exl:args(ex),ii,ss,ll:lmxchar,rr,lmxchar],
-    if is(ll="[") then rr: "]"
-    else if is(ll="(") then rr: ")"
-    else if is(ll="") then (ll: ".", rr: ".")
-    else if is(ll="{") then (ll: "\\{", rr: "\\}")
-    else if is(ll="|") then rr: "|",
-    lmxchar: "",
-    ss: ["\\left",ll,tex1(exl[1])],
-    for ii: 2 thru length(exl) do block(
-      ii: ev(ii,simp),
-      ss: append(ss, ["\\left|",tex1(exl[ii]),"\\right."])
-    ),
-    ss: append(ss, ["\\right",rr]),
-    return(simplode(ss))
-  )
-));
-
-/**
- * Converts a matrix to an aug_matrix
- * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
- * To convert back, use de_aug 
- *
- * @param[matrix] M The matrix or matrices you would like to display as an augmented matrix
- * @return[aug_matrix] An augmented matrix
- */
-aug([M]):= if is(length(M)=1) then apply(aug_matrix,[submatrix(first(M),second(matrix_size(first(M)))),col(first(M),second(matrix_size(first(M))))]) else apply(aug_matrix,M);
-
-/**
- * Converts an aug_matrix to a matrix
- * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
- * Note: This always returns a single matrix constructed by concatenating the arguments of the original aug_matrix. 
- *
- * @param[matrix] M The aug_matrix you would like to treat as a regular matrix
- * @return[aug_matrix] A matrix
- */
-de_aug(M):= apply(addcol, args(M));
+/* aug, aug_matrix display and de_aug are provided by linearalgebra_core.mac. */
 
 /*********************************************************************************/
 /* Functions to extract parts of matrices                                        */

--- a/stack/maxima/linearalgebra_core.mac
+++ b/stack/maxima/linearalgebra_core.mac
@@ -447,3 +447,44 @@ crossproduct(a,b) := block(
     if (not(is(matrix_size(a)=[3,1])) or not(is(matrix_size(b)=[3,1]))) then error("crossproduct requires 3 by 1 matrices."),
     transpose(matrix([a[2,1]*b[3,1]-a[3,1]*b[2,1],a[3,1]*b[1,1]-a[1,1]*b[3,1],a[1,1]*b[2,1]-a[2,1]*b[1,1]]))
 )$
+
+/*******************************************************************************/
+/* A convenience function for displaying a matrix as an augmented matrix       */
+/*******************************************************************************/
+texput(aug_matrix, lambda([ex],
+  block([exl:map(vec_convert,args(ex)),ii,ss,ll:lmxchar,rr,lmxchar],
+    if is(ll="[") then rr: "]"
+    else if is(ll="(") then rr: ")"
+    else if is(ll="") then (ll: ".", rr: ".")
+    else if is(ll="{") then (ll: "\\{", rr: "\\}")
+    else if is(ll="|") then rr: "|",
+    lmxchar: "",
+    ss: ["\\left",ll,tex1(exl[1])],
+    for ii: 2 thru length(exl) do block(
+      ii: ev(ii,simp),
+      ss: append(ss, ["\\left|",tex1(exl[ii]),"\\right."])
+    ),
+    ss: append(ss, ["\\right",rr]),
+    return(simplode(ss))
+  )
+));
+
+/**
+ * Converts a matrix to an aug_matrix
+ * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
+ * To convert back, use de_aug
+ *
+ * @param[matrix] M The matrix or matrices you would like to display as an augmented matrix
+ * @return[aug_matrix] An augmented matrix
+ */
+aug([M]):= if is(length(M)=1) then apply(aug_matrix,[submatrix(first(M),second(matrix_size(first(M)))),col(first(M),second(matrix_size(first(M))))]) else apply(aug_matrix,M);
+
+/**
+ * Converts an aug_matrix to a matrix
+ * aug_matrix is an inert function that is used for displaying a matrix as an augmented matrix
+ * Note: This always returns a single matrix constructed by concatenating the arguments of the original aug_matrix.
+ *
+ * @param[matrix] M The aug_matrix you would like to treat as a regular matrix
+ * @return[aug_matrix] A matrix
+ */
+de_aug(M):= apply(addcol, map(vec_convert,args(M)));

--- a/stack/maxima/linearalgebra_core_test.mac
+++ b/stack/maxima/linearalgebra_core_test.mac
@@ -140,3 +140,9 @@ s_test_case_simp(pinv(matrix([1,0],[0,1],[1,1])),matrix([2/3,-(1/3),1/3],[-(1/3)
 s_test_case_simp(pinv(matrix([1,0,1],[0,1,1])),matrix([2/3,-(1/3)],[-(1/3),2/3],[1/3,1/3]));
 
 s_test_case(crossproduct(matrix([1],[2],[3]),matrix([a],[b],[c])),matrix([2*c-3*b],[3*a-1*c],[1*b-2*a]));
+
+/* Augmented values retain their blocks, including vector blocks. */
+s_test_case(aug(matrix([1,2],[3,4]),matrix([5],[6])),aug_matrix(matrix([1,2],[3,4]),matrix([5],[6])));
+s_test_case(de_aug(aug(matrix([1,2],[3,4]),c(5,6))),matrix([1,2,5],[3,4,6]));
+s_test_case(de_aug(aug(r(1,2),r(3))),matrix([1,2,3]));
+s_test_case(de_aug(aug(matrix([1,2]),matrix([3]),matrix([4,5]))),matrix([1,2,3,4,5]));

--- a/styles.css
+++ b/styles.css
@@ -1704,7 +1704,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
     color: #495057;
 }
 
-/* Visual augmentation only: the response remains one ordinary matrix. */
+/* Grid augmentation mirrors the block boundaries in the model answer. */
 .que.stack .matrixtable td.stack-matrix-column-separator {
     border-right: 1px solid currentColor;
     padding-right: 0.4em;

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,27 +386,4 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
-
-    /**
-     * Conditionally press collapseElement-2 on Moodle 4.2 and 5.0 only.
-     * This is needed because the PRT section collapse behavior differs across Moodle versions.
-     *
-     * @When /^I press collapseElement-2 if on Moodle 4.2 or 5.0$/
-     */
-    public function i_press_collapse_element_if_on_moodle_42_or_50() {
-        global $CFG;
-        require_once($CFG->libdir . '/environmentlib.php');
-
-        $currentversion = normalize_version(get_config('', 'release'));
-
-        // Check if running on Moodle 4.2.x or 5.0.x
-        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
-        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
-
-        if ($is42 || $is50) {
-            $context = behat_context_helper::get('behat_general');
-            $context->i_press("collapseElement-2");
-        }
-        // On other versions, do nothing - the PRT section is already expanded
-    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,4 +386,27 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
+
+    /**
+     * Conditionally press collapseElement-2 on Moodle 4.2 and 5.0 only.
+     * This is needed because the PRT section collapse behavior differs across Moodle versions.
+     *
+     * @When /^I press collapseElement-2 if on Moodle 4.2 or 5.0$/
+     */
+    public function i_press_collapse_element_if_on_moodle_42_or_50() {
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
+
+        // Check if running on Moodle 4.2.x or 5.0.x
+        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
+        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
+
+        if ($is42 || $is50) {
+            $context = behat_context_helper::get('behat_general');
+            $context->i_press("collapseElement-2");
+        }
+        // On other versions, do nothing - the PRT section is already expanded
+    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -386,4 +386,28 @@ class behat_qtype_stack extends behat_base {
         }
         return $id;
     }
+
+    /**
+     * Conditionally press element on Moodle 4.2 and 5.0 only.
+     * This is needed because section collapse behavior differs across Moodle versions.
+     *
+     * @param string $element id to press
+     * @When /^I press "(?P<element>[^"]*)" if on Moodle 4.2 or 5.0$/
+     */
+    public function i_press_collapse_element_if_on_moodle_42_or_50($element) {
+        global $CFG;
+        require_once($CFG->libdir . '/environmentlib.php');
+
+        $currentversion = normalize_version(get_config('', 'release'));
+
+        // Check if running on Moodle 4.2.x or 5.0.x
+        $is42 = version_compare($currentversion, '4.2', '>=') && version_compare($currentversion, '4.3', '<');
+        $is50 = version_compare($currentversion, '5.0', '>=') && version_compare($currentversion, '5.1', '<');
+
+        if ($is42 || $is50) {
+            $context = behat_context_helper::get('behat_general');
+            $context->i_press($element);
+        }
+        // On other versions, do nothing - the PRT section is already expanded
+    }
 }

--- a/tests/behat/behat_qtype_stack.php
+++ b/tests/behat/behat_qtype_stack.php
@@ -406,7 +406,7 @@ class behat_qtype_stack extends behat_base {
 
         if ($is42 || $is50) {
             $context = behat_context_helper::get('behat_general');
-            $context->i_press($element);
+            $context->i_click_on('#' . $element, 'css');
         }
         // On other versions, do nothing - the PRT section is already expanded
     }

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -80,6 +80,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
+    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -71,7 +71,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I press "collapseElement-2"
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +80,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -20,6 +20,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
   Scenario: Create, preview, test, tidy and edit STACK questions in Moodle ≥ 4.0
     Given the site is running Moodle version 4.0 or higher
     When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
+    And I pause
     # Create a new question.
     And I add a "STACK" question filling the form with:
       | Question name        | Test STACK question                                                           |
@@ -32,7 +33,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then I should see "Test STACK question"
 
     When I am on the "Test STACK question" "core_question > edit" page
-    And I pause
     Then the following fields match these values:
       | Question name        | Test STACK question                                                           |
       | Question variables   | p : (x-1)^3;                                                                  |
@@ -68,10 +68,10 @@ Feature: Create, edit STACK questions adding in PRT and saving.
       | Model answer         | diff(p,x)                                                                     |
       | SAns                 | ans1                                                                          |
       | TAns                 | diff(p,x)                                                                     |
-    And I press "collapseElement-2"
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
+    And I press collapseElement-2 if on Moodle 4.2 or 5.0
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +81,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press "collapseElement-2"
+    And I press collapseElement-2
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -70,8 +70,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I wait "2" seconds
-    And I press "collapseElement-2"
+    And I press "collapseElement-2" if on Moodle 4.2 or 5.0
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -20,7 +20,6 @@ Feature: Create, edit STACK questions adding in PRT and saving.
   Scenario: Create, preview, test, tidy and edit STACK questions in Moodle ≥ 4.0
     Given the site is running Moodle version 4.0 or higher
     When I am on the "Course 1" "core_question > course question bank" page logged in as "teacher"
-    And I pause
     # Create a new question.
     And I add a "STACK" question filling the form with:
       | Question name        | Test STACK question                                                           |
@@ -71,7 +70,8 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"
-    And I press collapseElement-2 if on Moodle 4.2 or 5.0
+    And I wait "2" seconds
+    And I press "collapseElement-2"
     Then I should see "Node 2"
     And I set the following fields to these values:
       | id_prt1sans_1 | int(ans1,x) |
@@ -81,7 +81,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     And I set the following fields to these values:
       | id_prt1falsenextnode_0 | Node 2 |
     And I press "id_updatebutton"
-    And I press collapseElement-2
+    And I press "collapseElement-2"
     Then I should see "This potential response tree will become active when the student has answered: ans1"
     Then I should see "ATAlgEquiv(int(ans1,x),p)"
     And I set the following fields to these values:

--- a/tests/behat/create_prt_node.feature
+++ b/tests/behat/create_prt_node.feature
@@ -32,6 +32,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
     Then I should see "Test STACK question"
 
     When I am on the "Test STACK question" "core_question > edit" page
+    And I pause
     Then the following fields match these values:
       | Question name        | Test STACK question                                                           |
       | Question variables   | p : (x-1)^3;                                                                  |
@@ -67,7 +68,7 @@ Feature: Create, edit STACK questions adding in PRT and saving.
       | Model answer         | diff(p,x)                                                                     |
       | SAns                 | ans1                                                                          |
       | TAns                 | diff(p,x)                                                                     |
-
+    And I press "collapseElement-2"
     Then the following fields match these values:
       | Number to add (max 9) | 1 |
     When I press "Add node(s)"

--- a/tests/input_matrix_test.php
+++ b/tests/input_matrix_test.php
@@ -39,32 +39,52 @@ require_once(__DIR__ . '/../stack/input/factory.class.php');
  * @covers \stack_matrix_input
  */
 final class input_matrix_test extends qtype_stack_testcase {
-    public function test_augmented_matrix_column_separators(): void {
+    public function test_augmented_matrix_roundtrip(): void {
         $options = new stack_options();
-        $el = stack_input_factory::make('matrix', 'ans1', 'M', $options,
-            ['options' => 'columnseparators:1;3']);
-        $el->adapt_to_model_answer('matrix([1,2,3,4],[5,6,7,8])');
-        $state = new stack_input_state(stack_input::BLANK, [], '', '', '', '', '');
-        $html = $el->render($state, 'ans1', false, null);
-        $this->assertSame(4, substr_count($html, 'class="stack-matrix-column-separator"'));
-        $this->assertSame(8, substr_count($html, 'type="text"'));
-        $this->assertStringContainsString('name="ans1_sub_1_3"', $html);
-        $this->assertSame([1, 3], $el->render_api_data(null)['columnseparators']);
-        $this->assertSame('matrix([1,2,3,4],[5,6,7,8])',
-            $el->contents_to_maxima([['1', '2', '3', '4'], ['5', '6', '7', '8']]));
-        $this->assertStringContainsString('readonly="readonly"', $el->render($state, 'ans1', true, null));
+        $model = 'aug_matrix(matrix([1,2],[3,4]),c(5,6))';
+        $el = stack_input_factory::make('matrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer($model);
+        $contents = [['1', '2', '5'], ['3', '4', '6']];
+        $this->assertEmpty($el->get_errors());
+        $this->assertSame($model, $el->contents_to_maxima($contents));
+        $response = $el->maxima_to_response_array($model);
+        $this->assertSame($contents, $el->response_to_contents($response));
+        $data = $el->render_api_data(null);
+        $this->assertSame('aug_matrix', $data['casValueType']);
+        $this->assertSame([['type' => 'matrix', 'columns' => 2], ['type' => 'c', 'columns' => 1]], $data['blocks']);
+        $blank = new stack_input_state(stack_input::BLANK, [], '', '', '', '', '');
+        $html = $el->render($blank, 'ans1', false, null);
+        $this->assertSame(2, substr_count($html, 'class="stack-matrix-column-separator"'));
+        $this->assertSame(6, substr_count($html, 'type="text"'));
+        $this->assertStringContainsString('readonly="readonly"', $el->render($blank, 'ans1', true, null));
+        $state = $el->validate_student_response($response, $options, $model, new stack_cas_security());
+        $this->assertContains($state->status, [stack_input::VALID, stack_input::SCORE]);
+        $this->assertSame($model, $state->contentsmodified);
+        $this->assertStringContainsString('\\left|', $state->contentsdisplayed);
+        $this->assertStringNotContainsString('aug\\_matrix', $state->contentsdisplayed);
+        $response['ans1_sub_0_0'] = '';
+        $state = $el->validate_student_response($response, $options, $model, new stack_cas_security());
+        $this->assertSame(stack_input::INVALID, $state->status);
     }
 
-    public function test_augmented_matrix_invalid_separators(): void {
-        foreach (['0', '-1', '1;1', '2;1', '1.5', '1;;2', 'true', '1;'] as $value) {
-            $el = stack_input_factory::make('matrix', 'ans1', 'M', new stack_options(),
-                ['options' => 'columnseparators:' . $value]);
-            $this->assertNotEmpty($el->get_errors(), $value);
+    public function test_augmented_matrix_multiple_blocks_and_reset(): void {
+        $el = stack_input_factory::make('matrix', 'ans1', 'M', new stack_options());
+        $model = 'aug_matrix(r(1,2),r(3),r(4,5))';
+        $el->adapt_to_model_answer($model);
+        $this->assertSame($model, $el->contents_to_maxima([['1', '2', '3', '4', '5']]));
+        $this->assertCount(3, $el->render_api_data(null)['blocks']);
+        $el->adapt_to_model_answer('matrix([1,2])');
+        $this->assertSame('matrix([1,2])', $el->contents_to_maxima([['1', '2']]));
+        $this->assertArrayNotHasKey('blocks', $el->render_api_data(null));
+    }
+
+    public function test_augmented_matrix_invalid_shapes(): void {
+        foreach (['aug_matrix(matrix([1]),matrix([2],[3]))',
+                'aug_matrix(matrix([1]))', 'aug_matrix(matrix([1]),matrix([]))'] as $model) {
+            $el = stack_input_factory::make('matrix', 'ans1', 'M', new stack_options());
+            $el->adapt_to_model_answer($model);
+            $this->assertNotEmpty($el->get_errors(), $model);
         }
-        $el = stack_input_factory::make('matrix', 'ans1', 'M', new stack_options(),
-            ['options' => 'columnseparators:3']);
-        $el->adapt_to_model_answer('matrix([1,2,3])');
-        $this->assertNotEmpty($el->get_errors());
     }
 
     public function test_render_blank(): void {

--- a/tests/input_varmatrix_test.php
+++ b/tests/input_varmatrix_test.php
@@ -212,6 +212,99 @@ final class input_varmatrix_test extends qtype_stack_testcase {
         );
     }
 
+    public function test_column_vector_model_answer(): void {
+
+        $options = new stack_options();
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'v', $options);
+        $el->adapt_to_model_answer('c(1,2,3)');
+
+        $api = $el->render_api_data('c(1,2,3)');
+        $this->assertEquals('c', $api['casValueType']);
+
+        $html = $el->render(
+            new stack_input_state(stack_input::BLANK, [], '', '', '', '', ''),
+            'ans1',
+            false,
+            null
+        );
+        $this->assertStringContainsString(
+            '<div class="matrixsquarebrackets" data-stack-input-value-type="c">',
+            $html
+        );
+        $this->assertStringContainsString('data-stack-input-type="varmatrix"', $html);
+
+        $state = $el->validate_student_response(
+            ['ans1' => "1 a\na+b"],
+            $options,
+            'c(1,2,3)',
+            new stack_cas_security()
+        );
+        $this->assertEquals(stack_input::VALID, $state->status);
+        $this->assertEquals('c(1,a,a+b)', $state->contentsmodified);
+        $this->assertEquals([
+            'ans1' => "1\n2\n3",
+            'ans1_val' => 'c(1,2,3)',
+        ], $el->maxima_to_response_array('c(1,2,3)'));
+        $this->assertEquals([
+            'ans1' => "f(1,2)\na+b",
+            'ans1_val' => 'c(f(1,2),a+b)',
+        ], $el->maxima_to_response_array('c(f(1,2),a+b)'));
+    }
+
+    public function test_row_vector_model_answer(): void {
+
+        $options = new stack_options();
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'v', $options);
+        $el->adapt_to_model_answer('r(1,2,3)');
+
+        $api = $el->render_api_data('r(1,2,3)');
+        $this->assertEquals('r', $api['casValueType']);
+
+        $state = $el->validate_student_response(
+            ['ans1' => "1\na a+b"],
+            $options,
+            'r(1,2,3)',
+            new stack_cas_security()
+        );
+        $this->assertEquals(stack_input::VALID, $state->status);
+        $this->assertEquals('r(1,a,a+b)', $state->contentsmodified);
+        $this->assertEquals([
+            'ans1' => '1 2 3',
+            'ans1_val' => 'r(1,2,3)',
+        ], $el->maxima_to_response_array('r(1,2,3)'));
+        $this->assertEquals([
+            'ans1' => 'f(1,2) a+b',
+            'ans1_val' => 'r(f(1,2),a+b)',
+        ], $el->maxima_to_response_array('r(f(1,2),a+b)'));
+    }
+
+    public function test_generated_vector_constructor_can_be_forbidden(): void {
+
+        $options = new stack_options();
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'v', $options);
+        $el->set_parameter('forbidWords', 'c, sin');
+        $el->set_parameter('sameType', false);
+        $el->adapt_to_model_answer('c(1,2)');
+
+        $state = $el->validate_student_response(
+            ['ans1' => "1\n2"],
+            $options,
+            'c(1,2)',
+            new stack_cas_security()
+        );
+        $this->assertEquals(stack_input::VALID, $state->status);
+        $this->assertEquals('c(1,2)', $state->contentsmodified);
+
+        $state = $el->validate_student_response(
+            ['ans1' => "1\nc(2,3)"],
+            $options,
+            'c(1,2)',
+            new stack_cas_security()
+        );
+        $this->assertEquals(stack_input::INVALID, $state->status);
+        $this->assertEquals('forbiddenFunction', $state->note);
+    }
+
     public function test_validate_student_response_invalid_one_blank(): void {
 
         $options = new stack_options();
@@ -572,5 +665,59 @@ final class input_varmatrix_test extends qtype_stack_testcase {
             '<span class="stacksyntaxexample">matrix([a,b],[c,matrix([a,b],[c,d])])</span>',
             $state->contentsdisplayed
         );
+    }
+    public function test_augmented_varmatrix_roundtrip(): void {
+        $options = new stack_options();
+        $model = 'aug_matrix(matrix([1,2],[3,4]),c(5,6))';
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer($model);
+        $this->assertEmpty($el->get_errors());
+        $response = $el->maxima_to_response_array($model);
+        $this->assertEquals("1 2 | 5\n3 4 | 6", trim($response['ans1']));
+        $state = $el->validate_student_response($response, $options, $model, new stack_cas_security());
+        $this->assertEquals(stack_input::SCORE, $state->status);
+        $this->assertEquals($model, $state->contentsmodified);
+        $this->assertStringContainsString('\\left|', $state->contentsdisplayed);
+        $this->assertStringContainsString('data-stack-input-value-type="aug_matrix"',
+            $el->render($state, 'ans1', false, null));
+        $this->assertEquals(['matrix', 'c'], $el->render_api_data(null)['blockTypes']);
+        $this->assertEquals('|', $el->render_api_data(null)['blockSeparator']);
+    }
+
+    public function test_augmented_varmatrix_student_dimensions(): void {
+        $options = new stack_options();
+        $model = 'aug_matrix(matrix([1,2],[3,4]),matrix([5],[6]))';
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer($model);
+        foreach (["1 | 2", "1 2 3 | 4 5\n6 7 8 | 9 10"] as $raw) {
+            $state = $el->validate_student_response(['ans1' => $raw], $options, $model, new stack_cas_security());
+            $this->assertEquals(stack_input::VALID, $state->status);
+            $this->assertStringStartsWith('aug_matrix(', $state->contentsmodified);
+        }
+        foreach (["1 2 3", "1 | 2\n3 4 | 5", "| 1 2", "1 2 |", "1 || 2", "1 ? | 2"] as $raw) {
+            $state = $el->validate_student_response(['ans1' => $raw], $options, $model, new stack_cas_security());
+            $this->assertEquals(stack_input::INVALID, $state->status);
+        }
+        $el->adapt_to_model_answer('matrix([1,2])');
+        $this->assertEquals('matrix([1,2])', $el->contents_to_maxima([['1', '2']]));
+    }
+
+    public function test_augmented_varmatrix_multiple_blocks_and_security(): void {
+        $options = new stack_options();
+        $model = 'aug_matrix(r(1,2),r(3),r(4,5))';
+        $el = stack_input_factory::make('varmatrix', 'ans1', 'M', $options);
+        $el->adapt_to_model_answer($model);
+        $this->assertEquals('1 2 | 3 | 4 5', trim($el->maxima_to_response_array($model)['ans1']));
+        $el->set_parameter('forbidWords', 'sin,r,aug_matrix');
+        $state = $el->validate_student_response(['ans1' => '1 2 | 3 | 4 5'],
+            $options, $model, new stack_cas_security());
+        $this->assertEquals(stack_input::VALID, $state->status);
+        $this->assertEquals($model, $state->contentsmodified);
+        $state = $el->validate_student_response(['ans1' => 'sin(1) 2 | 3 | 4 5'],
+            $options, $model, new stack_cas_security());
+        $this->assertEquals(stack_input::INVALID, $state->status);
+        $state = $el->validate_student_response('1 2 | 3 | 4 5',
+            $options, $model, new stack_cas_security(), true);
+        $this->assertEquals($model, $state->contentsmodified);
     }
 }


### PR DESCRIPTION
Follow-up to #1859, based on the maintainer integration branch `iss1850`. Replaces the explicit separator option with native augmented model-answer support.

Fixed and variable-size matrix inputs now accept an augmented model answer directly, for example `ta:aug(A,b)`. The instantiated `aug_matrix(...)` value determines the grid size and block boundaries. Students fill one grid; submission, saved responses, syntax hints and AJAX validation preserve the augmented constructor and its matrix/column-vector/row-vector blocks. The validation echo renders the augmented matrix with its separators.

This follows the value-preserving approach used for row and column vectors in #1847/#1848 and addresses #1850. Multiple blocks such as `aug(A,B,C)` are supported. Blocks must be nonempty and have equal row counts. There is no separate boundary option.

The existing `aug`, `aug_matrix` TeX rules and `de_aug` helpers move from the contributed matrix library into the linear-algebra core so ordinary validation sessions can render the same value. Vector blocks are converted to bare matrices only for display and `de_aug`, retaining their constructors in the submitted augmented object. Matrix-specific answer tests can use `de_aug(ans1)` explicitly.

API consumers receive the augmented value type and a `blocks` array with each block's constructor and column count. Ordinary matrix input fields, response serialization and API shape remain unchanged.

Validation: isolated STACK API/Maxima checks cover matrix, column-vector, row-vector and multiple-block roundtrips; automatic boundaries; readonly grids; native and AJAX validation echoes; malformed shapes; partial blanks; forbidden cell functions; and the core helpers. Added Moodle PHPUnit and Maxima test cases. The complete Moodle PHPUnit suite was not available locally.


### Screenshots

Captured from the patched STACK input renderer and its actual CAS validation output in an isolated API harness, with MathJax 3. These are not screenshots of an ETH Moodle deployment.

![Column-vector augmented block and validation echo](https://raw.githubusercontent.com/adamant-pwn/moodle-qtype_stack/643a962374972678da3e617570e9c471a0d8e48b/doc/en/Authoring/Inputs/screenshots/augmented-column-vector.png)

![Three augmented blocks and validation echo](https://raw.githubusercontent.com/adamant-pwn/moodle-qtype_stack/643a962374972678da3e617570e9c471a0d8e48b/doc/en/Authoring/Inputs/screenshots/augmented-three-blocks.png)

### CI context

The earlier separator-only commit's [run 34235575242](https://github.com/maths/moodle-qtype_stack/actions/runs/34235575242) had two passing jobs and three failures at `create_prt_node.feature:75` (`Node 2` found but not visible). The same failure also occurs in the independent upstream [dev run 34235897023](https://github.com/maths/moodle-qtype_stack/actions/runs/34235897023). This does not establish the current native extension's CI result; its own checks are still running.


### Maintainer sample follow-up

Updated `samplequestions/stacklibrary/Topics/LinearAlgebra/LinearSystems/Linear-system.xml` as requested in review. The input model is `aug(TAM1)` with automatic boundaries; `columnseparators` and the contributed-library include are removed. PRTs explicitly flatten `ans1` with `de_aug` for matrix operations, while feedback displays the preserved augmented object.

The existing correct-answer and consequential-marking tests now submit augmented values. A third case rejects an equivalent but unreduced augmented system. All three cases pass on all six deployed seeds: 18/18 tests using the patched STACK API and Maxima runtime. The maintainer's latest `iss1850` changes, including the `setdiagmx` variable-name fix, are preserved.


### Variable-size augmented input

`varmatrix` now preserves augmented answers as well. Students type spaces between entries, newlines between rows and `|` between blocks on every row. Matrix dimensions remain student-selected; the model fixes block count and constructor types only. Column-vector blocks remain one column and row-vector blocks remain one row. Inconsistent separators, empty blocks and malformed cells produce validation errors.

This reuses the previously accepted varmatrix row/column-vector handling from #1847 (which is on `iss1848`, not yet on this PR's base) and extends it for augmented blocks. It preserves ordinary matrix syntax and exposes augmented input metadata to API/CSS consumers. All four standard outer-bracket options work for the textarea and validation. A separate semantic CSS wrapper for augmented MathJax output is not part of this change.

Validation: 56 isolated runtime assertions pass, including resized dimensions, matrix/vector compatibility, multiple blocks, syntax hints, readonly display, decimal commas, implied multiplication, allowed empty answers, malformed inputs, AJAX and forbidden cell functions. The linear-system sample also passes all 18 tests with its first input changed to varmatrix, preserving the follow-through checks. Moodle PHPUnit cases are added; the complete suite remains an upstream CI check.

![Variable-size augmented input and validation echo](https://raw.githubusercontent.com/adamant-pwn/moodle-qtype_stack/88381a17cdf90a1fca3396ca6911cb0c11b0a776/doc/en/Authoring/Inputs/screenshots/augmented-varmatrix.png)


### CI refresh

Merged current upstream `dev` (including #1860) into this PR as `5f2d0b8d8`. Upstream [run 34247459194](https://github.com/maths/moodle-qtype_stack/actions/runs/34247459194) passes with the PRT-node visibility fix and missing library-import default. Of the five jobs in our older completed run 34242042739, one passed, three failed at that Node 2 step, and the Moodle 4.2 job hit browser connection/time-out errors. Fresh CI on the merged revision must verify the result; those browser failures are not assumed to be resolved.
